### PR TITLE
FORMS-9362: loading icon behind fields

### DIFF
--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v2/container/README.md
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v2/container/README.md
@@ -66,3 +66,5 @@ BLOCK cmp-adaptiveform-container
 ## JavaScript Data Attribute Bindings
 
 Apply a `data-cmp-is="adaptiveFormContainer"` attribute to the `cmp-adaptiveform-container` block to enable initialization of the JavaScript component.
+
+Applying `data-cmp-adaptiveform-container-loader` attribute to the div specifically for applying the loader class on it, it is to ensure that the loading icon should not appear over components.

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v2/container/clientlibs/site/js/formcontainerview.js
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v2/container/clientlibs/site/js/formcontainerview.js
@@ -64,7 +64,9 @@
         let elements = document.querySelectorAll(FormContainerV2.selectors.self);
         for (let i = 0; i < elements.length; i++) {
             let loaderToAdd = document.querySelector("[data-cmp-adaptiveform-container-loader='"+ elements[i].id + "']");
+            if(loaderToAdd){
             loaderToAdd.classList.add(FormContainerV2.loadingClass);
+            }
             console.debug("Form loading started", elements[i].id);
         }
         function onInit(e) {
@@ -72,7 +74,9 @@
             let formEl = formContainer.getFormElement();
             setTimeout(() => {
                 let loaderToRemove = document.querySelector("[data-cmp-adaptiveform-container-loader='"+ formEl.id + "']");
+                if(loaderToRemove){
                 loaderToRemove.classList.remove(FormContainerV2.loadingClass);
+                }
                 const timeTaken = new Date().getTime() - startTime;
                 console.debug("Form loading complete", formEl.id, timeTaken);
                 }, 10);

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v2/container/clientlibs/site/js/formcontainerview.js
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v2/container/clientlibs/site/js/formcontainerview.js
@@ -65,7 +65,7 @@
         for (let i = 0; i < elements.length; i++) {
             let loaderToAdd = document.querySelector("[data-cmp-adaptiveform-container-loader='"+ elements[i].id + "']");
             if(loaderToAdd){
-            loaderToAdd.classList.add(FormContainerV2.loadingClass);
+                loaderToAdd.classList.add(FormContainerV2.loadingClass);
             }
             console.debug("Form loading started", elements[i].id);
         }
@@ -75,7 +75,7 @@
             setTimeout(() => {
                 let loaderToRemove = document.querySelector("[data-cmp-adaptiveform-container-loader='"+ formEl.id + "']");
                 if(loaderToRemove){
-                loaderToRemove.classList.remove(FormContainerV2.loadingClass);
+                    loaderToRemove.classList.remove(FormContainerV2.loadingClass);
                 }
                 const timeTaken = new Date().getTime() - startTime;
                 console.debug("Form loading complete", formEl.id, timeTaken);

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v2/container/clientlibs/site/js/formcontainerview.js
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v2/container/clientlibs/site/js/formcontainerview.js
@@ -63,14 +63,16 @@
         const startTime = new Date().getTime();
         let elements = document.querySelectorAll(FormContainerV2.selectors.self);
         for (let i = 0; i < elements.length; i++) {
-            elements[i].classList.add(FormContainerV2.loadingClass);
+            let loaderToAdd = document.querySelector("[data-cmp-adaptiveform-container-loader='"+ elements[i].id + "']");
+            loaderToAdd.classList.add(FormContainerV2.loadingClass);
             console.debug("Form loading started", elements[i].id);
         }
         function onInit(e) {
             let formContainer =  e.detail;
             let formEl = formContainer.getFormElement();
             setTimeout(() => {
-                formEl.classList.remove(FormContainerV2.loadingClass);
+                let loaderToRemove = document.querySelector("[data-cmp-adaptiveform-container-loader='"+ formEl.id + "']");
+                loaderToRemove.classList.remove(FormContainerV2.loadingClass);
                 const timeTaken = new Date().getTime() - startTime;
                 console.debug("Form loading complete", formEl.id, timeTaken);
                 }, 10);

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v2/container/container.html
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v2/container/container.html
@@ -42,4 +42,4 @@
         <sly data-sly-use="${'removeattribute.js' @ referencedPage }"/>
     </div>
 </form>
-
+<div data-cmp-adaptiveform-container-loader="${container.id}"></div>

--- a/ui.tests/test-module/libs/support/commands.js
+++ b/ui.tests/test-module/libs/support/commands.js
@@ -339,7 +339,11 @@ const waitForFormInit = () => {
             const promise = new Cypress.Promise((resolve, reject) => {
                 const listener1 = e => {
                     const isReady = () => {
-                        if (!($form[0].classList.contains("cmp-adaptiveform-container--loading"))) {
+                        const container = document.querySelector("[data-cmp-adaptiveform-container-loader='"+ $form[0].id + "']");
+                        if (container &&
+                            e.detail._path === $form.data("cmp-path") &&
+                            !container.classList.contains("cmp-adaptiveform-container--loading")) {
+
                             resolve(e.detail);
                         }
                         setTimeout(isReady, 0)
@@ -361,8 +365,11 @@ const waitForFormInitMultipleContiners = () => {
             const promise = new Cypress.Promise((resolve, reject) => {
                 const listener1 = e => {
                     const isReady = () => {
-                        if (e.detail._path === $form.data("cmp-path") &&
-                            !($form[0].classList.contains("cmp-adaptiveform-container--loading"))) {
+                        const container = document.querySelector("[data-cmp-adaptiveform-container-loader='"+ $form[0].id + "']");
+                        if (container &&
+                            e.detail._path === $form.data("cmp-path") &&
+                            !container.classList.contains("cmp-adaptiveform-container--loading")) {
+
                             resolve(e.detail);
                         }
                         setTimeout(isReady, 0)

--- a/ui.tests/test-module/libs/support/commands.js
+++ b/ui.tests/test-module/libs/support/commands.js
@@ -338,6 +338,7 @@ const waitForFormInit = () => {
         cy.get('form').then(($form) => {
             const promise = new Cypress.Promise((resolve, reject) => {
                 const listener1 = e => {
+                    if(document.querySelector("[data-cmp-adaptiveform-container-loader='"+ $form[0].id + "']").classList.contains("cmp-adaptiveform-container--loading")){
                     const isReady = () => {
                         const container = document.querySelector("[data-cmp-adaptiveform-container-loader='"+ $form[0].id + "']");
                         if (container &&
@@ -349,6 +350,7 @@ const waitForFormInit = () => {
                         setTimeout(isReady, 0)
                     }
                     isReady();
+                }
                 }
                 document.addEventListener(INIT_EVENT, listener1);
             })
@@ -364,6 +366,7 @@ const waitForFormInitMultipleContiners = () => {
         cy.get('form').each(($form) => {
             const promise = new Cypress.Promise((resolve, reject) => {
                 const listener1 = e => {
+                    if(document.querySelector("[data-cmp-adaptiveform-container-loader='"+ $form[0].id + "']").classList.contains("cmp-adaptiveform-container--loading")){
                     const isReady = () => {
                         const container = document.querySelector("[data-cmp-adaptiveform-container-loader='"+ $form[0].id + "']");
                         if (container &&
@@ -375,6 +378,7 @@ const waitForFormInitMultipleContiners = () => {
                         setTimeout(isReady, 0)
                     }
                     isReady();
+                }
                 }
                 document.addEventListener(INIT_EVENT, listener1);
             })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As discussed with Rishi, the sibling div should have the selector as the ID of form and selecting the div with the same and adding the loading class on it later removing as well with the same steps.
However the test cases were already written in command.js file therefore, I have made the corrections in the same for the updated logic.
the new updates has been added to the readme file as well.

## Related Issue
FORMS-9362: Loading Icon Behind Fields
<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
