### PR TITLE
[CQ-4348552] DoR dropdown styling issue

### DIFF
--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/base/v1/base/_cq_dialog/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/base/v1/base/_cq_dialog/.content.xml
@@ -451,70 +451,13 @@
                                     value="Boolean"/>
                             <dorColspan
                                     jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="granite/ui/components/coral/foundation/form/autocomplete"
+                                    sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"
                                     disabled="false"
-                                    emptyText=""
+                                    defaultValue=""
                                     fieldDescription="Enter number of columns the field should span in Document of Record. Supported only for Column layout in Document of Record."
                                     fieldLabel="Colspan for Document of Record"
                                     name="./dorColspan"
                                     renderReadOnly="false">
-                                <options
-                                        jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="granite/ui/components/coral/foundation/form/autocomplete/list"/>
-                                <items jcr:primaryType="nt:unstructured">
-                                    <empty
-                                            jcr:primaryType="nt:unstructured"
-                                            text=""
-                                            value=""/>
-                                    <v1
-                                            jcr:primaryType="nt:unstructured"
-                                            text="1"
-                                            value="1"/>
-                                    <v2
-                                            jcr:primaryType="nt:unstructured"
-                                            text="2"
-                                            value="2"/>
-                                    <v3
-                                            jcr:primaryType="nt:unstructured"
-                                            text="3"
-                                            value="3"/>
-                                    <v4
-                                            jcr:primaryType="nt:unstructured"
-                                            text="4"
-                                            value="4"/>
-                                    <v5
-                                            jcr:primaryType="nt:unstructured"
-                                            text="5"
-                                            value="5"/>
-                                    <v6
-                                            jcr:primaryType="nt:unstructured"
-                                            text="6"
-                                            value="6"/>
-                                    <v7
-                                            jcr:primaryType="nt:unstructured"
-                                            text="7"
-                                            value="7"/>
-                                    <v8
-                                            jcr:primaryType="nt:unstructured"
-                                            text="8"
-                                            value="8"/>
-                                    <v9
-                                            jcr:primaryType="nt:unstructured"
-                                            text="9"
-                                            value="9"/>
-                                    <v10
-                                            jcr:primaryType="nt:unstructured"
-                                            text="10"
-                                            value="10"/>
-                                    <v11
-                                            jcr:primaryType="nt:unstructured"
-                                            text="11"
-                                            value="11"/>
-                                    <v12
-                                            jcr:primaryType="nt:unstructured"
-                                            text="12"
-                                            value="12"/>
-                                </items>
                             </dorColspan>
                         </items>
                         <granite:rendercondition


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changing the dorColspan resourceSuperType to Numeric Field input.
Reason:
1. Autocomplete Granite UI component is deprecated and had styling issues which reduced the ease of use of dropdown in the coral panel as it did not fit in property to let the user see the available options from the dropdown. 
2. The field should allow only number input but, using autocomplete the user could earlier enter non-numeric values. 

## Related Issue
[CQ-4348552](https://jira.corp.adobe.com/browse/CQ-4348552)
<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![Screenshot (460)](https://user-images.githubusercontent.com/110378842/202423703-92be78c8-44d0-4654-8ab5-c1dcb630ff17.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
