### PR TITLE
[DRAFT] CQ-4345168 Add create form button in AEM Forms container

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v1/aemform/_cq_editConfig.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v1/aemform/_cq_editConfig.xml
@@ -26,7 +26,7 @@
             text="Edit in a new window"/>
         <createFormViaWizard
             jcr:primaryType="nt:unstructured"
-            condition="fd.core.formExists"
+            condition="fd.core.featureEnabled"
             handler="fd.core.openCreateFormWizard"
             icon="addCircle"
             text="Create Form Via Wizard"/>

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v1/aemform/_cq_editConfig.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v1/aemform/_cq_editConfig.xml
@@ -24,6 +24,12 @@
             handler="fd.core.openFormForEditing"
             icon="alias"
             text="Edit in a new window"/>
+        <createFormViaWizard
+            jcr:primaryType="nt:unstructured"
+            condition="fd.core.formExists"
+            handler="fd.core.openCreateFormWizard"
+            icon="addCircle"
+            text="Create Form Via Wizard"/>
     </cq:actionConfigs>
     <cq:listeners
         jcr:primaryType="cq:EditListenersConfig"

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v1/aemform/clientlibs/editorhook/js/EditListeners.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v1/aemform/clientlibs/editorhook/js/EditListeners.js
@@ -29,6 +29,21 @@
         window.open(url);
     };
 
+    window.fd.core.openCreateFormWizard = function (editable) {
+        $.ajax({
+            url: Granite.HTTP.externalize('/libs/fd/fm/base/content/commons/wizardspalink.html'),
+            type: "GET",
+            success: function(data){
+                var wizardspalink = $(data).get(0);
+                redirectUrl = Granite.HTTP.externalize(wizardspalink.pathname + wizardspalink.search);
+                window.open(redirectUrl, "_self");
+            },
+            error: function (error) {
+                console.log("Error: " + error);
+            }
+        });
+    }
+
     window.fd.core.formExists = function (editable) {
         return $(window.fd.core.constants.AEM_FORM_SELECTOR, editable.dom).addBack(window.fd.core.constants.AEM_FORM_SELECTOR).length > 0;
     };

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v1/aemform/clientlibs/editorhook/js/EditListeners.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v1/aemform/clientlibs/editorhook/js/EditListeners.js
@@ -19,7 +19,8 @@
     window.fd.core.constants = window.fd.core.constants || {};
     window.fd.core.constants = {
         "AEM_FORM_SELECTOR" : "[data-form-page-path]",
-        "AEM_FORM_CONTAINER_SELECTOR" : ".cmp-aemform"
+        "AEM_FORM_CONTAINER_SELECTOR" : ".cmp-aemform",
+        "AEM_FORM_WIZARD_LINK" : "/libs/fd/fm/base/content/commons/wizardspalink.html"
     };
 
     window.fd.core.openFormForEditing = function (editable) {
@@ -31,12 +32,13 @@
 
     window.fd.core.openCreateFormWizard = function (editable) {
         $.ajax({
-            url: Granite.HTTP.externalize('/libs/fd/fm/base/content/commons/wizardspalink.html'),
+            url: Granite.HTTP.externalize(window.fd.core.constants.AEM_FORM_WIZARD_LINK),
             type: "GET",
             success: function(data){
-                var wizardspalink = $(data).get(0);
-                redirectUrl = Granite.HTTP.externalize(wizardspalink.pathname + wizardspalink.search);
-                window.open(redirectUrl, "_self");
+                var wizardURL = new URL($(data).get(0).href);
+                wizardURL.searchParams.append('embedAt', btoa(editable.path));
+                wizardURL.searchParams.append('redirectUrl', btoa(window.location.href));
+                window.open(Granite.HTTP.externalize(wizardURL.href), "_self");
             },
             error: function (error) {
                 console.log("Error: " + error);
@@ -50,6 +52,10 @@
 
     window.fd.core.aemFormExistsInPage = function () {
         return Granite.author.ContentFrame.getDocument().find(window.fd.core.constants.AEM_FORM_CONTAINER_SELECTOR).length > 0;
+    };
+
+    window.fd.core.featureEnabled = function (editable) {
+        return Granite.Toggles.isEnabled("FT_CQ-4343036");
     };
 
 }(window.Granite));

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v1/aemform/formcontainer.html
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v1/aemform/formcontainer.html
@@ -19,7 +19,7 @@
 <sly data-sly-test="${!wcmmode.disabled && !form.isFormSelected}">
     <sly data-sly-call="${clientLib.all @ categories='core.forms.components.aemform.v1'}"/>
     <div class="cmp-aemform--no-form-selected">
-        ${'You need to select a Form from the Dialog' @ i18n, locale=request.locale}
+        ${'You need to select/create a Form from the Dialog/Wizard' @ i18n, locale=request.locale}
     </div>
 </sly>
 <div class="cmp-aemform__content"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This change will provide a button to users to create a Form on the fly using Form creation wizard. This button is available as an action button for AEM Forms Container component.

## Related Issue

https://jira.corp.adobe.com/browse/CQ-4345168

## Motivation and Context

This will ease Site authors to create a form first and then map the created form path in a AEM Forms container configuration. With this, authors will be able to create a form and link it to their Site page on the fly using latest business friendly AEM Forms Creation wizard.

## How Has This Been Tested?

Tested on local and Skyline environments.

## Screenshots (if appropriate):
<img width="1182" alt="Screenshot 2022-06-02 at 2 26 43 PM" src="https://user-images.githubusercontent.com/7971922/173745557-410231dd-9ddc-497e-a815-7d2026541c81.png">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
