### PR TITLE
Parent element have same classes for some components

### DIFF
--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/checkbox/v1/checkbox/_cq_htmlTag/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/checkbox/v1/checkbox/_cq_htmlTag/.content.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    jcr:primaryType="nt:unstructured"
-    class="cmp-adaptiveform-checkbox"
-    cq:tagName="div"/>

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/checkboxgroup/v1/checkboxgroup/_cq_htmlTag/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/checkboxgroup/v1/checkboxgroup/_cq_htmlTag/.content.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    jcr:primaryType="nt:unstructured"
-    class="cmp-adaptiveform-checkboxgroup"
-    cq:tagName="div"/>

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/datepicker/v1/datepicker/_cq_htmlTag/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/datepicker/v1/datepicker/_cq_htmlTag/.content.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    jcr:primaryType="nt:unstructured"
-    class="cmp cmp-adaptiveform-container"
-    cq:tagName="div"/>

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/dropdown/v1/dropdown/_cq_htmlTag/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/dropdown/v1/dropdown/_cq_htmlTag/.content.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    jcr:primaryType="nt:unstructured"
-    class="cmp cmp-adaptiveform-dropdown"
-    cq:tagName="div"/>

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/emailinput/v1/emailinput/_cq_htmlTag/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/emailinput/v1/emailinput/_cq_htmlTag/.content.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    jcr:primaryType="nt:unstructured"
-    cq:tagName="div"/>

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/fileinput/v1/fileinput/_cq_htmlTag/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/fileinput/v1/fileinput/_cq_htmlTag/.content.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    jcr:primaryType="nt:unstructured"
-    class="cmp-adaptiveform-fileinput"
-    cq:tagName="div"/>

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/footer/v1/footer/_cq_htmlTag/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/footer/v1/footer/_cq_htmlTag/.content.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    jcr:primaryType="nt:unstructured"
-    class="cmp cmp-adaptiveform-footer"
-    cq:tagName="div"/>

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/numberinput/v1/numberinput/_cq_htmlTag/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/numberinput/v1/numberinput/_cq_htmlTag/.content.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    jcr:primaryType="nt:unstructured"
-    class="cmp cmp-adaptiveform-numberinput"
-    cq:tagName="div"/>

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/radiobutton/v1/radiobutton/_cq_htmlTag/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/radiobutton/v1/radiobutton/_cq_htmlTag/.content.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    jcr:primaryType="nt:unstructured"
-    class="cmp cmp-adaptiveform-radiobutton"
-    cq:tagName="div"/>

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/recaptcha/v1/recaptcha/_cq_htmlTag/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/recaptcha/v1/recaptcha/_cq_htmlTag/.content.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    jcr:primaryType="nt:unstructured"
-    class="cmp-adaptiveform-recaptcha"
-    cq:tagName="div"/>

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/telephoneinput/v1/telephoneinput/_cq_htmlTag/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/telephoneinput/v1/telephoneinput/_cq_htmlTag/.content.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    jcr:primaryType="nt:unstructured"
-    cq:tagName="div"/>

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/textinput/v1/textinput/_cq_htmlTag/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/textinput/v1/textinput/_cq_htmlTag/.content.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    jcr:primaryType="nt:unstructured"
-    class="cmp-adaptiveform-textinput"
-    cq:tagName="div"/>

--- a/ui.tests/test-module/specs/checkbox/checkbox.runtime.spec.js
+++ b/ui.tests/test-module/specs/checkbox/checkbox.runtime.spec.js
@@ -171,4 +171,13 @@ describe("Form Runtime with CheckBox Input", () => {
             })
         })
     })
+
+    it("decoration element should not have same class name", () => {
+        expect(formContainer, "formcontainer is initialized").to.not.be.null;
+        cy.wrap().then(() => {
+            const id = formContainer._model._children[0].id;
+            cy.get(`#${id}`).parent().should("not.have.class", "cmp-adaptiveform-checkbox");
+        })
+
+    })
 })

--- a/ui.tests/test-module/specs/checkboxgroup/checkboxgroup.authoring.spec.js
+++ b/ui.tests/test-module/specs/checkboxgroup/checkboxgroup.authoring.spec.js
@@ -156,9 +156,9 @@ describe('Page - Authoring', function () {
             cy.get('.cq-dialog-submit').should('not.exist')
         });
         getPreviewIframeBody().find('.cmp-adaptiveform-checkboxgroup-item').should('have.length',2);
-        getPreviewIframeBody().find('.cmp-adaptiveform-checkboxgroup').parent().contains('Item 3');
-        getPreviewIframeBody().find('.cmp-adaptiveform-checkboxgroup').parent().contains('Item 2');
-        getPreviewIframeBody().find('.cmp-adaptiveform-checkboxgroup').parent().contains('Item 1').should('not.exist');
+        getPreviewIframeBody().find('.cmp-adaptiveform-checkboxgroup').parent().parent().contains('Item 3');
+        getPreviewIframeBody().find('.cmp-adaptiveform-checkboxgroup').parent().parent().contains('Item 2');
+        getPreviewIframeBody().find('.cmp-adaptiveform-checkboxgroup').parent().parent().contains('Item 1').should('not.exist');
         cy.deleteComponentByPath(checkBoxGroupDrop);
     });
 

--- a/ui.tests/test-module/specs/checkboxgroup/checkboxgroup.runtime.spec.js
+++ b/ui.tests/test-module/specs/checkboxgroup/checkboxgroup.runtime.spec.js
@@ -189,4 +189,13 @@ describe("Form Runtime with CheckBoxGroup Input", () => {
         cy.get(`#${checkBox6}`).find(".cmp-adaptiveform-checkboxgroup__label").contains('Item 1').should('not.exist');
 
     })
+
+    it("decoration element should not have same class name", () => {
+        expect(formContainer, "formcontainer is initialized").to.not.be.null;
+        cy.wrap().then(() => {
+            const id = formContainer._model._children[0].id;
+            cy.get(`#${id}`).parent().should("not.have.class", bemBlock);
+        })
+
+    })
 })

--- a/ui.tests/test-module/specs/datepicker/datepicker.runtime.spec.js
+++ b/ui.tests/test-module/specs/datepicker/datepicker.runtime.spec.js
@@ -193,4 +193,12 @@ describe("Form Runtime with Date Picker", () => {
         });
     });
 
+    it("decoration element should not have same class name", () => {
+        expect(formContainer, "formcontainer is initialized").to.not.be.null;
+        cy.wrap().then(() => {
+            const id = formContainer._model._children[0].id;
+            cy.get(`#${id}`).parent().should("not.have.class", bemBlock);
+        })
+    })
+
 })

--- a/ui.tests/test-module/specs/dropdown/dropdown.runtime.spec.js
+++ b/ui.tests/test-module/specs/dropdown/dropdown.runtime.spec.js
@@ -199,4 +199,12 @@ describe("Form with Dropdown", () => {
         cy.get(`#${dropdown7}`).find(".cmp-adaptiveform-dropdown__option").contains('Item 1').should('not.exist');
 
     })
+
+    it("decoration element should not have same class name", () => {
+        expect(formContainer, "formcontainer is initialized").to.not.be.null;
+        cy.wrap().then(() => {
+            const id = formContainer._model._children[0].id;
+            cy.get(`#${id}`).parent().should("not.have.class", bemBlock);
+        })
+    })
 })

--- a/ui.tests/test-module/specs/emailinput/emailinput.runtime.spec.js
+++ b/ui.tests/test-module/specs/emailinput/emailinput.runtime.spec.js
@@ -127,4 +127,12 @@ describe("Form Runtime with Email Input", () => {
         cy.toggleDescriptionTooltip(bemBlock, 'tooltip_scenario_test');
     })
 
+    it("decoration element should not have same class name", () => {
+        expect(formContainer, "formcontainer is initialized").to.not.be.null;
+        cy.wrap().then(() => {
+            const id = formContainer._model._children[0].id;
+            cy.get(`#${id}`).parent().should("not.have.class", bemBlock);
+        })
+    })
+
 })

--- a/ui.tests/test-module/specs/fileinput/fileinput.runtime.spec.js
+++ b/ui.tests/test-module/specs/fileinput/fileinput.runtime.spec.js
@@ -127,6 +127,14 @@ describe("Form with File Input - Basic Tests", () => {
     it("should toggle description and tooltip", () => {
         cy.toggleDescriptionTooltip(bemBlock, 'fileinput_tooltip_scenario_test');
     })
+
+    it("decoration element should not have same class name", () => {
+        expect(formContainer, "formcontainer is initialized").to.not.be.null;
+        cy.wrap().then(() => {
+            const id = formContainer._model._children[0].id;
+            cy.get(`#${id}`).parent().should("not.have.class", bemBlock);
+        })
+    })
 })
 
 describe("Form with File Input - Prefill & Submit tests", () => {

--- a/ui.tests/test-module/specs/numberinput/numberinput.runtime.spec.js
+++ b/ui.tests/test-module/specs/numberinput/numberinput.runtime.spec.js
@@ -201,4 +201,12 @@ describe("Form with Number Input", () => {
             cy.get(`#${numberInput7}`).find('input').should('have.value', model.getState().displayValue);
         })
     })
+
+    it("decoration element should not have same class name", () => {
+        expect(formContainer, "formcontainer is initialized").to.not.be.null;
+        cy.wrap().then(() => {
+            const id = formContainer._model._children[0].id;
+            cy.get(`#${id}`).parent().should("not.have.class", bemBlock);
+        })
+    })
 })

--- a/ui.tests/test-module/specs/radiobutton/radiobutton.authoring.spec.js
+++ b/ui.tests/test-module/specs/radiobutton/radiobutton.authoring.spec.js
@@ -139,9 +139,9 @@ describe('Page - Authoring', function () {
             cy.get('.cq-dialog-submit').should('not.exist')
         });
         getPreviewIframeBody().find('.cmp-adaptiveform-radiobutton__option').should('have.length',2);
-        getPreviewIframeBody().find('.cmp-adaptiveform-radiobutton').parent().contains('Item 3');
-        getPreviewIframeBody().find('.cmp-adaptiveform-radiobutton').parent().contains('Item 2');
-        getPreviewIframeBody().find('.cmp-adaptiveform-radiobutton').parent().contains('Item 1').should('not.exist');
+        getPreviewIframeBody().find('.cmp-adaptiveform-radiobutton').parent().parent().contains('Item 3');
+        getPreviewIframeBody().find('.cmp-adaptiveform-radiobutton').parent().parent().contains('Item 2');
+        getPreviewIframeBody().find('.cmp-adaptiveform-radiobutton').parent().parent().contains('Item 1').should('not.exist');
         cy.deleteComponentByPath(radioButtonDrop);
 
     })

--- a/ui.tests/test-module/specs/radiobutton/radiobutton.runtime.spec.js
+++ b/ui.tests/test-module/specs/radiobutton/radiobutton.runtime.spec.js
@@ -172,5 +172,13 @@ describe("Form with Radio Button Input", () => {
 
     })
 
+    it("decoration element should not have same class name", () => {
+        expect(formContainer, "formcontainer is initialized").to.not.be.null;
+        cy.wrap().then(() => {
+            const id = formContainer._model._children[0].id;
+            cy.get(`#${id}`).parent().should("not.have.class", bemBlock);
+        })
+    })
+
 
 })

--- a/ui.tests/test-module/specs/recaptcha/recaptcha.runtime.spec.js
+++ b/ui.tests/test-module/specs/recaptcha/recaptcha.runtime.spec.js
@@ -108,4 +108,12 @@ describe("Form Runtime with Recaptcha Input", () => {
             cy.log('Tests were skipped because the feature toggle of captcha is disabled');
         });
     }
+
+    it("decoration element should not have same class name", () => {
+        expect(formContainer, "formcontainer is initialized").to.not.be.null;
+        cy.wrap().then(() => {
+            const id = formContainer._model._children[0].id;
+            cy.get(`#${id}`).parent().should("not.have.class", bemBlock);
+        })
+    })
 })

--- a/ui.tests/test-module/specs/telephoneinput/telephoneinput.runtime.spec.js
+++ b/ui.tests/test-module/specs/telephoneinput/telephoneinput.runtime.spec.js
@@ -122,4 +122,12 @@ describe("Form Runtime with Telephone Input", () => {
         cy.toggleDescriptionTooltip(bemBlock, 'tooltip_scenario_test');
     })
 
+    it("decoration element should not have same class name", () => {
+        expect(formContainer, "formcontainer is initialized").to.not.be.null;
+        cy.wrap().then(() => {
+            const id = formContainer._model._children[0].id;
+            cy.get(`#${id}`).parent().should("not.have.class", bemBlock);
+        })
+    })
+
 })

--- a/ui.tests/test-module/specs/textinput/textinput.runtime.spec.js
+++ b/ui.tests/test-module/specs/textinput/textinput.runtime.spec.js
@@ -253,6 +253,15 @@ describe("Form Runtime with Text Input", () => {
             })
         })
     })
+
+    it("decoration element should not have same class name", () => {
+        expect(formContainer, "formcontainer is initialized").to.not.be.null;
+        cy.wrap().then(() => {
+            const id = formContainer._model._children[0].id;
+            cy.get(`#${id}`).parent().should("not.have.class", "cmp-adaptiveform-textinput");
+        })
+
+    })
 })
 
 describe("Form Runtime with Text Input For Different locale", () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

All input components (excluding date, email and telephone fields) have the same classes for parent and child containers.

## Related Issue
FORMS-10478

<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
