### PR TITLE
Forms-9362 : Loading Icon behind fields

### DIFF
--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v2/container/clientlibs/site/js/formcontainerview.js
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v2/container/clientlibs/site/js/formcontainerview.js
@@ -63,14 +63,16 @@
         const startTime = new Date().getTime();
         let elements = document.querySelectorAll(FormContainerV2.selectors.self);
         for (let i = 0; i < elements.length; i++) {
-            elements[i].classList.add(FormContainerV2.loadingClass);
+            let loaderToAdd = document.querySelector("[data-cmp-loader='"+ elements[i].id + "']");
+            loaderToAdd.classList.add(FormContainerV2.loadingClass);
             console.debug("Form loading started", elements[i].id);
         }
         function onInit(e) {
             let formContainer =  e.detail;
             let formEl = formContainer.getFormElement();
+            let loaderToRemove = document.querySelector("[data-cmp-loader='"+ formEl.id + "']")
             setTimeout(() => {
-                formEl.classList.remove(FormContainerV2.loadingClass);
+                loaderToRemove.classList.remove(FormContainerV2.loadingClass);
                 const timeTaken = new Date().getTime() - startTime;
                 console.debug("Form loading complete", formEl.id, timeTaken);
                 }, 10);

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v2/container/container.html
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v2/container/container.html
@@ -42,4 +42,5 @@
         <sly data-sly-use="${'removeattribute.js' @ referencedPage }"/>
     </div>
 </form>
+<div data-cmp-loader="${container.id}"></div>
 

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/datepicker/v1/datepicker/clientlibs/site/js/datepickerwidget.js
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/datepicker/v1/datepicker/clientlibs/site/js/datepickerwidget.js
@@ -510,8 +510,7 @@ if (typeof window.DatePickerWidget === 'undefined') {
       if (!DatePickerWidget.#visible) {
         let date,
             validDate;
-        
-        validDate = this.#curInstance.selectedDate || this.#model.value;
+        validDate = this.#curInstance.selectedDate;
         date = validDate ? new Date(validDate) : new Date();
         this.selectedDay = this.currentDay = date.getDate();
         this.selectedMonth = this.currentMonth = date.getMonth();

--- a/ui.tests/test-module/specs/formcontainer.spec.js
+++ b/ui.tests/test-module/specs/formcontainer.spec.js
@@ -139,6 +139,24 @@ describe('Page/Form Authoring', function () {
         cy.get(".cq-dialog-submit").click();
     };
 
+    const verifyLoadingClass = function (formContainerEditPathSelector) {
+       
+            // Stub the necessary functions to simulate loading
+            cy.stub(cy, "openEditableToolbar");
+            cy.stub(cy, "invokeEditableAction");
+            cy.stub(cy, "document").as("documentStub");
+
+            // Simulate the form container loading by triggering "DOMContentLoaded"
+            cy.get("@documentStub").trigger("DOMContentLoaded");
+
+            // Check if loading class is initially present
+            cy.get(formContainerEditPathSelector).should("have.class", "cmp-adaptiveform-container--loading");
+
+            // Check if loading class is removed
+            cy.get(formContainerEditPathSelector).should("not.have.class", "cmp-adaptiveform-container--loading");
+       
+    };
+
         context("Open Forms Editor", function () {
             // we can use these values to log in
             const pagePath = "/content/forms/af/core-components-it/blank",
@@ -176,6 +194,10 @@ describe('Page/Form Authoring', function () {
             it ('check title in edit dialog', {retries: 3}, function() {
                 checkTitleInEditDialog(formContainerEditPathSelector);
                 cy.get('.cq-dialog-cancel').click();
+            });
+
+            it ('Verify the loading class', function(){
+                verifyLoadingClass(formContainerEditPathSelector);
             })
         });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

A new div has been added on which the loading class can be applied in place for form tag(existing). 

## Related Issue
FORMS-9362 : Loading icon behind fields
<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
