### PR TITLE
CQ-4346081 Moving embed feature to AEM Forms Container component v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See [AEM Sites Core Components](https://docs.adobe.com/content/help/en/experienc
 
 ### Page Authoring Components
 
--   [AEM Forms Container](ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v1/aemform)
+-   [AEM Forms Container](ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform)
 
 ### Forms And Communications Portal
 

--- a/bundles/core/src/main/java/com/adobe/cq/forms/core/components/internal/models/v2/aemform/AEMFormImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/forms/core/components/internal/models/v2/aemform/AEMFormImpl.java
@@ -1,0 +1,34 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2022 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.forms.core.components.internal.models.v2.aemform;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.models.annotations.Exporter;
+import org.apache.sling.models.annotations.Model;
+
+import com.adobe.cq.export.json.ComponentExporter;
+import com.adobe.cq.export.json.ExporterConstants;
+import com.adobe.cq.forms.core.components.models.aemform.AEMForm;
+
+@Model(
+    adaptables = SlingHttpServletRequest.class,
+    adapters = { AEMForm.class,
+        ComponentExporter.class },
+    resourceType = AEMFormImpl.RESOURCE_TYPE)
+@Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)
+public class AEMFormImpl extends com.adobe.cq.forms.core.components.internal.models.v1.aemform.AEMFormImpl implements AEMForm {
+    public static final String RESOURCE_TYPE = "core/fd/components/aemform/v2/aemform";
+}

--- a/bundles/core/src/test/java/com/adobe/cq/forms/core/components/internal/models/v2/aemform/AEMFormImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/forms/core/components/internal/models/v2/aemform/AEMFormImplTest.java
@@ -1,0 +1,62 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2022 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.forms.core.components.internal.models.v2.aemform;
+
+import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+
+import com.adobe.cq.forms.core.components.models.aemform.AEMForm;
+import com.adobe.cq.forms.core.context.FormsCoreComponentTestContext;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+
+import static org.junit.Assert.assertEquals;
+
+@ExtendWith(AemContextExtension.class)
+public class AEMFormImplTest {
+    private static final String BASE = "/aemform";
+    private static final String CONTENT_ROOT = "/content";
+    private static final String ROOT_PAGE = "/content/aemform";
+    private static final String GRID = ROOT_PAGE + "/jcr:content/root/responsivegrid";
+    private static final String FORM_1 = "/aemformv2-1";
+    private static final String PATH_FORM_1 = GRID + FORM_1;
+
+    private final AemContext context = FormsCoreComponentTestContext.newAemContext();
+
+    @BeforeEach
+    void setUp() {
+        context.load().json(BASE + FormsCoreComponentTestContext.TEST_CONTENT_JSON, CONTENT_ROOT);
+    }
+
+    @Test
+    void testExportedType() {
+        AEMForm aemform = getAEMFormUnderTest(PATH_FORM_1);
+        assertEquals("core/fd/components/aemform/v2/aemform", aemform.getExportedType());
+        AEMForm aemFormMock = Mockito.mock(AEMForm.class);
+        Mockito.when(aemFormMock.getExportedType()).thenCallRealMethod();
+        Assertions.assertThrows(UnsupportedOperationException.class, aemFormMock::getExportedType);
+    }
+
+    private AEMForm getAEMFormUnderTest(String resourcePath) {
+        context.currentResource(resourcePath);
+        MockSlingHttpServletRequest request = context.request();
+        return request.adaptTo(AEMForm.class);
+    }
+}

--- a/bundles/core/src/test/resources/aemform/test-content.json
+++ b/bundles/core/src/test/resources/aemform/test-content.json
@@ -33,6 +33,21 @@
                         "sling:resourceType": "core/fd/components/aemform/v1/aemform",
                         "usePageLocale" : "true",
                         "height" : "abc"
+                    },
+                    "aemformv2-1" : {
+                        "jcr:primaryType": "nt:unstructured",
+                        "sling:resourceType": "core/fd/components/aemform/v2/aemform",
+                        "height": "100",
+                        "thankyouPage": "/a/b/c",
+                        "thankyouConfig": "page",
+                        "formType": "adaptiveForm",
+                        "formRef": "/content/forms/af/abc",
+                        "themeRef": "/content/dam/formsanddocuments-themes/abc",
+                        "submitType": "inline",
+                        "cssClientlib": "abc.def",
+                        "useiframe" : "true",
+                        "usePageLocale" : "true",
+                        "enableFocusOnFirstField" : true
                     }
                 }
             }

--- a/examples/ui.apps/src/main/content/jcr_root/apps/forms-components-examples/components/aemform/.content.xml
+++ b/examples/ui.apps/src/main/content/jcr_root/apps/forms-components-examples/components/aemform/.content.xml
@@ -3,5 +3,5 @@
     jcr:description="AEM Forms Container Component for the Core Components Library"
     jcr:primaryType="cq:Component"
     jcr:title="AEM Forms Container"
-    sling:resourceSuperType="core/fd/components/aemform/v1/aemform"
+    sling:resourceSuperType="core/fd/components/aemform/v2/aemform"
     componentGroup="Core Components Examples"/>

--- a/examples/ui.content/src/main/content/jcr_root/content/core-components-examples/library/core-content/aemform/.content.xml
+++ b/examples/ui.content/src/main/content/jcr_root/content/core-components-examples/library/core-content/aemform/.content.xml
@@ -24,7 +24,7 @@
                     jcr:lastModifiedBy="admin"
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="core/wcm/components/text/v2/text"
-                    text="&lt;h1>AEM Forms Container&lt;sub>v1&lt;/sub>&lt;/h1>"
+                    text="&lt;h1>AEM Forms Container&lt;sub>v2&lt;/sub>&lt;/h1>"
                     textIsRich="true"/>
                 <text
                     cq:styleIds="[1544762734201]"
@@ -48,7 +48,7 @@
                     sling:resourceType="core-components-examples/components/teaser"
                     actionsEnabled="false"
                     descriptionFromPage="false"
-                    linkURL="https://github.com/adobe/aem-core-forms-components/tree/master/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v1/aemform"
+                    linkURL="https://github.com/adobe/aem-core-forms-components/tree/master/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform"
                     textIsRich="true"
                     titleFromPage="false"/>
                 <title_865328580

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -269,6 +269,7 @@
                                 <configuration>
                                     <tasks>
                                         <replace file="target/jcr_root/libs/core/fd/components/aemform/v1/aemform/.content.xml" token=".core-forms" value="Core Content" />
+                                        <replace file="target/jcr_root/libs/core/fd/components/aemform/v2/aemform/.content.xml" token=".core-forms" value="Core Content" />
                                         <!-- Only beta customers should see this, to enable form container create proxy unless GA -->
                                         <!--
                                         <replace file="target/jcr_root/libs/core/fd/components/form/container/v1/container/.content.xml" token=".core-wcm" value="Core Content" />

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v1/aemform/clientlibs/editorhook/js/EditListeners.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v1/aemform/clientlibs/editorhook/js/EditListeners.js
@@ -19,8 +19,7 @@
     window.fd.core.constants = window.fd.core.constants || {};
     window.fd.core.constants = {
         "AEM_FORM_SELECTOR" : "[data-form-page-path]",
-        "AEM_FORM_CONTAINER_SELECTOR" : ".cmp-aemform",
-        "AEM_FORM_WIZARD_LINK" : "/libs/fd/fm/base/content/commons/wizardspalink.html"
+        "AEM_FORM_CONTAINER_SELECTOR" : ".cmp-aemform"
     };
 
     window.fd.core.openFormForEditing = function (editable) {
@@ -30,32 +29,12 @@
         window.open(url);
     };
 
-    window.fd.core.openCreateFormWizard = function (editable) {
-        $.ajax({
-            url: Granite.HTTP.externalize(window.fd.core.constants.AEM_FORM_WIZARD_LINK),
-            type: "GET",
-            success: function(data){
-                var wizardURL = new URL($(data).get(0).href);
-                wizardURL.searchParams.append('embedAt', btoa(editable.path));
-                wizardURL.searchParams.append('redirectUrl', btoa(window.location.href));
-                window.open(Granite.HTTP.externalize(wizardURL.href), "_self");
-            },
-            error: function (error) {
-                console.log("Error: " + error);
-            }
-        });
-    }
-
     window.fd.core.formExists = function (editable) {
         return $(window.fd.core.constants.AEM_FORM_SELECTOR, editable.dom).addBack(window.fd.core.constants.AEM_FORM_SELECTOR).length > 0;
     };
 
     window.fd.core.aemFormExistsInPage = function () {
         return Granite.author.ContentFrame.getDocument().find(window.fd.core.constants.AEM_FORM_CONTAINER_SELECTOR).length > 0;
-    };
-
-    window.fd.core.featureEnabled = function (editable) {
-        return Granite.Toggles.isEnabled("FT_CQ-4343036");
     };
 
 }(window.Granite));

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright 2020 Adobe
+  ~ Copyright 2022 Adobe
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -14,18 +14,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
-<jcr:root xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    cq:actions="[EDIT,DELETE,INSERT,COPYMOVE]"
-    jcr:primaryType="cq:EditConfig">
-    <cq:actionConfigs jcr:primaryType="nt:unstructured">
-        <editexpression
-            jcr:primaryType="nt:unstructured"
-            condition="fd.core.formExists"
-            handler="fd.core.openFormForEditing"
-            icon="alias"
-            text="Edit in a new window"/>
-    </cq:actionConfigs>
-    <cq:listeners
-        jcr:primaryType="cq:EditListenersConfig"
-        afteredit="REFRESH_PARENT"/>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+          jcr:primaryType="nt:unstructured">
+    <aemform/>
 </jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright 2020 Adobe
+  ~ Copyright 2022 Adobe
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -14,18 +14,9 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
-<jcr:root xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    cq:actions="[EDIT,DELETE,INSERT,COPYMOVE]"
-    jcr:primaryType="cq:EditConfig">
-    <cq:actionConfigs jcr:primaryType="nt:unstructured">
-        <editexpression
-            jcr:primaryType="nt:unstructured"
-            condition="fd.core.formExists"
-            handler="fd.core.openFormForEditing"
-            icon="alias"
-            text="Edit in a new window"/>
-    </cq:actionConfigs>
-    <cq:listeners
-        jcr:primaryType="cq:EditListenersConfig"
-        afteredit="REFRESH_PARENT"/>
-</jcr:root>
+<jcr:root xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    cq:icon="form"
+    jcr:description="Container for AEM Forms"
+    jcr:primaryType="cq:Component"
+    jcr:title="AEM Forms Container (v2)"
+    componentGroup=".core-forms"/>

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/README.md
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/README.md
@@ -1,0 +1,55 @@
+<!--
+Copyright 2022 Adobe
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+AEM Forms Container (v2)
+====
+AEM Forms Container component written in HTL.
+
+## Features
+* Customizable to use AEM Forms Theme
+* AEM Forms Pages could be used inside iframe or non-iframe mode
+* Customizable to enable/disable focus on the form
+* Provides an action config to create an Adaptive Form on the fly.
+
+### Use Object
+The AEM Forms Container component uses the `com.adobe.cq.forms.core.components.models.aemform.AEMForm` Sling model as its Use-object.
+
+### Edit Dialog Properties
+The following properties are written to JCR for the AEM Form component and are expected to be available as `Resource` properties:
+
+1. `./useIframe` - specifies whether to use iframe as a container for the form or interactive communication.
+2. `./thankyouPage` - specifies the thank you page to show on form submission.
+3. `./thankyouMessage` - specifies the thank you message to show on form submission.
+4. `./themeRef` - specifies the AEM Forms theme to use for the form or interactive communication.
+5. `./enableFocusOnFirstField` - specifies whether to bring focus on the form or page containing the form or interactive communication.
+6. `./submitType` - specifies a submit type for the form. It can be synchronous or asynchronous.
+7. `./locale` - specifies the locale of the form or interactive communication. It could be sites page locale or a custom locale.
+8. `./id` - specifies value for the component HTML ID attribute.
+
+
+## BEM Description
+```
+BLOCK cmp-aemform
+    ELEMENT cmp-aemform__iframecontent
+    ELEMENT cmp-aemform__content
+```
+
+## Information
+* **Vendor**: Adobe
+* **Version**: v2
+* **Compatibility**: AEM Forms as a cloud service
+* **Status**: production-ready
+
+_If you were involved in the authoring of this component and are not credited above, please reach out to us on [GitHub](https://github.com/adobe/aem-core-forms-components)._

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/_cq_dialog/.content.xml
@@ -1,0 +1,229 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Edit AEM Forms Container"
+    sling:resourceType="cq/gui/components/authoring/dialog"
+    extraClientlibs="core.forms.components.aemform.v2.editor"
+    trackingFeature="core-components:aemform:v2"
+    helpPath="https://helpx.adobe.com/aem-forms/6-4/embed-adaptive-form-aem-sites.html">
+    <content
+        jcr:primaryType="nt:unstructured"
+        sling:resourceType="granite/ui/components/coral/foundation/container">
+        <items jcr:primaryType="nt:unstructured">
+            <columns
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns">
+                <items jcr:primaryType="nt:unstructured">
+                    <column
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="granite/ui/components/coral/foundation/container">
+                        <items jcr:primaryType="nt:unstructured">
+                            <adaptiveFormContainer
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="granite/ui/components/coral/foundation/container">
+                                <granite:data
+                                        jcr:primaryType="nt:unstructured"
+                                        id="adaptiveFormContainer"/>
+                                <items jcr:primaryType="nt:unstructured">
+                                    <form_ref
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="fd/af/granite/components/formpicker"
+                                            fieldLabel="Asset Path"
+                                            filter="adaptiveForm"
+                                            name="./formRef"
+                                            rootPath="/content/dam/formsanddocuments"/>
+                                    <thankyou_config
+                                            jcr:primaryType="nt:unstructured"
+                                            granite:class="cmp-aemform--editor-thankyouConfig"
+                                            sling:resourceType="granite/ui/components/coral/foundation/form/radiogroup"
+                                            fieldLabel="Post-submission"
+                                            name="./thankyouConfig">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <message
+                                                    jcr:primaryType="nt:unstructured"
+                                                    text="Show Thank You Message"
+                                                    value="message">
+                                                <granite:data
+                                                        jcr:primaryType="nt:unstructured"
+                                                        hide="thankyoupage_field,submitType"
+                                                        show="thankyoumessage_field"
+                                                        toggle=""/>
+                                            </message>
+                                            <page
+                                                    jcr:primaryType="nt:unstructured"
+                                                    text="Show Thank You Page"
+                                                    value="page">
+                                                <granite:data
+                                                        jcr:primaryType="nt:unstructured"
+                                                        hide="thankyoumessage_field"
+                                                        show="thankyoupage_field,submitType"
+                                                        toggle=""/>
+                                            </page>
+                                        </items>
+                                    </thankyou_config>
+                                    <submit_type
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                            fieldLabel="Submit Type"
+                                            fieldDescription="Select to replace the page containing the embedded Adaptive Form with thank you page."
+                                            granite:class="cmp-aemform--editor-submitType"
+                                            name="./submitType"
+                                            text="Redirect to thank you page"
+                                            uncheckedValue="inline"
+                                            value="pageRefresh">
+                                        <granite:data
+                                                jcr:primaryType="nt:unstructured"
+                                                id="submitType"
+                                                toggle=""/>
+                                    </submit_type>
+                                    <thankyou_message
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="cq/gui/components/authoring/dialog/richtext"
+                                            class="thankyoumessage_field"
+                                            fieldLabel="Thank You Message"
+                                            name="./thankyouMessage"
+                                            useFixedInlineToolbar="{Boolean}true">
+                                        <rtePlugins jcr:primaryType="nt:unstructured">
+                                            <links jcr:primaryType="nt:unstructured">
+                                                <linkDialogConfig
+                                                        jcr:primaryType="nt:unstructured"
+                                                        height="{Long}316">
+                                                    <linkAttributes jcr:primaryType="cq:WidgetCollection"/>
+                                                </linkDialogConfig>
+                                            </links>
+                                            <format
+                                                    jcr:primaryType="nt:unstructured"
+                                                    features="*"/>
+                                            <lists
+                                                    jcr:primaryType="nt:unstructured"
+                                                    features="*"/>
+                                            <justify
+                                                    jcr:primaryType="nt:unstructured"
+                                                    features="*"/>
+                                            <keys
+                                                    jcr:primaryType="nt:unstructured"
+                                                    features="*"/>
+                                            <paraformat
+                                                    jcr:primaryType="nt:unstructured"
+                                                    features="*"/>
+                                            <misctools
+                                                    jcr:primaryType="nt:unstructured"
+                                                    features="*"/>
+                                            <fullscreen
+                                                    jcr:primaryType="nt:unstructured"
+                                                    features="*"/>
+                                        </rtePlugins>
+                                        <uiSettings jcr:primaryType="nt:unstructured">
+                                            <cui jcr:primaryType="nt:unstructured">
+                                                <inline
+                                                        jcr:primaryType="nt:unstructured"
+                                                        toolbar="[format#bold,format#italic,format#underline,fullscreen#start]">
+                                                    <popovers jcr:primaryType="nt:unstructured">
+                                                        <justify
+                                                                jcr:primaryType="nt:unstructured"
+                                                                items="[justify#justifyleft,justify#justifycenter,justify#justifyright]"
+                                                                ref="justify"/>
+                                                        <lists
+                                                                jcr:primaryType="nt:unstructured"
+                                                                items="[lists#unordered,lists#ordered,lists#outdent,lists#indent]"
+                                                                ref="lists"/>
+                                                    </popovers>
+                                                </inline>
+                                                <fullscreen
+                                                        jcr:primaryType="nt:unstructured"
+                                                        toolbar="[format#bold,format#italic,format#underline,subsuperscript#subscript,subsuperscript#superscript,-,links#modifylink,links#unlink,links#anchor,tracklinks#modifylinktracking,-,justify#justifyleft,justify#justifycenter,justify#justifyright,-,image#imageProps,-,lists#unordered,lists#ordered,lists#outdent,lists#indent,-,misctools#sourceedit,fullscreen#finish]">
+                                                    <popovers jcr:primaryType="nt:unstructured">
+                                                        <styles
+                                                                jcr:primaryType="nt:unstructured"
+                                                                items="styles:getStyles:styles-pulldown"
+                                                                ref="styles"/>
+                                                        <paraformat
+                                                                jcr:primaryType="nt:unstructured"
+                                                                items="paraformat:getFormats:paraformat-pulldown"
+                                                                ref="paraformat"/>
+                                                    </popovers>
+                                                </fullscreen>
+                                            </cui>
+                                        </uiSettings>
+                                    </thankyou_message>
+                                    <thankyou_page
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                            fieldLabel="Thank you page"
+                                            name="./thankyouPage"
+                                            rootPath="/content">
+                                        <granite:data
+                                                jcr:primaryType="nt:unstructured"
+                                                id="thankyoupage_field"
+                                                toggle=""/>
+                                    </thankyou_page>
+                                    <usePageLocale
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                            checked="{Boolean}true"
+                                            name="./usePageLocale"
+                                            text="Use Page Language"
+                                            value="true"/>
+                                    <enableFocusOnFirstField
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                            fieldDescription="Select to keep the focus on the first field of the adaptive form or uncheck to keep the focus on the parent page or application."
+                                            granite:class="cmp-aemform--editor-enablefocusonfirstfield"
+                                            name="./enableFocusOnFirstField"
+                                            checked="{Boolean}true"
+                                            text="Set Focus on Form"
+                                            uncheckedValue="false"
+                                            value="true"/>
+                                    <enableFocusOnFirstField-typehint
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/form/hidden"
+                                            name="./enableFocusOnFirstField@TypeHint"
+                                            value="Boolean"/>
+                                </items>
+                            </adaptiveFormContainer>
+                            <themeRef
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                    disabled="false"
+                                    emptyOption="false"
+                                    fieldLabel="Theme"
+                                    name="./themeRef"
+                                    renderReadOnly="false">
+                                <datasource
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="fd/af/components/commons/datasources/propertyprovider"
+                                        type="theme"/>
+                            </themeRef>
+                            <full_page_width
+                                    granite:id="useIframe"
+                                    granite:class="cmp-aemform--editor-useiframe"
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                    fieldDescription="If checked, iframe will not be used to render the form."
+                                    name="./useiframe"
+                                    text="Form covers entire width of the page"
+                                    checked="{Boolean}true"
+                                    uncheckedValue="true"
+                                    value="false"/>
+                            <height
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"
+                                    defaultValue=""
+                                    fieldDescription="Leave this field empty to resize the container automatically based on content."
+                                    fieldLabel="Height (pixels)"
+                                    min="0"
+                                    name="./height"/>
+                            <cssClientlib
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                    fieldDescription="CSS client library."
+                                    fieldLabel="CSS Client Library"
+                                    name="./cssClientlib"
+                                    value=""/>
+                        </items>
+                    </column>
+                </items>
+            </columns>
+        </items>
+    </content>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/_cq_editConfig.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/_cq_editConfig.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright 2020 Adobe
+  ~ Copyright 2022 Adobe
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -20,10 +20,16 @@
     <cq:actionConfigs jcr:primaryType="nt:unstructured">
         <editexpression
             jcr:primaryType="nt:unstructured"
-            condition="fd.core.formExists"
-            handler="fd.core.openFormForEditing"
+            condition="CQ.FormsCoreComponents.aemform.v2.actions.formExists"
+            handler="CQ.FormsCoreComponents.aemform.v2.actions.openFormForEditing"
             icon="alias"
             text="Edit in a new window"/>
+        <createFormViaWizard
+            jcr:primaryType="nt:unstructured"
+            condition="CQ.FormsCoreComponents.aemform.v2.actions.featureEnabled"
+            handler="CQ.FormsCoreComponents.aemform.v2.actions.openCreateFormWizard"
+            icon="addCircle"
+            text="Create Form"/>
     </cq:actionConfigs>
     <cq:listeners
         jcr:primaryType="cq:EditListenersConfig"

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/aemform.html
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/aemform.html
@@ -1,0 +1,54 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2022 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<sly data-sly-use.form="com.adobe.cq.forms.core.components.models.aemform.AEMForm"
+     data-sly-use.templates="core/wcm/components/commons/v1/templates.html"/>
+<script>
+    // Editor evaluates this script and if the clientlib is not loaded by then, it will fail. Hence triggering an
+    // event after clientlib load and initializing on that event.
+    (function () {
+        var onScriptLoad = function (evnt) {
+            var formApp = evnt.detail.formApp;
+            formApp.initializeAEMForm({
+                "form" : "${form.isFormSelected @ context='scriptString'}",
+                "submitType" : "${form.submitType @ context='scriptString'}",
+                "thankyouConfig" : "${form.thankyouConfig  @ context='scriptString'}",
+                "thankyouMessage": "${form.thankyouMessage  @ context='scriptString'}",
+                "thankyouPage" : "${form.thankyouPage  @ context='scriptString'}",
+                "useIframe" : "${form.useIframe @ context='scriptString'}",
+                "height" : "${form.height @ context='scriptString'}",
+                "aemFormComponentPath" : "${resource.path @ context='scriptString'}",
+                "enableFocusOnFirstField" : "${form.enableFocusOnFirstField @ context='scriptString'}"
+            });
+            //remove the event listener after completion
+            window.removeEventListener("aemform-onscript-load", onScriptLoad);
+        };
+        window.addEventListener("aemform-onscript-load", onScriptLoad);
+    }());
+</script>
+<sly data-sly-use.clientLib="${'/libs/granite/sightly/templates/clientlib.html'}"/>
+<sly data-sly-test.useIframe="${form.useIframe != 'false'}">
+    <sly data-sly-test.formLocaleString="${form.locale || 'en'}"/>
+        <iframe class="cmp-aemform__iframecontent"
+            src="${request.contextPath}${resource.path}.iframe.${formLocaleString}.html?dataRef=${request.requestParameterMap['dataRef'] != null ? request.requestParameterMap['dataRef'][0].toString : '' @ context='attribute'}${!wcmmode.edit ? '&wcmmode={0}':'' @ format=[wcmmode.toString]}"
+            stye="width:100%;"
+            data-form-page-path="${form.formEditPagePath}"></iframe>
+    <sly data-sly-test="${form.useIframe != 'false' && form.height == 'auto'}"
+         data-sly-call="${clientLib.all @ categories=['core.forms.components.aemform.v2.iframeResizer']}"/>
+</sly>
+<sly data-sly-call="${clientLib.all @ categories=['core.forms.components.aemform.v2.formapp']}"/>
+<sly data-sly-test="${!useIframe}">
+    <sly data-sly-include="formcontainer.html"></sly>
+</sly>

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright 2020 Adobe
+  ~ Copyright 2022 Adobe
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -14,18 +14,5 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
-<jcr:root xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    cq:actions="[EDIT,DELETE,INSERT,COPYMOVE]"
-    jcr:primaryType="cq:EditConfig">
-    <cq:actionConfigs jcr:primaryType="nt:unstructured">
-        <editexpression
-            jcr:primaryType="nt:unstructured"
-            condition="fd.core.formExists"
-            handler="fd.core.openFormForEditing"
-            icon="alias"
-            text="Edit in a new window"/>
-    </cq:actionConfigs>
-    <cq:listeners
-        jcr:primaryType="cq:EditListenersConfig"
-        afteredit="REFRESH_PARENT"/>
-</jcr:root>
+<jcr:root xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="sling:Folder"/>

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/editor/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/editor/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright 2020 Adobe
+  ~ Copyright 2022 Adobe
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -14,18 +14,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
-<jcr:root xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    cq:actions="[EDIT,DELETE,INSERT,COPYMOVE]"
-    jcr:primaryType="cq:EditConfig">
-    <cq:actionConfigs jcr:primaryType="nt:unstructured">
-        <editexpression
-            jcr:primaryType="nt:unstructured"
-            condition="fd.core.formExists"
-            handler="fd.core.openFormForEditing"
-            icon="alias"
-            text="Edit in a new window"/>
-    </cq:actionConfigs>
-    <cq:listeners
-        jcr:primaryType="cq:EditListenersConfig"
-        afteredit="REFRESH_PARENT"/>
-</jcr:root>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="cq:ClientLibraryFolder"
+          categories="[core.forms.components.aemform.v2.editor]"
+          dependencies="[core.forms.components.aemform.v1.editor]"/>

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/editor/js.txt
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/editor/js.txt
@@ -1,0 +1,17 @@
+###############################################################################
+# Copyright 2022 Adobe
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+#base=js

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/editorhook/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/editorhook/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright 2020 Adobe
+  ~ Copyright 2022 Adobe
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -14,18 +14,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
-<jcr:root xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    cq:actions="[EDIT,DELETE,INSERT,COPYMOVE]"
-    jcr:primaryType="cq:EditConfig">
-    <cq:actionConfigs jcr:primaryType="nt:unstructured">
-        <editexpression
-            jcr:primaryType="nt:unstructured"
-            condition="fd.core.formExists"
-            handler="fd.core.openFormForEditing"
-            icon="alias"
-            text="Edit in a new window"/>
-    </cq:actionConfigs>
-    <cq:listeners
-        jcr:primaryType="cq:EditListenersConfig"
-        afteredit="REFRESH_PARENT"/>
-</jcr:root>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="cq:ClientLibraryFolder"
+          allowProxy="{Boolean}true"
+          categories="[core.forms.components.aemform.editor.hook.v2, cq.authoring.editor.hook]"
+          dependencies="[cq.authoring.editor.core]"/>

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/editorhook/js.txt
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/editorhook/js.txt
@@ -1,0 +1,20 @@
+###############################################################################
+# Copyright 2022 Adobe
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+#base=js
+namespace.js
+EditListeners.js
+PreviewHook.js

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/editorhook/js/EditListeners.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/editorhook/js/EditListeners.js
@@ -1,0 +1,58 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2022 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+(function (Granite, ns) {
+    ns.aemform.v2.constants = {
+        "AEM_FORM_SELECTOR" : "[data-form-page-path]",
+        "AEM_FORM_CONTAINER_SELECTOR" : ".cmp-aemform",
+        "AEM_FORM_WIZARD_LINK" : "/libs/fd/fm/base/content/commons/wizardspalink.html"
+    };
+
+    ns.aemform.v2.actions.openFormForEditing = function (editable) {
+        var htmlElement = $(ns.aemform.v2.constants.AEM_FORM_SELECTOR, editable.dom).addBack("[data-form-page-path]"),
+            formPath = htmlElement.attr("data-form-page-path"),
+            url = Granite.HTTP.externalize("/editor.html" + formPath + ".html");
+        window.open(url);
+    };
+
+    ns.aemform.v2.actions.openCreateFormWizard = function (editable) {
+        $.ajax({
+            url: Granite.HTTP.externalize(ns.aemform.v2.constants.AEM_FORM_WIZARD_LINK),
+            type: "GET",
+            success: function(data){
+                var wizardURL = new URL($(data).get(0).href);
+                wizardURL.searchParams.append('embedAt', btoa(editable.path));
+                wizardURL.searchParams.append('redirectUrl', btoa(window.location.href));
+                window.open(Granite.HTTP.externalize(wizardURL.href), "_self");
+            },
+            error: function (error) {
+                console.log("Error: " + error);
+            }
+        });
+    }
+
+    ns.aemform.v2.actions.formExists = function (editable) {
+        return $(ns.aemform.v2.constants.AEM_FORM_SELECTOR, editable.dom).addBack(ns.aemform.v2.constants.AEM_FORM_SELECTOR).length > 0;
+    };
+
+    ns.aemform.v2.actions.aemFormExistsInPage = function () {
+        return Granite.author.ContentFrame.getDocument().find(ns.aemform.v2.constants.AEM_FORM_CONTAINER_SELECTOR).length > 0;
+    };
+
+    ns.aemform.v2.actions.featureEnabled = function (editable) {
+        return Granite.Toggles.isEnabled("FT_CQ-4343036");
+    };
+
+}(window.Granite, CQ.FormsCoreComponents));

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/editorhook/js/PreviewHook.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/editorhook/js/PreviewHook.js
@@ -1,0 +1,31 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2022 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+(function (channel, ns) {
+
+    // once the layer is switched, check if AEM form component exists in the page
+    // if aem form component exists, then refresh the page, so that we can show the test data in wcmmode preview
+    channel.on("editor-frame-mode-changed.aemform", function () {
+        if (ns.aemform && ns.aemform.v2 && ns.aemform.v2.actions && ns.aemform.v2.actions.aemFormExistsInPage()) {
+            // check if the cookie is wcmmode preview
+            var wcModeCookie = $.cookie("wcmmode");
+            if (wcModeCookie == "preview" || wcModeCookie == "edit") {
+                // reload the page
+                window.location.reload();
+            }
+        }
+    });
+
+}($(document), CQ.FormsCoreComponents));

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/editorhook/js/namespace.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/editorhook/js/namespace.js
@@ -1,0 +1,22 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2022 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+(function() {
+    window.CQ = window.CQ || {};
+    window.CQ.FormsCoreComponents = window.CQ.FormsCoreComponents || {};
+    window.CQ.FormsCoreComponents.aemform = window.CQ.FormsCoreComponents.aemform || {};
+    window.CQ.FormsCoreComponents.aemform.v2 = window.CQ.FormsCoreComponents.aemform.v2 || {};
+    window.CQ.FormsCoreComponents.aemform.v2.actions = {};
+})();

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/runtime/formapp/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/runtime/formapp/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright 2020 Adobe
+  ~ Copyright 2022 Adobe
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -14,18 +14,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
-<jcr:root xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    cq:actions="[EDIT,DELETE,INSERT,COPYMOVE]"
-    jcr:primaryType="cq:EditConfig">
-    <cq:actionConfigs jcr:primaryType="nt:unstructured">
-        <editexpression
-            jcr:primaryType="nt:unstructured"
-            condition="fd.core.formExists"
-            handler="fd.core.openFormForEditing"
-            icon="alias"
-            text="Edit in a new window"/>
-    </cq:actionConfigs>
-    <cq:listeners
-        jcr:primaryType="cq:EditListenersConfig"
-        afteredit="REFRESH_PARENT"/>
-</jcr:root>
+<jcr:root xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:ClientLibraryFolder"
+    allowProxy="{Boolean}true"
+    categories="[core.forms.components.aemform.v2.formapp]"
+    dependencies="core.forms.components.aemform.v1.formapp"/>

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/runtime/formapp/css.txt
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/runtime/formapp/css.txt
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright 2022 Adobe
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+#base=css

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/runtime/formapp/js.txt
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/runtime/formapp/js.txt
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright 2022 Adobe
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+#base=js

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/runtime/third-party/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/runtime/third-party/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright 2020 Adobe
+  ~ Copyright 2022 Adobe
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -14,18 +14,5 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
-<jcr:root xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    cq:actions="[EDIT,DELETE,INSERT,COPYMOVE]"
-    jcr:primaryType="cq:EditConfig">
-    <cq:actionConfigs jcr:primaryType="nt:unstructured">
-        <editexpression
-            jcr:primaryType="nt:unstructured"
-            condition="fd.core.formExists"
-            handler="fd.core.openFormForEditing"
-            icon="alias"
-            text="Edit in a new window"/>
-    </cq:actionConfigs>
-    <cq:listeners
-        jcr:primaryType="cq:EditListenersConfig"
-        afteredit="REFRESH_PARENT"/>
-</jcr:root>
+<jcr:root xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+          jcr:primaryType="sling:Folder"/>

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/runtime/third-party/iframeContentResizer/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/runtime/third-party/iframeContentResizer/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright 2020 Adobe
+  ~ Copyright 2022 Adobe
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -14,18 +14,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
-<jcr:root xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    cq:actions="[EDIT,DELETE,INSERT,COPYMOVE]"
-    jcr:primaryType="cq:EditConfig">
-    <cq:actionConfigs jcr:primaryType="nt:unstructured">
-        <editexpression
-            jcr:primaryType="nt:unstructured"
-            condition="fd.core.formExists"
-            handler="fd.core.openFormForEditing"
-            icon="alias"
-            text="Edit in a new window"/>
-    </cq:actionConfigs>
-    <cq:listeners
-        jcr:primaryType="cq:EditListenersConfig"
-        afteredit="REFRESH_PARENT"/>
-</jcr:root>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:ClientLibraryFolder"
+    allowProxy="{Boolean}true"
+    categories="[core.forms.components.aemform.v2.iframeContentResizer]"
+    dependencies="core.forms.components.aemform.v1.iframeContentResizer"/>

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/runtime/third-party/iframeContentResizer/css.txt
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/runtime/third-party/iframeContentResizer/css.txt
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright 2022 Adobe
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+#base=css

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/runtime/third-party/iframeContentResizer/js.txt
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/runtime/third-party/iframeContentResizer/js.txt
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright 2022 Adobe
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+#base=js

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/runtime/third-party/iframeResizer/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/runtime/third-party/iframeResizer/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright 2020 Adobe
+  ~ Copyright 2022 Adobe
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -14,18 +14,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
-<jcr:root xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    cq:actions="[EDIT,DELETE,INSERT,COPYMOVE]"
-    jcr:primaryType="cq:EditConfig">
-    <cq:actionConfigs jcr:primaryType="nt:unstructured">
-        <editexpression
-            jcr:primaryType="nt:unstructured"
-            condition="fd.core.formExists"
-            handler="fd.core.openFormForEditing"
-            icon="alias"
-            text="Edit in a new window"/>
-    </cq:actionConfigs>
-    <cq:listeners
-        jcr:primaryType="cq:EditListenersConfig"
-        afteredit="REFRESH_PARENT"/>
-</jcr:root>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:ClientLibraryFolder"
+    allowProxy="{Boolean}true"
+    categories="[core.forms.components.aemform.v2.iframeResizer]"
+    dependencies="core.forms.components.aemform.v1.iframeResizer"/>

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/runtime/third-party/iframeResizer/js.txt
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/runtime/third-party/iframeResizer/js.txt
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright 2022 Adobe
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+#base=js

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/site/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/site/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright 2020 Adobe
+  ~ Copyright 2022 Adobe
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -14,18 +14,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
-<jcr:root xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    cq:actions="[EDIT,DELETE,INSERT,COPYMOVE]"
-    jcr:primaryType="cq:EditConfig">
-    <cq:actionConfigs jcr:primaryType="nt:unstructured">
-        <editexpression
-            jcr:primaryType="nt:unstructured"
-            condition="fd.core.formExists"
-            handler="fd.core.openFormForEditing"
-            icon="alias"
-            text="Edit in a new window"/>
-    </cq:actionConfigs>
-    <cq:listeners
-        jcr:primaryType="cq:EditListenersConfig"
-        afteredit="REFRESH_PARENT"/>
-</jcr:root>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="cq:ClientLibraryFolder"
+          allowProxy="{Boolean}true"
+          categories="[core.forms.components.aemform.v2]"
+          dependencies="core.forms.components.aemform.v1"/>

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/site/css.txt
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/clientlibs/site/css.txt
@@ -1,0 +1,17 @@
+###############################################################################
+# Copyright 2022 Adobe
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+#base=css

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/formcontainer.html
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/formcontainer.html
@@ -1,0 +1,40 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2022 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<sly data-sly-use.clientLib="${'/libs/granite/sightly/templates/clientlib.html'}"/>
+<sly data-sly-call="${clientlib.all @ categories='coralui3'}"/>
+<sly data-sly-use.form="com.adobe.cq.forms.core.components.models.aemform.AEMForm"
+     data-sly-use.templates="core/wcm/components/commons/v1/templates.html"/>
+<sly data-sly-test="${!wcmmode.disabled && !form.isFormSelected}">
+    <sly data-sly-call="${clientLib.all @ categories='core.forms.components.aemform.v2'}"/>
+    <div class="cmp-aemform--no-form-selected">
+        ${'Select a form to embed.' @ i18n, locale=request.locale} <br/>
+        ${'Tap' @ i18n, locale=request.locale}
+        <coral-icon icon="wrench" size="XS"></coral-icon>
+        ${'to embed an existing form or use ' @ i18n, locale=request.locale}
+        <coral-icon icon="addCircle" size="XS"></coral-icon>
+        ${'to create and embed a new form.' @ i18n, locale=request.locale}
+    </div>
+</sly>
+<div class="cmp-aemform__content"
+     data-sly-test.af="${form.isAdaptiveForm || form.isMCDocument}"
+     data-form-page-path="${form.formEditPagePath}"
+     data-sly-use.guideConstants="com.adobe.aemds.guide.utils.GuideConstants">
+    <sly data-sly-call="${clientLib.css @ categories=['guide.core.common']}"/>
+    <sly data-sly-test.isParentWCMModeDisabled="${wcmmode.disabled}"/>
+    <sly data-sly-test.isWCMModePreview="${wcmmode.preview}"/>
+    <sly data-sly-use="${'formcontainer.js' @ wcmmode=isWCMModePreview ? 'preview' : 'disabled', themeOverride=form.themePath, pageFallbackClientlib=guideConstants.THEME_DEFAULT_CLIENTLIB, parentWcmModeDisabled=isParentWCMModeDisabled, afAcceptLang=form.locale}" data-sly-resource="${ @ path=form.formPagePath, wcmmode=isWCMModePreview ? 'preview' : 'disabled'}" />
+    <sly data-sly-call="${clientLib.css @ categories=[form.cssClientlib]}"/>
+</div>

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/formcontainer.js
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/formcontainer.js
@@ -1,0 +1,24 @@
+/*
+ *  Copyright 2022 Adobe
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/**
+ * using property wcmmode and theme configured in af in aem.
+ */
+use(function () {
+    var property;
+    for (property in this) {
+        request.setAttribute(property, this[property]);
+    }
+});

--- a/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/iframe.html
+++ b/ui.apps/src/main/content/jcr_root/apps/core/fd/components/aemform/v2/aemform/iframe.html
@@ -1,0 +1,30 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2022 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<!DOCTYPE html>
+<html>
+<head lang="en">
+    <sly data-sly-use.form="com.adobe.cq.forms.core.components.models.aemform.AEMForm"
+         data-sly-use.templates="core/wcm/components/commons/v1/templates.html"/>
+    <title data-sly-test="${form.isAdaptiveForm || form.isMCDocument}"><sly data-sly-use.af="com.adobe.aemds.guide.common.AdaptiveForm" />${af.formTitle @ context='html'}</title>
+    <meta charset="UTF-8" name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta name="robots" content="noindex, nofollow"/>
+    <sly data-sly-use.clientLib="${'/libs/granite/sightly/templates/clientlib.html'}"/>
+    <sly data-sly-test="${form.useIframe != 'false' && form.height == 'auto'}" data-sly-call="${clientLib.all @ categories=['core.forms.components.aemform.v2.iframeContentResizer']}"/>
+</head>
+<body>
+<sly data-sly-include="formcontainer.html"></sly>
+</body>
+</html>

--- a/ui.tests/test-module/specs/aemformcontainer.spec.js
+++ b/ui.tests/test-module/specs/aemformcontainer.spec.js
@@ -61,10 +61,6 @@ describe('Page - Authoring', function () {
             // click configure action on aem forms container component
             cy.openEditableToolbar(sitesSelectors.overlays.overlay.component + aemFormContainerEditPathSelector);
             cy.invokeEditableAction("[data-action='CONFIGURE']"); // this line is causing frame busting which is causing cypress to fail
-            // check if adaptive form is selected by default
-            cy.get("[name='./formType']")
-                .should("be.visible")
-                .should("have.value", "adaptiveForm");
             // check for dynamic operations performed using JS
             cy.get("[name='./thankyouConfig'][value='message']")
                 .should("be.visible")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Moved forms embed feature in Sites page to AEM Forms Container component v2.
Removed ./formType support. Now, AEM Forms Container acts as a container to use AEM Forms pages only for Adaptive Form(default).

## Related Issue

https://jira.corp.adobe.com/browse/CQ-4346081

## Motivation and Context

Since we are providing a new feature(embed forms in a Site page) for AEM Forms Container component, we should create a v2 for the same.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
