### PR TITLE
[FORMS-7828] resolved problem of navigation not working in authoring without refresh in case of horizontal and vertical tabs

### DIFF
--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/tabsontop/v1/tabsontop/clientlibs/site/js/tabs.js
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/tabsontop/v1/tabsontop/clientlibs/site/js/tabs.js
@@ -47,7 +47,7 @@
                 var _self = this;
                 CQ.CoreComponents.MESSAGE_CHANNEL.subscribeRequestMessage("cmp.panelcontainer", function (message) {
                     if (message.data && message.data.type === "cmp-tabs" && message.data.id === _self._elements.self.dataset["cmpPanelcontainerId"]) {
-                        if (message.data.operation === "navigate") {
+                        if (message.data.operation === "navigate" && _self._elements["tab"][message.data.index] != undefined) {
                             _self.navigate(_self._elements["tab"][message.data.index].id);
                         }
                     }

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/verticaltabs/v1/verticaltabs/clientlibs/site/js/verticaltabs.js
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/verticaltabs/v1/verticaltabs/clientlibs/site/js/verticaltabs.js
@@ -47,7 +47,7 @@
                 var _self = this;
                 CQ.CoreComponents.MESSAGE_CHANNEL.subscribeRequestMessage("cmp.panelcontainer", function (message) {
                     if (message.data && message.data.type === "cmp-verticaltabs" && message.data.id === _self._elements.self.dataset["cmpPanelcontainerId"]) {
-                        if (message.data.operation === "navigate") {
+                        if (message.data.operation === "navigate" && _self._elements["tab"][message.data.index] != undefined) {
                             _self.navigate(_self._elements["tab"][message.data.index].id);
                         }
                     }

--- a/ui.tests/test-module/specs/datepicker/datepicker.authoring.spec.js
+++ b/ui.tests/test-module/specs/datepicker/datepicker.authoring.spec.js
@@ -14,8 +14,8 @@
  *  limitations under the License.
  */
 
- const sitesSelectors = require('../../libs/commons/sitesSelectors'),
-     afConstants = require('../../libs/commons/formsConstants');
+const sitesSelectors = require('../../libs/commons/sitesSelectors'),
+    afConstants = require('../../libs/commons/formsConstants');
 
 describe('Page - Authoring', function () {
 
@@ -43,9 +43,12 @@ describe('Page - Authoring', function () {
             dropDatePickerInContainer();
         }
         cy.openEditableToolbar(sitesSelectors.overlays.overlay.component + datePickerEditPathSelector);
-        cy.invokeEditableAction("[data-action='CONFIGURE']");
-        cy.get('.cq-dialog-cancel').click();
-        cy.deleteComponentByPath(datePickerDrop);
+        cy.invokeEditableAction("[data-action='CONFIGURE']").then(() => {
+            cy.get('.cq-dialog-cancel').should('be.visible').click().then(() => {
+                cy.deleteComponentByPath(datePickerDrop);
+            });
+        })
+
     }
 
     const testDatePickerBasicTab = function (datePickerEditPathSelector, datePickerDrop, isSites) {
@@ -75,13 +78,15 @@ describe('Page - Authoring', function () {
         }
         cy.openEditableToolbar(sitesSelectors.overlays.overlay.component + datePickerEditPathSelector);
         cy.invokeEditableAction("[data-action='CONFIGURE']");
-        cy.get(bemEditDialog).contains('Validation').click({force:true});
-        cy.get("[name='./minimumDate']").should("exist");
-        cy.get("[name='./minimumMessage']").should("exist");
-        cy.get("[name='./maximumDate']").should("exist");
-        cy.get("[name='./maximumMessage']").should("exist");
-        cy.get('.cq-dialog-cancel').click();
-        cy.deleteComponentByPath(datePickerDrop);
+        cy.get(bemEditDialog).contains('Validation').click().then(() => {
+            cy.get("[name='./minimumDate']").should("exist");
+            cy.get("[name='./minimumMessage']").should("exist");
+            cy.get("[name='./maximumDate']").should("exist");
+            cy.get("[name='./maximumMessage']").should("exist");
+            cy.get('.cq-dialog-cancel').should('be.visible').click().then(() => {
+                cy.deleteComponentByPath(datePickerDrop);
+            })
+        });
     }
 
     context('Open Forms Editor', function () {
@@ -91,8 +96,8 @@ describe('Page - Authoring', function () {
             datePickerDrop = pagePath + afConstants.FORM_EDITOR_FORM_CONTAINER_SUFFIX + "/" + afConstants.components.forms.resourceType.datepicker.split("/").pop();
 
         beforeEach(function () {
-          // this is done since cypress session results in 403 sometimes
-          cy.openAuthoring(pagePath);
+            // this is done since cypress session results in 403 sometimes
+            cy.openAuthoring(pagePath);
         });
 
 
@@ -105,8 +110,8 @@ describe('Page - Authoring', function () {
             testDatePickerEditDialog(datePickerEditPathSelector, datePickerDrop);
         });
 
-        it('verify Basic tab in edit dialog of DatePicker', { retries: 3 }, function () {
-            cy.cleanTest(datePickerDrop).then(function() {
+        it('verify Basic tab in edit dialog of DatePicker', {retries: 3}, function () {
+            cy.cleanTest(datePickerDrop).then(function () {
                 testDatePickerBasicTab(datePickerEditPathSelector, datePickerDrop);
             });
         });
@@ -117,33 +122,33 @@ describe('Page - Authoring', function () {
 
     });
 
- context('Open Sites Editor', function () {
-     const   pagePath = "/content/core-components-examples/library/adaptive-form/datepicker",
-         datePickerEditPath = pagePath + afConstants.RESPONSIVE_GRID_DEMO_SUFFIX + "/guideContainer/datepicker",
-         datePickerEditPathSelector = "[data-path='" + datePickerEditPath + "']",
-         datePickerDrop = pagePath + afConstants.RESPONSIVE_GRID_DEMO_SUFFIX + '/guideContainer/' + afConstants.components.forms.resourceType.datepicker.split("/").pop();
+    context('Open Sites Editor', function () {
+        const pagePath = "/content/core-components-examples/library/adaptive-form/datepicker",
+            datePickerEditPath = pagePath + afConstants.RESPONSIVE_GRID_DEMO_SUFFIX + "/guideContainer/datepicker",
+            datePickerEditPathSelector = "[data-path='" + datePickerEditPath + "']",
+            datePickerDrop = pagePath + afConstants.RESPONSIVE_GRID_DEMO_SUFFIX + '/guideContainer/' + afConstants.components.forms.resourceType.datepicker.split("/").pop();
 
-     beforeEach(function () {
-       // this is done since cypress session results in 403 sometimes
-       cy.openAuthoring(pagePath);
-     });
+        beforeEach(function () {
+            // this is done since cypress session results in 403 sometimes
+            cy.openAuthoring(pagePath);
+        });
 
-     it('checking add and delete in form container', function () {
-         dropDatePickerInSites();
-         cy.deleteComponentByPath(datePickerDrop);
-     });
+        it('checking add and delete in form container', function () {
+            dropDatePickerInSites();
+            cy.deleteComponentByPath(datePickerDrop);
+        });
 
-     it ('open edit dialog of DatePicker', function(){
-         testDatePickerEditDialog(datePickerEditPathSelector, datePickerDrop, true);
-     });
+        it('open edit dialog of DatePicker', function () {
+            testDatePickerEditDialog(datePickerEditPathSelector, datePickerDrop, true);
+        });
 
-     it('verify Basic tab in edit dialog of DatePicker', function () {
-         testDatePickerBasicTab(datePickerEditPathSelector, datePickerDrop, true);
-     });
+        it('verify Basic tab in edit dialog of DatePicker', function () {
+            testDatePickerBasicTab(datePickerEditPathSelector, datePickerDrop, true);
+        });
 
-     it('verify Validation tab in edit dialog of DatePicker', function () {
-         testDatePickerValidationTab(datePickerEditPathSelector, datePickerDrop, true);
-     });
+        it('verify Validation tab in edit dialog of DatePicker', function () {
+            testDatePickerValidationTab(datePickerEditPathSelector, datePickerDrop, true);
+        });
 
- });
+    });
 });

--- a/ui.tests/test-module/specs/numberinput/numberinput.authoring.spec.js
+++ b/ui.tests/test-module/specs/numberinput/numberinput.authoring.spec.js
@@ -57,65 +57,73 @@ describe('Page - Authoring', function () {
             dropNumberInputInContainer();
             cy.openEditableToolbar(sitesSelectors.overlays.overlay.component + numberInputEditPathSelector);
             cy.invokeEditableAction(editDialogConfigurationSelector);
-            cy.get(numberInputBlockBemSelector + '__editdialog').contains('Validation').click({force: true});
-            cy.get(numberInputBlockBemSelector + '__editdialog').contains('Help Content').click({force: true});
-            cy.get(numberInputBlockBemSelector + '__editdialog').contains('Accessibility').click({force: true});
-            cy.get(numberInputBlockBemSelector + '__editdialog').contains('Formats').click({force: true});
-            cy.get(numberInputBlockBemSelector + '__editdialog').contains('Basic').click({force: true});
-            cy.get("[name='./name']").should("exist");
-            cy.get("[name='./jcr:title']").should("exist");
-            cy.get("[name='./hideTitle']").should("exist");
-            cy.get("[name='./placeholder']").should("exist");
-            cy.get("[name='./type']").should("exist");
-            cy.get("[name='./default']").should("exist");
-            cy.get("[name='./minimum']").should("exist");
-            cy.get("[name='./exclusiveMinimum']").should("exist");
-            cy.get("[name='./maximum']").should("exist");
-            cy.get("[name='./exclusiveMaximum']").should("exist");
-            cy.get('.cq-dialog-cancel').should('be.visible');
-            cy.get('.cq-dialog-submit').should('be.visible');
-            cy.get('.cq-dialog-cancel').click({force: true});
-            cy.deleteComponentByPath(numberInputDrop);
+            cy.get(numberInputBlockBemSelector + '__editdialog').contains('Validation').click().then(() => {
+                cy.get(numberInputBlockBemSelector + '__editdialog').contains('Help Content').click().then(() => {
+                    cy.get(numberInputBlockBemSelector + '__editdialog').contains('Accessibility').click().then(() => {
+                        cy.get(numberInputBlockBemSelector + '__editdialog').contains('Formats').click().then(() => {
+                            cy.get(numberInputBlockBemSelector + '__editdialog').contains('Basic').click().then(() => {
+                                cy.get("[name='./name']").should("exist");
+                                cy.get("[name='./jcr:title']").should("exist");
+                                cy.get("[name='./hideTitle']").should("exist");
+                                cy.get("[name='./placeholder']").should("exist");
+                                cy.get("[name='./type']").should("exist");
+                                cy.get("[name='./default']").should("exist");
+                                cy.get("[name='./minimum']").should("exist");
+                                cy.get("[name='./exclusiveMinimum']").should("exist");
+                                cy.get("[name='./maximum']").should("exist");
+                                cy.get("[name='./exclusiveMaximum']").should("exist");
+                                cy.get('.cq-dialog-submit').should('be.visible');
+                                cy.get('.cq-dialog-cancel').should('be.visible').click().then(() => {
+                                    cy.deleteComponentByPath(numberInputDrop);
+                                });
+                            })
+                        });
+                    })
+                })
+            });
         });
 
         it(' type dropdown in Basic tab in edit dialog of NumberInput', function () {
             dropNumberInputInContainer();
             cy.openEditableToolbar(sitesSelectors.overlays.overlay.component + numberInputEditPathSelector);
             cy.invokeEditableAction(editDialogConfigurationSelector);
-            cy.get(numberInputBlockBemSelector + '__editdialog').contains('Validation').click({force: true});
-            cy.get(numberInputBlockBemSelector + '__editdialog').contains('Basic').click({force: true});
-            cy.get(numberInputBlockBemSelector + '__leaddigits').parent().children('label').contains('Number of digits before the decimal separator (1234.000)');
-            cy.get(numberInputBlockBemSelector + '__fracdigits').parent().children('label').contains('Number of digits after the decimal separator (1234.000)');
-            cy.get(numberInputBlockBemSelector + "__type").children('._coral-Dropdown-trigger').click();
-            cy.get("._coral-Menu-itemLabel").contains('Decimal').should('be.visible');
-            cy.get("._coral-Menu-itemLabel").contains('Integer').should('be.visible').click();
-            cy.get(numberInputBlockBemSelector + '__leaddigits').parent().children('label').contains('Maximum Number of Digits');
-            cy.get('.cq-dialog-cancel').click({force: true});
-            cy.deleteComponentByPath(numberInputDrop);
-        });
+            cy.get(numberInputBlockBemSelector + '__editdialog').contains('Validation').click().then(() => {
+                cy.get(numberInputBlockBemSelector + '__editdialog').contains('Basic').click().then(() => {
+                    cy.get(numberInputBlockBemSelector + '__leaddigits').parent().children('label').contains('Number of digits before the decimal separator (1234.000)');
+                    cy.get(numberInputBlockBemSelector + '__fracdigits').parent().children('label').contains('Number of digits after the decimal separator (1234.000)');
+                    cy.get(numberInputBlockBemSelector + "__type").children('._coral-Dropdown-trigger').click();
+                    cy.get("._coral-Menu-itemLabel").contains('Decimal').should('be.visible');
+                    cy.get("._coral-Menu-itemLabel").contains('Integer').should('be.visible').click();
+                    cy.get(numberInputBlockBemSelector + '__leaddigits').parent().children('label').contains('Maximum Number of Digits');
+                    cy.get('.cq-dialog-cancel').should('be.visible').click().then(() => {
+                        cy.deleteComponentByPath(numberInputDrop);
+                    })
+                });
+            });
+        })
 
         it('verify editFormat Value Getting saved correctly', function () {
             dropNumberInputInContainer();
             cy.openEditableToolbar(sitesSelectors.overlays.overlay.component + numberInputEditPathSelector);
             cy.invokeEditableAction(editDialogConfigurationSelector);
-            cy.get(numberInputBlockBemSelector + '__editdialog').contains('Formats').click({force: true});
-            cy.wait(1000).then(() => {
+            cy.get(numberInputBlockBemSelector + '__editdialog').contains('Formats').click().then(() => {
                 cy.get(numberInputBlockBemSelector + '__leaddigits').clear();
                 cy.get(numberInputBlockBemSelector + '__leaddigits').type(4);
                 cy.get(numberInputBlockBemSelector + '__fracdigits').clear();
                 cy.get(numberInputBlockBemSelector + '__fracdigits').type(4);
-                cy.get('.cq-dialog-submit').click();
-                cy.wait(1000).then(() => {
-                    cy.openEditableToolbar(sitesSelectors.overlays.overlay.component + numberInputEditPathSelector);
-                    cy.invokeEditableAction(editDialogConfigurationSelector);
-                    cy.get(numberInputBlockBemSelector + '__editdialog').contains('Formats').click({force: true});
-                    cy.get(numberInputBlockBemSelector + '__leaddigits').should('have.value', 4);
-                    cy.get(numberInputBlockBemSelector + '__fracdigits').should('have.value', 4);
-                    cy.wait(1000).then(() => {
-                        cy.get('.cq-dialog-cancel').should('be.visible').click({force: true});
-                        cy.deleteComponentByPath(numberInputDrop);
-                    });
-                });
+                cy.get('.cq-dialog-submit').should('be.visible').click().then(() => {
+                    cy.get('.cq-dialog-submit').should('not.exist').then(() => {
+                        cy.openEditableToolbar(sitesSelectors.overlays.overlay.component + numberInputEditPathSelector);
+                        cy.invokeEditableAction(editDialogConfigurationSelector).then(() => {
+                            cy.get(numberInputBlockBemSelector + '__editdialog').contains('Formats').click();
+                            cy.get(numberInputBlockBemSelector + '__leaddigits').should('have.value', 4);
+                            cy.get(numberInputBlockBemSelector + '__fracdigits').should('have.value', 4);
+                            cy.get('.cq-dialog-cancel').should('be.visible').click().then(() => {
+                                cy.deleteComponentByPath(numberInputDrop);
+                            })
+                        })
+                    })
+                })
             });
         })
     });
@@ -153,7 +161,7 @@ describe('Page - Authoring', function () {
                     cy.get("[name='./maximum']").should("exist");
                     cy.get("[name='./exclusiveMaximum']").should("exist");
                     cy.get('.cq-dialog-submit').should('be.visible');
-                    cy.get('.cq-dialog-cancel').should('be.visible').click({force: true}).then(() => {
+                    cy.get('.cq-dialog-cancel').should('be.visible').click().then(() => {
                         cy.deleteComponentByPath(numberInputDrop);
                     })
                 })

--- a/ui.tests/test-module/specs/tabsontop/tabsontop.authoring.spec.js
+++ b/ui.tests/test-module/specs/tabsontop/tabsontop.authoring.spec.js
@@ -26,136 +26,134 @@ const commons = require('../../libs/commons/commons'),
  */
 describe.only('Page - Authoring', function () {
 
-  const dropComponent = function(responsiveGridDropZoneSelector, componentTitle, componentType) {
-    cy.selectLayer("Edit");
-    cy.insertComponent(responsiveGridDropZoneSelector, componentTitle, componentType);
-    cy.get('body').click( 0,0);
-  }  
-
-  const getDropZoneSelector = function(responsiveGridDropZone) {
-    return sitesSelectors.overlays.overlay.component + "[data-path='" + responsiveGridDropZone + "']";
-  }
-
-  const dropTabsInContainer = function() {
-    const responsiveGridDropZoneSelector = getDropZoneSelector("/content/forms/af/core-components-it/blank/jcr:content/guideContainer/*");
-    dropComponent(responsiveGridDropZoneSelector, "Adaptive Form Horizontal Tabs", afConstants.components.forms.resourceType.tabsontop);
-  }
-
-  const dropTextInputInTabComponent = function() {
-    const responsiveGridDropZoneSelector = sitesSelectors.overlays.overlay.component + "[data-text='Please drag Tab components here']:last";
-    dropComponent(responsiveGridDropZoneSelector, "Adaptive Form Text Box", afConstants.components.forms.resourceType.formtextinput);
-  }
-  const dropDatePickerInTabComponent = function() {
-    const responsiveGridDropZoneSelector = sitesSelectors.overlays.overlay.component + "[data-text='Please drag Tab components here']:last";
-    dropComponent(responsiveGridDropZoneSelector, "Adaptive Form Date Picker", afConstants.components.forms.resourceType.datepicker);
-  }
-  const dropTabsInSites = function() {
-    const dataPath = "/content/core-components-examples/library/adaptive-form/panelcontainer/jcr:content/root/responsivegrid/demo/component/guideContainer/*",
-        responsiveGridDropZoneSelector = sitesSelectors.overlays.overlay.component + "[data-path='" + dataPath + "']";
-    dropComponent(responsiveGridDropZoneSelector, "Adaptive Form Horizontal Tabs", afConstants.components.forms.resourceType.tabsontop);
-  }
-
-  const testPanelBehaviour = function(tabsEditPathSelector, tabsContainerDrop, isSites) {
-    if (isSites) {
-      dropTabsInSites();
-    } else {
-      dropTabsInContainer();
+    const dropComponent = function (responsiveGridDropZoneSelector, componentTitle, componentType) {
+        cy.selectLayer("Edit");
+        cy.insertComponent(responsiveGridDropZoneSelector, componentTitle, componentType);
+        cy.get('body').click(0, 0);
     }
-    cy.openEditableToolbar(sitesSelectors.overlays.overlay.component + tabsEditPathSelector);
-    cy.invokeEditableAction("[data-action='CONFIGURE']"); // this line is causing frame busting which is causing cypress to fail
-    // Check If Dialog Options Are Visible
-    cy.get("[name='./name']")
-    .should("exist");
-    cy.get("[name='./jcr:title']")
-    .should("exist");
-    cy.get("[name='./dataRef']")
-        .should("exist");
-    cy.get("[name='./visible']")
-        .should("exist");
-    cy.get("[name='./enabled']")
-        .should("exist");
-    cy.get("[name='./assistPriority']")
-        .should("exist");
-    cy.get("[name='./custom']")
-        .should("exist");
 
-    cy.get('.cq-dialog-cancel').click();
-    cy.deleteComponentByPath(tabsContainerDrop);
-  }
+    const getDropZoneSelector = function (responsiveGridDropZone) {
+        return sitesSelectors.overlays.overlay.component + "[data-path='" + responsiveGridDropZone + "']";
+    }
 
-  context('Open Forms Editor', function() {
-    const pagePath = "/content/forms/af/core-components-it/blank",
-        tabsPath = pagePath + afConstants.FORM_EDITOR_FORM_CONTAINER_SUFFIX + "/tabsontop",
-        tabsContainerPathSelector = "[data-path='" + tabsPath + "']";
-    beforeEach(function () {
-      // this is done since cypress session results in 403 sometimes
-      cy.openAuthoring(pagePath);
-    });
+    const dropTabsInContainer = function () {
+        const responsiveGridDropZoneSelector = getDropZoneSelector("/content/forms/af/core-components-it/blank/jcr:content/guideContainer/*");
+        dropComponent(responsiveGridDropZoneSelector, "Adaptive Form Horizontal Tabs", afConstants.components.forms.resourceType.tabsontop);
+    }
 
-    it('insert Tabs on top in form container', function () {
-      dropTabsInContainer();
-      cy.deleteComponentByPath(tabsPath);
-    });
+    const dropTextInputInTabComponent = function () {
+        const responsiveGridDropZoneSelector = sitesSelectors.overlays.overlay.component + "[data-text='Please drag Tab components here']:last";
+        dropComponent(responsiveGridDropZoneSelector, "Adaptive Form Text Box", afConstants.components.forms.resourceType.formtextinput);
+    }
+    const dropDatePickerInTabComponent = function () {
+        const responsiveGridDropZoneSelector = sitesSelectors.overlays.overlay.component + "[data-text='Please drag Tab components here']:last";
+        dropComponent(responsiveGridDropZoneSelector, "Adaptive Form Date Picker", afConstants.components.forms.resourceType.datepicker);
+    }
+    const dropTabsInSites = function () {
+        const dataPath = "/content/core-components-examples/library/adaptive-form/panelcontainer/jcr:content/root/responsivegrid/demo/component/guideContainer/*",
+            responsiveGridDropZoneSelector = sitesSelectors.overlays.overlay.component + "[data-path='" + dataPath + "']";
+        dropComponent(responsiveGridDropZoneSelector, "Adaptive Form Horizontal Tabs", afConstants.components.forms.resourceType.tabsontop);
+    }
 
-
-    it('drop element in tabs on top', { retries: 3 }, function () {
-        cy.cleanTest(tabsPath).then(function(){
+    const testPanelBehaviour = function (tabsEditPathSelector, tabsContainerDrop, isSites) {
+        if (isSites) {
+            dropTabsInSites();
+        } else {
             dropTabsInContainer();
-            dropTextInputInTabComponent();
-            cy.get(`[data-path="${tabsPath}"] [data-path="${tabsPath}/textinput"]`).should('be.visible');
+        }
+        cy.openEditableToolbar(sitesSelectors.overlays.overlay.component + tabsEditPathSelector);
+        cy.invokeEditableAction("[data-action='CONFIGURE']"); // this line is causing frame busting which is causing cypress to fail
+        // Check If Dialog Options Are Visible
+        cy.get("[name='./name']")
+            .should("exist");
+        cy.get("[name='./jcr:title']")
+            .should("exist");
+        cy.get("[name='./dataRef']")
+            .should("exist");
+        cy.get("[name='./visible']")
+            .should("exist");
+        cy.get("[name='./enabled']")
+            .should("exist");
+        cy.get("[name='./assistPriority']")
+            .should("exist");
+        cy.get("[name='./custom']")
+            .should("exist");
+
+        cy.get('.cq-dialog-cancel').click();
+        cy.deleteComponentByPath(tabsContainerDrop);
+    }
+
+    context('Open Forms Editor', function () {
+        const pagePath = "/content/forms/af/core-components-it/blank",
+            tabsPath = pagePath + afConstants.FORM_EDITOR_FORM_CONTAINER_SUFFIX + "/tabsontop",
+            tabsContainerPathSelector = "[data-path='" + tabsPath + "']";
+        beforeEach(function () {
+            // this is done since cypress session results in 403 sometimes
+            cy.openAuthoring(pagePath);
+        });
+
+        it('insert Tabs on top in form container', function () {
+            dropTabsInContainer();
             cy.deleteComponentByPath(tabsPath);
         });
-    });
 
-    // todo: flaky
-    it('switch tabs using dialog select panel button in toolbar', { retries: 3 }, function(){
-        cy.cleanTest(tabsPath).then(function() {
-            dropTabsInContainer();
-            //Add 2 children in tabs on top component
-            dropTextInputInTabComponent();
-            dropDatePickerInTabComponent();
-            cy.openEditableToolbar(sitesSelectors.overlays.overlay.component + tabsContainerPathSelector);
-            cy.invokeEditableAction("[data-action='PANEL_SELECT']");
-            cy.get("table.cmp-panelselector__table").find("tr").should("have.length", 2);
-            const datePickerPath = tabsPath + "/datepicker";
-            cy.get(`[data-id="${datePickerPath}`).click();
-            cy.get('body').click(0, 0);
-            cy.invokeEditableAction("[data-action='PANEL_SELECT']");
-            //Click datepicker from panel select list
-            cy.get(`[data-id="${datePickerPath}`).click();
-            cy.get(`[data-path="${datePickerPath}"]`).should('be.visible');
-            cy.deleteComponentByPath(tabsPath);
+
+        it('drop element in tabs on top', {retries: 3}, function () {
+            cy.cleanTest(tabsPath).then(function () {
+                dropTabsInContainer();
+                dropTextInputInTabComponent();
+                cy.get(`[data-path="${tabsPath}"] [data-path="${tabsPath}/textinput"]`).should('be.visible');
+                cy.deleteComponentByPath(tabsPath);
+            });
         });
-    });
 
-    it ('open edit dialog of Tab on top',{ retries: 3 }, function(){
-        cy.cleanTest(tabsPath).then(function() {
-            testPanelBehaviour(tabsContainerPathSelector, tabsPath);
+        // todo: flaky
+        it.only('switch tabs using dialog select panel button in toolbar', {retries: 3}, function () {
+            cy.cleanTest(tabsPath).then(function () {
+                dropTabsInContainer();
+                //Add 2 children in tabs on top component
+                dropTextInputInTabComponent();
+                dropDatePickerInTabComponent();
+                cy.openEditableToolbar(sitesSelectors.overlays.overlay.component + tabsContainerPathSelector);
+                cy.invokeEditableAction("[data-action='PANEL_SELECT']").then(() => {
+                    cy.get("table.cmp-panelselector__table").find("tr").should("have.length", 2);
+                    const datePickerPath = tabsPath + "/datepicker";
+                    cy.get(`[data-id="${datePickerPath}`).click().then(() => {
+                        cy.get(`[data-path="${datePickerPath}"]`).should('be.visible');
+                        cy.deleteComponentByPath(tabsPath);
+                    })
+                })
+            });
         });
-    });
 
-  });
-
-  context('Open Sites Editor', function () {
-    const   pagePath = "/content/core-components-examples/library/adaptive-form/panelcontainer",
-        panelContainerEditPath = pagePath + afConstants.RESPONSIVE_GRID_DEMO_SUFFIX + "/guideContainer/tabsontop",
-        tabsEditPathSelector = "[data-path='" + panelContainerEditPath + "']";
-
-    beforeEach(function () {
-      // this is done since cypress session results in 403 sometimes
-      cy.openAuthoring(pagePath);
-    });
-
-    it('insert tabs on top of form', function () {
-      dropTabsInSites();
-      cy.deleteComponentByPath(panelContainerEditPath);
-    });
-
-    it('open edit dialog of tabs on top of form', { retries: 3 }, function() {
-        cy.cleanTest(panelContainerEditPath).then(function(){
-            testPanelBehaviour(tabsEditPathSelector, panelContainerEditPath, true);
+        it('open edit dialog of Tab on top', {retries: 3}, function () {
+            cy.cleanTest(tabsPath).then(function () {
+                testPanelBehaviour(tabsContainerPathSelector, tabsPath);
+            });
         });
+
     });
 
-  });
+    context('Open Sites Editor', function () {
+        const pagePath = "/content/core-components-examples/library/adaptive-form/panelcontainer",
+            panelContainerEditPath = pagePath + afConstants.RESPONSIVE_GRID_DEMO_SUFFIX + "/guideContainer/tabsontop",
+            tabsEditPathSelector = "[data-path='" + panelContainerEditPath + "']";
+
+        beforeEach(function () {
+            // this is done since cypress session results in 403 sometimes
+            cy.openAuthoring(pagePath);
+        });
+
+        it('insert tabs on top of form', function () {
+            dropTabsInSites();
+            cy.deleteComponentByPath(panelContainerEditPath);
+        });
+
+        it('open edit dialog of tabs on top of form', {retries: 3}, function () {
+            cy.cleanTest(panelContainerEditPath).then(function () {
+                testPanelBehaviour(tabsEditPathSelector, panelContainerEditPath, true);
+            });
+        });
+
+    });
 });

--- a/ui.tests/test-module/specs/wizard/wizard.authoring.spec.js
+++ b/ui.tests/test-module/specs/wizard/wizard.authoring.spec.js
@@ -21,72 +21,74 @@ const guideSelectors = require("../../libs/commons/guideSelectors");
 describe('Page - Authoring', function () {
     // we can use these values to log in
 
-    const dropWizardInContainer = function() {
+    const dropWizardInContainer = function () {
         const dataPath = "/content/forms/af/core-components-it/blank/jcr:content/guideContainer/*",
             responsiveGridDropZoneSelector = sitesSelectors.overlays.overlay.component + "[data-path='" + dataPath + "']";
         cy.selectLayer("Edit");
         cy.insertComponent(responsiveGridDropZoneSelector, "Adaptive Form Wizard Layout", afConstants.components.forms.resourceType.wizard);
-        cy.get('body').click( 0,0);
+        cy.get('body').click(0, 0);
     }
 
     const addComponentInWizard = function (componentString, componentType) {
-        const dataPath="/content/forms/af/core-components-it/blank/jcr:content/guideContainer/wizard/*",
+        const dataPath = "/content/forms/af/core-components-it/blank/jcr:content/guideContainer/wizard/*",
             wizardDropZoneSelector = sitesSelectors.overlays.overlay.component + "[data-path='" + dataPath + "']";
         cy.selectLayer("Edit");
         cy.insertComponent(wizardDropZoneSelector, componentString, componentType);
 
-        cy.get('body').click( 0,0);
+        cy.get('body').click(0, 0);
     }
 
-    const dropWizardInSites = function() {
+    const dropWizardInSites = function () {
         const dataPath = "/content/core-components-examples/library/adaptive-form/wizard/jcr:content/root/responsivegrid/demo/component/guideContainer/*",
             responsiveGridDropZoneSelector = sitesSelectors.overlays.overlay.component + "[data-path='" + dataPath + "']";
         cy.selectLayer("Edit");
         cy.insertComponent(responsiveGridDropZoneSelector, "Adaptive Form Wizard Layout", afConstants.components.forms.resourceType.wizard);
-        cy.get('body').click( 0,0);
+        cy.get('body').click(0, 0);
     }
 
 
-
-    context('Open Forms Editor', function() {
+    context('Open Forms Editor', function () {
         const pagePath = "/content/forms/af/core-components-it/blank",
             wizardLayoutDrop = pagePath + afConstants.FORM_EDITOR_FORM_CONTAINER_SUFFIX + "/" + afConstants.components.forms.resourceType.wizard.split("/").pop(),
             wizardEditPathSelector = "[data-path='" + wizardLayoutDrop + "']",
             wizardBlockBemSelector = '.cmp-adaptiveform-wizard',
             insertComponentDialog_searchField = ".InsertComponentDialog-components input[type='search']",
             editDialogNavigationPanelSelector = "[data-action='PANEL_SELECT']",
-            textInputPath=wizardLayoutDrop+"/"+afConstants.components.forms.resourceType.formtextinput.split("/").pop(),
-            numberInputPath=wizardLayoutDrop+"/"+afConstants.components.forms.resourceType.formnumberinput.split("/").pop(),
-            textInputDataId="[data-id='"+textInputPath+"']",
-            numberInputDataId="[data-id='" + numberInputPath + "']",
-            textInputDataPath="[data-path='" + textInputPath + "']",
-            numberInputDataPath="[data-path='" + numberInputPath + "']",
+            textInputPath = wizardLayoutDrop + "/" + afConstants.components.forms.resourceType.formtextinput.split("/").pop(),
+            numberInputPath = wizardLayoutDrop + "/" + afConstants.components.forms.resourceType.formnumberinput.split("/").pop(),
+            textInputDataId = "[data-id='" + textInputPath + "']",
+            numberInputDataId = "[data-id='" + numberInputPath + "']",
+            textInputDataPath = "[data-path='" + textInputPath + "']",
+            numberInputDataPath = "[data-path='" + numberInputPath + "']",
             editDialogConfigurationSelector = "[data-action='CONFIGURE']";
         beforeEach(function () {
             // this is done since cypress session results in 403 sometimes
             cy.openAuthoring(pagePath);
         });
 
-        it('verify Basic tab in edit dialog of Wizard',function (){
+        it('verify Basic tab in edit dialog of Wizard', function () {
             dropWizardInContainer();
-            cy.openEditableToolbar(sitesSelectors.overlays.overlay.component + wizardEditPathSelector).then(()=>{
-                cy.invokeEditableAction(editDialogConfigurationSelector).then(()=>{
-                    cy.get(wizardBlockBemSelector+'__editdialog').contains('Help Content').click({force:true});
-                    cy.get(wizardBlockBemSelector+'__editdialog').contains('Basic').click({force:true});
-                    cy.get("[name='./name']").should("exist");
-                    cy.get("[name='./jcr:title']").should("exist");
-                    cy.get("[name='./layout']").should("exist");
-                    cy.get("[name='./dataRef']").should("exist");
-                    cy.get("[name='./visible']").should("exist");
-                    cy.get("[name='./enabled']").should("exist");
-                    cy.get('.cq-dialog-cancel').click({force:true});
+            cy.openEditableToolbar(sitesSelectors.overlays.overlay.component + wizardEditPathSelector).then(() => {
+                cy.invokeEditableAction(editDialogConfigurationSelector).then(() => {
+                    cy.get(wizardBlockBemSelector + '__editdialog').contains('Help Content').click().then(() => {
+                        cy.get(wizardBlockBemSelector + '__editdialog').contains('Basic').click().then(() => {
+                            cy.get("[name='./name']").should("exist");
+                            cy.get("[name='./jcr:title']").should("exist");
+                            cy.get("[name='./layout']").should("exist");
+                            cy.get("[name='./dataRef']").should("exist");
+                            cy.get("[name='./visible']").should("exist");
+                            cy.get("[name='./enabled']").should("exist");
+                            cy.get('.cq-dialog-cancel').should('be.visible').click().then(() => {
+                                cy.deleteComponentByPath(wizardLayoutDrop);
+                            });
+                        });
+                    });
                 });
             });
-            cy.deleteComponentByPath(wizardLayoutDrop) ;
         });
 
-        it('verify Navigation Working between tabs in Authoring', { retries: 3 }, function(){
-            cy.cleanTest(wizardLayoutDrop).then(function() {
+        it('verify Navigation Working between tabs in Authoring', {retries: 3}, function () {
+            cy.cleanTest(wizardLayoutDrop).then(function () {
                 dropWizardInContainer();
                 addComponentInWizard("Adaptive Form Number Input", afConstants.components.forms.resourceType.formnumberinput);
                 addComponentInWizard("Adaptive Form Text Box", afConstants.components.forms.resourceType.formtextinput);
@@ -94,11 +96,11 @@ describe('Page - Authoring', function () {
                 cy.invokeEditableAction(editDialogNavigationPanelSelector);
                 cy.wait(2000).then(() => {
                     cy.get("table.cmp-panelselector__table").find("tr").should("have.length", 2);
-                    cy.get("table.cmp-panelselector__table").find(textInputDataId).find("td").first().should('be.visible').click({force: true});
+                    cy.get("table.cmp-panelselector__table").find(textInputDataId).find("td").first().should('be.visible').click();
                     cy.get('body').click(0, 0);
                     cy.get('div' + numberInputDataPath).should('not.be.visible');
                     cy.invokeEditableAction(editDialogNavigationPanelSelector);
-                    cy.get("table.cmp-panelselector__table").find(numberInputDataId).find("td").first().should('be.visible').click({force: true});
+                    cy.get("table.cmp-panelselector__table").find(numberInputDataId).find("td").first().should('be.visible').click();
                     cy.get('body').click(0, 0);
                     cy.get('div' + textInputDataPath).should('not.be.visible');
                     cy.deleteComponentByPath(wizardLayoutDrop);
@@ -108,7 +110,7 @@ describe('Page - Authoring', function () {
     });
 
     context('Open Sites Editor', function () {
-        const   pagePath = "/content/core-components-examples/library/adaptive-form/wizard",
+        const pagePath = "/content/core-components-examples/library/adaptive-form/wizard",
             wizardEditPath = pagePath + afConstants.RESPONSIVE_GRID_DEMO_SUFFIX + "/guideContainer/wizard",
             wizardBlockBemSelector = '.cmp-adaptiveform-wizard',
             editDialogConfigurationSelector = "[data-action='CONFIGURE']",
@@ -119,29 +121,31 @@ describe('Page - Authoring', function () {
             cy.openAuthoring(pagePath);
         });
 
-        it('insert aem forms Wizard', { retries: 3 }, function () {
-            cy.cleanTest(wizardEditPath).then(function(){
+        it('insert aem forms Wizard', {retries: 3}, function () {
+            cy.cleanTest(wizardEditPath).then(function () {
                 dropWizardInSites();
                 cy.deleteComponentByPath(wizardEditPath);
             });
         });
 
         // adding retry, sometimes site editor does not load
-        it('open edit dialog of aem forms Wizard', { retries: 3 }, function() {
-            cy.cleanTest(wizardEditPath).then(function() {
+        it('open edit dialog of aem forms Wizard', {retries: 3}, function () {
+            cy.cleanTest(wizardEditPath).then(function () {
                 dropWizardInSites();
                 cy.openEditableToolbar(sitesSelectors.overlays.overlay.component + wizardEditPathSelector);
                 cy.invokeEditableAction(editDialogConfigurationSelector);
-                cy.get(wizardBlockBemSelector + '__editdialog').contains('Help Content').click({force: true});
-                cy.get(wizardBlockBemSelector + '__editdialog').contains('Basic').click({force: true});
+                cy.get(wizardBlockBemSelector + '__editdialog').contains('Help Content').click();
+                cy.get(wizardBlockBemSelector + '__editdialog').contains('Basic').click();
                 cy.get("[name='./name']").should("exist");
                 cy.get("[name='./jcr:title']").should("exist");
                 cy.get("[name='./layout']").should("exist");
                 cy.get("[name='./dataRef']").should("exist");
                 cy.get("[name='./visible']").should("exist");
                 cy.get("[name='./enabled']").should("exist");
-                cy.get('.cq-dialog-cancel').click({force: true});
-                cy.deleteComponentByPath(wizardEditPath);
+                cy.get('.cq-dialog-cancel').should('be.visible').click().then(() => {
+                    cy.deleteComponentByPath(wizardEditPath);
+                })
+
             });
         });
 


### PR DESCRIPTION
Added test case to check this behaviour :-

The issue was because the editor hook sends a navigation event as soon as the element is added to tab before the tab's constructor call . hence the _self._elements cache doesn't have the newly added elements and while checking the array at the index , the call fails and constructor call doesn't happens.

When we refresh the constructor call happens resulting in correct cache formation and hence correct navigation.