### PR TITLE
FORMS-3342 : Title issue in form authoring with Button, Reset and Submit button.

### DIFF
--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/button/v1/button/_cq_editConfig.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/button/v1/button/_cq_editConfig.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="cq:EditConfig"
+          cq:actions="[edit,-,copymove,delete,-,insert,-]"
+          cq:dialogMode="floating"
+          cq:layout="editbar"
+          cq:disableTargeting="{Boolean}true">
+    <cq:actionConfigs jcr:primaryType="nt:unstructured">
+        <editexpression
+                jcr:primaryType="nt:unstructured"
+                handler="CQ.FormsCoreComponents.editorhooks.openRuleEditor"
+                order="after CONFIGURE"
+                icon="bidRule"
+                text="Edit Rules"/>
+        <replace
+                jcr:primaryType="nt:unstructured"
+                condition="CQ.FormsCoreComponents.editorhooks.isReplaceable"
+                handler="CQ.FormsCoreComponents.editorhooks.replace"
+                icon="shuffle"
+                text="Replace"/>
+    </cq:actionConfigs>
+    <cq:inplaceEditing
+            jcr:primaryType="cq:InplaceEditingConfig"
+            active="{Boolean}true"
+            configPath="inplaceEditingConfig"
+            editorType="plaintext">
+        <inplaceEditingConfig
+                jcr:primaryType="nt:unstructured"
+                editElementQuery="span:first"
+                textPropertyName="jcr:title"/>
+    </cq:inplaceEditing>
+</jcr:root>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The file _cq_editConfig.xml is added to override the inplaceEditingConfig property named editElementQuery.
Currently, the issue is due to the editElementQuery property as it was label:first and no label was defined in button, therefore with this fix the issue is resolved and doesn't impact other components.

## Related Issue
[FORMS-3342](https://jira.corp.adobe.com/browse/FORMS-3342) : Title issue in form authoring with Button, Reset and Submit button.
<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
