### PR TITLE
Forms 9357  added cleanTitle test command which deletes residual title components from previous tests, separate command needed because we can't delete by exact editPath in case of title component, we delete by matching startsWith in string...

### DIFF
--- a/ui.tests/test-module/libs/support/commands.js
+++ b/ui.tests/test-module/libs/support/commands.js
@@ -41,7 +41,7 @@
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
 import 'cypress-file-upload';
-import { recurse } from 'cypress-recurse'
+import {recurse} from 'cypress-recurse'
 
 const commons = require('../commons/commons'),
     siteSelectors = require('../commons/sitesSelectors'),
@@ -51,7 +51,7 @@ const commons = require('../commons/commons'),
 
 // Cypress command to login to aem page
 Cypress.Commands.add("login", (pagePath) => {
-    const username = Cypress.env('crx.username') ?  Cypress.env('crx.username') : "admin";
+    const username = Cypress.env('crx.username') ? Cypress.env('crx.username') : "admin";
     const password = Cypress.env('crx.password') ? Cypress.env('crx.password') : "admin";
     cy.get('#username').type(username);
     cy.get('#password').type(password);
@@ -101,7 +101,7 @@ Cypress.Commands.add("enableOrDisableTutorials", (enable) => {
         preferences[":cq_csrf_token"] = token;
     });
     cy.get("@home").then(home => {
-        const contextPath = Cypress.env('crx.contextPath') ?  Cypress.env('crx.contextPath') : "";
+        const contextPath = Cypress.env('crx.contextPath') ? Cypress.env('crx.contextPath') : "";
         const url = contextPath + home + '/preferences';
         //cy.request('POST', url, preferences) // not using cy.request, since application level cookies needs to be passed
         cy.window().then(win => {
@@ -145,7 +145,7 @@ Cypress.Commands.add("openSiteAuthoring", (pagePath) => {
                     //alert(Granite.I18n.get("Your request could not be completed because you have been signed out."));
                     // var l = util.getTopWindow().document.location; // this causes frame burst and ideally should be fixed in Granite code
                     var l = win.Granite.author.EditorFrame.$doc.get(0).defaultView.location;
-                    l.href =  win.Granite.HTTP.externalize("/") + "?resource=" + encodeURIComponent(l.pathname + l.search + l.hash);
+                    l.href = win.Granite.HTTP.externalize("/") + "?resource=" + encodeURIComponent(l.pathname + l.search + l.hash);
                 }
             };
         }
@@ -154,14 +154,14 @@ Cypress.Commands.add("openSiteAuthoring", (pagePath) => {
 
 // Cypress command to open authoring page
 Cypress.Commands.add("openAuthoring", (pagePath) => {
-    const baseUrl = Cypress.env('crx.contextPath') ?  Cypress.env('crx.contextPath') : "";
+    const baseUrl = Cypress.env('crx.contextPath') ? Cypress.env('crx.contextPath') : "";
     cy.visit(baseUrl);
     cy.login(baseUrl);
     cy.openSiteAuthoring(pagePath);
 });
 
 // Cypress command to open authoring page
-Cypress.Commands.add("openPage", (pagePath, options={}) => {
+Cypress.Commands.add("openPage", (pagePath, options = {}) => {
     if (!options.noLogin) {
         const baseUrl = Cypress.env('crx.contextPath') ? Cypress.env('crx.contextPath') : "";
         cy.visit(baseUrl);
@@ -182,30 +182,30 @@ Cypress.Commands.add("selectLayer", (layer) => {
 // cypress command to open editable toolbar
 Cypress.Commands.add("openEditableToolbar", (selector) => {
     cy.get(selector) // adding assertion does implicit retry
-    .invoke('attr', 'data-path')
-    .then(($path) => {
-        const path = siteSelectors.editableToolbar.elementDom.replace("%s", $path);
-        cy.get("body").then($body => {
-            if ($body.find(path).length === 0) {
-                //evaluates as true if toolbar doesnt exists at all
-                //you get here only if toolbar is visible
-                cy.get(selector).click({force: true}); // end user does not face this but due to cypress checks, we need to add force true here
-                // sometimes the above line results in this error, `<div.cq-Overlay.cq-Overlay--component.cq-draggable.cq-droptarget.is-resizable>` is not visible because its parent `<div.cq-Overlay.cq-Overlay--component.cq-Overlay--container>` has CSS property: `display: none`
-                cy.get(path).should('be.visible');
-            } else {
-                cy.get(path).then($header => {
-                    if (!$header.is(':visible')){
-                        cy.get(selector).first().click({force: true});
-                        cy.get(path).should('be.visible');
-                    } else {
-                        cy.get(siteSelectors.overlays.self).click(0,0); // dont click on body, always use overlay wrapper to click
-                        cy.get(selector).click({force: true});
-                        cy.get(path).should('be.visible');
-                    }
-                });
-            }
-        });
-    })
+        .invoke('attr', 'data-path')
+        .then(($path) => {
+            const path = siteSelectors.editableToolbar.elementDom.replace("%s", $path);
+            cy.get("body").then($body => {
+                if ($body.find(path).length === 0) {
+                    //evaluates as true if toolbar doesnt exists at all
+                    //you get here only if toolbar is visible
+                    cy.get(selector).click({force: true}); // end user does not face this but due to cypress checks, we need to add force true here
+                    // sometimes the above line results in this error, `<div.cq-Overlay.cq-Overlay--component.cq-draggable.cq-droptarget.is-resizable>` is not visible because its parent `<div.cq-Overlay.cq-Overlay--component.cq-Overlay--container>` has CSS property: `display: none`
+                    cy.get(path).should('be.visible');
+                } else {
+                    cy.get(path).then($header => {
+                        if (!$header.is(':visible')) {
+                            cy.get(selector).first().click({force: true});
+                            cy.get(path).should('be.visible');
+                        } else {
+                            cy.get(siteSelectors.overlays.self).click(0, 0); // dont click on body, always use overlay wrapper to click
+                            cy.get(selector).click({force: true});
+                            cy.get(path).should('be.visible');
+                        }
+                    });
+                }
+            });
+        })
 });
 
 // cypress command to invoke an editable action
@@ -284,7 +284,9 @@ const waitForChildViewAddition = () => {
 Cypress.Commands.add("getFormData", () => {
     return cy.window().then(win => {
         const promise = new Cypress.Promise((resolve, reject) => {
-            const successhandler = data => { resolve(data); };
+            const successhandler = data => {
+                resolve(data);
+            };
             win.guideBridge.getFormDataString({success: successhandler});
         });
         return promise;
@@ -293,7 +295,7 @@ Cypress.Commands.add("getFormData", () => {
 
 
 Cypress.Commands.add("getFromDefinitionUsingOpenAPI", (formPath, offset = 0, limit = 20) => {
-    return cy.request("GET", `/adobe/forms/af/listforms?offset=${offset}&limit=${limit}`).then(({ body }) => {
+    return cy.request("GET", `/adobe/forms/af/listforms?offset=${offset}&limit=${limit}`).then(({body}) => {
         // We need its ID to continue nesting below it
         let retVal = body.items.find(collection => collection.path === formPath);
         if (retVal) {
@@ -306,10 +308,10 @@ Cypress.Commands.add("getFromDefinitionUsingOpenAPI", (formPath, offset = 0, lim
 });
 
 
-Cypress.Commands.add("previewForm", (formPath, options={}) => {
+Cypress.Commands.add("previewForm", (formPath, options = {}) => {
     let pagePath = `${formPath}?wcmmode=disabled`;
-    if(options?.params) {
-        options.params.forEach((param) => pagePath +=`&${param}`)
+    if (options?.params) {
+        options.params.forEach((param) => pagePath += `&${param}`)
         delete options.params
     }
     return cy.openPage(pagePath, options).then(waitForFormInit)
@@ -321,9 +323,26 @@ Cypress.Commands.add("cleanTest", (editPath) => {
     return cy.get("body").then($body => {
         return new Cypress.Promise((resolve, reject) => {
             // do something custom here
-            const selector12 =  "[data-path='" + editPath + "']";
+            const selector12 = "[data-path='" + editPath + "']";
             if ($body.find(selector12).length > 0) {
                 cy.deleteComponentByPath(editPath);
+            }
+            resolve(editPath);
+        });
+    });
+})
+
+Cypress.Commands.add("cleanTitleTest", (editPath) => {
+    // clean the test before the next run, if any
+    return cy.get("body").then($body => {
+        return new Cypress.Promise((resolve, reject) => {
+            // do something custom here
+            const selector12 = "div[data-path^='" + editPath + "']";
+            if ($body.find(selector12).length > 0) {
+                $body.find(selector12).each(($index, $titleComponent) => {
+                    cy.log($titleComponent.dataset.path);
+                    cy.deleteComponentByPath($titleComponent.dataset.path);
+                })
             }
             resolve(editPath);
         });
@@ -358,7 +377,7 @@ Cypress.Commands.add("deleteComponentByPath", (componentPath) => {
 // cypress command to delete component by title
 Cypress.Commands.add("deleteComponentByTitle", (title) => {
     const editableUpdateEvent = siteConstants.EVENT_NAME_EDITABLES_UPDATED,
-        componentPathSelector = "[title='"+title+"']",
+        componentPathSelector = "[title='" + title + "']",
         overlayRepositionEvent = siteConstants.EVENT_NAME_OVERLAYS_REPOSITIONED;
     // intialize the event handler for editableUpdateEvent
     cy.initializeEventHandlerOnChannel(editableUpdateEvent).as("isEditableUpdateEventComplete");
@@ -446,25 +465,25 @@ Cypress.Commands.add("toggleDescriptionTooltip", (bemBlock, fieldId, shortDescri
         longDescriptionText = 'This is long description';
     }
     cy.get(`#${fieldId}`).find(`.${bemBlock}__shortdescription`).invoke('attr', 'data-cmp-visible=false')
-    .should('not.exist');
+        .should('not.exist');
     cy.get(`#${fieldId}`).find(`.${bemBlock}__shortdescription`)
         .should('contain.text', shortDescriptionText);
     // click on ? mark
     cy.get(`#${fieldId}`).find(`.${bemBlock}__questionmark`).click();
     // long description should be shown
     cy.get(`#${fieldId}`).find(`.${bemBlock}__longdescription`).invoke('attr', 'data-cmp-visible')
-    .should('not.exist');
+        .should('not.exist');
     cy.get(`#${fieldId}`).find(`.${bemBlock}__longdescription`)
         .should('contain.text', longDescriptionText);
     // short description should be hidden.
     cy.get(`#${fieldId}`).find(`.${bemBlock}__shortdescription`).invoke('attr', 'data-cmp-visible')
-    .should('eq', 'false');
+        .should('eq', 'false');
 });
 
 Cypress.Commands.add("openSidePanelTab", (tab) => {
-    cy.window().then(function(win) {
+    cy.window().then(function (win) {
         let isSidePanelOpen = win.$("#SidePanel").hasClass("sidepanel-opened");
-        if(!isSidePanelOpen) {
+        if (!isSidePanelOpen) {
             cy.get("#Content .toggle-sidepanel").click();
         }
     });

--- a/ui.tests/test-module/libs/support/commands.js
+++ b/ui.tests/test-module/libs/support/commands.js
@@ -340,7 +340,6 @@ Cypress.Commands.add("cleanTitleTest", (editPath) => {
             const selector12 = "div[data-path^='" + editPath + "']";
             if ($body.find(selector12).length > 0) {
                 $body.find(selector12).each(($index, $titleComponent) => {
-                    cy.log($titleComponent.dataset.path);
                     cy.deleteComponentByPath($titleComponent.dataset.path);
                 })
             }

--- a/ui.tests/test-module/specs/accordion/accordion.authoring.spec.js
+++ b/ui.tests/test-module/specs/accordion/accordion.authoring.spec.js
@@ -22,115 +22,115 @@ const sitesSelectors = require('../../libs/commons/sitesSelectors'),
  * Testing Accordion with Sites Editor
  */
 describe('Page - Authoring', function () {
-  // we can use these values to log in
+    // we can use these values to log in
 
-  const dropAccordionInContainer = function() {
-    const dataPath = "/content/forms/af/core-components-it/blank/jcr:content/guideContainer/*",
-        responsiveGridDropZoneSelector = sitesSelectors.overlays.overlay.component + "[data-path='" + dataPath + "']";
-    cy.selectLayer("Edit");
-    cy.insertComponent(responsiveGridDropZoneSelector, "Adaptive Form Accordion", afConstants.components.forms.resourceType.accordion);
-    cy.get('body').click( 0,0);
-  }
-
-  const dropAccordionInSites = function() {
-    const dataPath = "/content/core-components-examples/library/adaptive-form/accordion/jcr:content/root/responsivegrid/demo/component/guideContainer/*",
-        responsiveGridDropZoneSelector = sitesSelectors.overlays.overlay.component + "[data-path='" + dataPath + "']";
-    cy.selectLayer("Edit");
-    cy.insertComponent(responsiveGridDropZoneSelector, "Adaptive Form Accordion", afConstants.components.forms.resourceType.accordion);
-    cy.get('body').click( 0,0);
-  }
-
-  const testAccordionBehaviour = function(accordionEditPathSelector, accordionDrop, isSites) {
-    if (isSites) {
-      dropAccordionInSites();
-    } else {
-      dropAccordionInContainer();
+    const dropAccordionInContainer = function () {
+        const dataPath = "/content/forms/af/core-components-it/blank/jcr:content/guideContainer/*",
+            responsiveGridDropZoneSelector = sitesSelectors.overlays.overlay.component + "[data-path='" + dataPath + "']";
+        cy.selectLayer("Edit");
+        cy.insertComponent(responsiveGridDropZoneSelector, "Adaptive Form Accordion", afConstants.components.forms.resourceType.accordion);
+        cy.get('body').click(0, 0);
     }
-    cy.openEditableToolbar(sitesSelectors.overlays.overlay.component + accordionEditPathSelector);
-    cy.invokeEditableAction("[data-action='CONFIGURE']"); // this line is causing frame busting which is causing cypress to fail
-    // Check If Dialog Options Are Visible
-    cy.get("[name='./name']")
-        .should("exist");
-    cy.get("[name='./jcr:title']")
-        .should("exist");
-    cy.get("[name='./layout']")
-        .should("exist")
-    cy.get("[name='./dataRef']")
-        .should("exist");
-    cy.get("[name='./visible']")
-        .should("exist");
-    cy.get("[name='./enabled']")
-        .should("exist");
-    cy.get("[name='./assistPriority']")
-        .should("exist");
-    cy.get("[name='./custom']")
-        .should("exist");
 
-    cy.get('.cq-dialog-cancel').click();
-    cy.deleteComponentByPath(accordionDrop);
-  }
+    const dropAccordionInSites = function () {
+        const dataPath = "/content/core-components-examples/library/adaptive-form/accordion/jcr:content/root/responsivegrid/demo/component/guideContainer/*",
+            responsiveGridDropZoneSelector = sitesSelectors.overlays.overlay.component + "[data-path='" + dataPath + "']";
+        cy.selectLayer("Edit");
+        cy.insertComponent(responsiveGridDropZoneSelector, "Adaptive Form Accordion", afConstants.components.forms.resourceType.accordion);
+        cy.get('body').click(0, 0);
+    }
 
-  context('Open Forms Editor', function() {
-    const pagePath = "/content/forms/af/core-components-it/blank",
-        accordionEditPath = pagePath + afConstants.FORM_EDITOR_FORM_CONTAINER_SUFFIX + "/accordion",
-        accordionPathSelector = "[data-path='" + accordionEditPath + "']";
-    beforeEach(function () {
-      // this is done since cypress session results in 403 sometimes
-      cy.openAuthoring(pagePath);
-    });
+    const testAccordionBehaviour = function (accordionEditPathSelector, accordionDrop, isSites) {
+        if (isSites) {
+            dropAccordionInSites();
+        } else {
+            dropAccordionInContainer();
+        }
+        cy.openEditableToolbar(sitesSelectors.overlays.overlay.component + accordionEditPathSelector);
+        cy.invokeEditableAction("[data-action='CONFIGURE']"); // this line is causing frame busting which is causing cypress to fail
+        // Check If Dialog Options Are Visible
+        cy.get("[name='./name']")
+            .should("exist");
+        cy.get("[name='./jcr:title']")
+            .should("exist");
+        cy.get("[name='./layout']")
+            .should("exist")
+        cy.get("[name='./dataRef']")
+            .should("exist");
+        cy.get("[name='./visible']")
+            .should("exist");
+        cy.get("[name='./enabled']")
+            .should("exist");
+        cy.get("[name='./assistPriority']")
+            .should("exist");
+        cy.get("[name='./custom']")
+            .should("exist");
 
-    it('insert Accordion in form container', function () {
-      dropAccordionInContainer();
-      cy.deleteComponentByPath(accordionEditPath);
-    });
+        cy.get('.cq-dialog-cancel').click();
+        cy.deleteComponentByPath(accordionDrop);
+    }
 
-    it ('open edit dialog of Accordion', function(){
-      testAccordionBehaviour(accordionPathSelector, accordionEditPath);
+    context('Open Forms Editor', function () {
+        const pagePath = "/content/forms/af/core-components-it/blank",
+            accordionEditPath = pagePath + afConstants.FORM_EDITOR_FORM_CONTAINER_SUFFIX + "/accordion",
+            accordionPathSelector = "[data-path='" + accordionEditPath + "']";
+        beforeEach(function () {
+            // this is done since cypress session results in 403 sometimes
+            cy.openAuthoring(pagePath);
+        });
+
+        it('insert Accordion in form container', {retries: 3}, function () {
+            dropAccordionInContainer();
+            cy.deleteComponentByPath(accordionEditPath);
+        });
+
+        it('open edit dialog of Accordion', function () {
+            testAccordionBehaviour(accordionPathSelector, accordionEditPath);
+        })
+
+        it('switch accordion tabs', function () {
+            dropAccordionInContainer();
+
+            cy.get("div[data-path='/content/forms/af/core-components-it/blank/jcr:content/guideContainer/accordion/item_2']").should('have.css', 'height', '0px')
+
+            cy.openEditableToolbar(sitesSelectors.overlays.overlay.component + accordionPathSelector);
+            cy.invokeEditableAction("[data-action='PANEL_SELECT']");
+            cy.get("table.cmp-panelselector__table").find("tr").should("have.length", 2);
+            cy.get("tr[data-name='item_2']").click();
+
+            cy.get('body').click(0, 0);
+            cy.invokeEditableAction("[data-action='PANEL_SELECT']");
+            cy.get("tr[data-name='item_2']").click();
+            cy.get("div[data-path='/content/forms/af/core-components-it/blank/jcr:content/guideContainer/accordion/item_1']").should('have.css', 'height', '0px')
+
+            cy.deleteComponentByPath(accordionEditPath);
+        });
     })
 
-    it ('switch accordion tabs', function(){
-      dropAccordionInContainer();
+    context('Open Sites Editor', function () {
+        const pagePath = "/content/core-components-examples/library/adaptive-form/accordion",
+            accordionEditPath = pagePath + afConstants.RESPONSIVE_GRID_DEMO_SUFFIX + "/guideContainer/accordion",
+            accordionEditPathSelector = "[data-path='" + accordionEditPath + "']";
 
-      cy.get("div[data-path='/content/forms/af/core-components-it/blank/jcr:content/guideContainer/accordion/item_2']").should('have.css', 'height', '0px')
+        beforeEach(function () {
+            // this is done since cypress session results in 403 sometimes
+            cy.openAuthoring(pagePath);
 
-      cy.openEditableToolbar(sitesSelectors.overlays.overlay.component + accordionPathSelector);
-      cy.invokeEditableAction("[data-action='PANEL_SELECT']");
-      cy.get("table.cmp-panelselector__table").find("tr").should("have.length", 2);
-      cy.get("tr[data-name='item_2']").click();
+        });
 
-      cy.get('body').click( 0,0);
-      cy.invokeEditableAction("[data-action='PANEL_SELECT']");
-      cy.get("tr[data-name='item_2']").click();
-      cy.get("div[data-path='/content/forms/af/core-components-it/blank/jcr:content/guideContainer/accordion/item_1']").should('have.css', 'height', '0px')
+        it('insert aem forms Accordion', {retries: 3}, function () {
+            cy.cleanTest(accordionEditPath).then(function () {
+                dropAccordionInSites();
+                cy.deleteComponentByPath(accordionEditPath);
+            });
+        });
 
-      cy.deleteComponentByPath(accordionEditPath);
-    });
-  })
-
-  context('Open Sites Editor', function () {
-    const   pagePath = "/content/core-components-examples/library/adaptive-form/accordion",
-        accordionEditPath = pagePath + afConstants.RESPONSIVE_GRID_DEMO_SUFFIX + "/guideContainer/accordion",
-        accordionEditPathSelector = "[data-path='" + accordionEditPath + "']";
-
-    beforeEach(function () {
-      // this is done since cypress session results in 403 sometimes
-      cy.openAuthoring(pagePath);
+        // todo: intermittent failure
+        it('open edit dialog of aem forms Accordion', {retries: 3}, function () {
+            cy.cleanTest(accordionEditPath).then(function () {
+                testAccordionBehaviour(accordionEditPathSelector, accordionEditPath, true);
+            });
+        });
 
     });
-
-    it('insert aem forms Accordion', { retries: 3 }, function () {
-      cy.cleanTest(accordionEditPath).then(function(){
-          dropAccordionInSites();
-          cy.deleteComponentByPath(accordionEditPath);
-      });
-    });
-
-    // todo: intermittent failure
-    it('open edit dialog of aem forms Accordion', { retries: 3 }, function() {
-      cy.cleanTest(accordionEditPath).then(function() {
-          testAccordionBehaviour(accordionEditPathSelector, accordionEditPath, true);
-      });
-    });
-
-  });
 })

--- a/ui.tests/test-module/specs/title/title.authoring.spec.js
+++ b/ui.tests/test-module/specs/title/title.authoring.spec.js
@@ -19,23 +19,23 @@ const sitesSelectors = require("../../libs/commons/sitesSelectors");
 
 
 describe('Page - Authoring', function () {
-    const dropTitleInContainer = function() {
+    const dropTitleInContainer = function () {
         const dataPath = "/content/forms/af/core-components-it/blank/jcr:content/guideContainer/*",
             responsiveGridDropZoneSelector = sitesSelectors.overlays.overlay.component + "[data-path='" + dataPath + "']";
         cy.selectLayer("Edit");
         cy.insertComponent(responsiveGridDropZoneSelector, "Adaptive Form Title", afConstants.components.forms.resourceType.title);
-        cy.get('body').click( 0,0);
+        cy.get('body').click(0, 0);
     }
 
-    const dropTitleInSites = function() {
+    const dropTitleInSites = function () {
         const dataPath = "/content/core-components-examples/library/adaptive-form/title/jcr:content/root/responsivegrid/demo/component/guideContainer/*",
             responsiveGridDropZoneSelector = sitesSelectors.overlays.overlay.component + "[data-path='" + dataPath + "']";
         cy.selectLayer("Edit");
         cy.insertComponent(responsiveGridDropZoneSelector, "Adaptive Form Title", afConstants.components.forms.resourceType.title);
-        cy.get('body').click( 0,0);
+        cy.get('body').click(0, 0);
     }
 
-    const testTitleEditDialog = function(titleEditPathSelector, titleDrop, isSites) {
+    const testTitleEditDialog = function (titleEditPathSelector, titleDrop, isSites) {
         if (isSites) {
             dropTitleInSites();
             cy.openEditableToolbar(sitesSelectors.overlays.overlay.component + titleEditPathSelector);
@@ -48,10 +48,10 @@ describe('Page - Authoring', function () {
             cy.invokeEditableAction("[data-action='CONFIGURE']");
             cy.get('.cq-dialog-cancel').click();
             cy.get('[data-path^="/content/forms/af/core-components-it/blank/jcr:content/guideContainer/title_"]')
-            .invoke('attr', 'data-path')
-            .then(dataPath => {
-                cy.deleteComponentByPath(dataPath);
-            })
+                .invoke('attr', 'data-path')
+                .then(dataPath => {
+                    cy.deleteComponentByPath(dataPath);
+                })
         }
 
     }
@@ -69,25 +69,27 @@ describe('Page - Authoring', function () {
         });
 
         it('insert Title in form container', function () {
-            dropTitleInContainer();
-            cy.get('[data-path^="/content/forms/af/core-components-it/blank/jcr:content/guideContainer/title_"]')
-            .invoke('attr', 'data-path')
-            .then(dataPath => {
-                const id = dataPath.replace('/content/forms/af/core-components-it/blank/jcr:content/guideContainer/title_', '');
-                const _titleDrop = titleDrop + id;
-                cy.deleteComponentByPath(dataPath);
+            cy.cleanTitleTest(titleEditPath).then(() => {
+                dropTitleInContainer();
+                cy.get('[data-path^="/content/forms/af/core-components-it/blank/jcr:content/guideContainer/title_"]')
+                    .invoke('attr', 'data-path')
+                    .then(dataPath => {
+                        const id = dataPath.replace('/content/forms/af/core-components-it/blank/jcr:content/guideContainer/title_', '');
+                        const _titleDrop = titleDrop + id;
+                        cy.deleteComponentByPath(dataPath);
+                    })
+            });
+        });
+
+        it('check edit dialog availability of Title', function () {
+            cy.cleanTitleTest(titleEditPath + "_").then(() => {
+                testTitleEditDialog(titleEditPathSelector, titleDrop, false);
             })
         });
-
-        it ('check edit dialog availability of Title', function(){
-            testTitleEditDialog(titleEditPathSelector,titleDrop, false
-            );
-        });
-
     });
 
     context('Open Sites Editor', function () {
-        const   pagePath = "/content/core-components-examples/library/adaptive-form/title",
+        const pagePath = "/content/core-components-examples/library/adaptive-form/title",
             titleEditPath = pagePath + afConstants.RESPONSIVE_GRID_DEMO_SUFFIX + "/guideContainer/title",
             titleEditPathSelector = "[data-path='" + titleEditPath + "']",
             editDialogConfigurationSelector = "[data-action='CONFIGURE']",
@@ -103,8 +105,8 @@ describe('Page - Authoring', function () {
             cy.deleteComponentByPath(titleDrop);
         });
 
-        it ('check edit dialog availability of Title', function(){
-           testTitleEditDialog(titleEditPathSelector,titleDrop, true);
+        it('check edit dialog availability of Title', function () {
+            testTitleEditDialog(titleEditPathSelector, titleDrop, true);
         });
 
     });


### PR DESCRIPTION
Solves flaky tests in cases where residual title component is left behind in the test form from some previously failed test.