### PR TITLE
Forms-3342 editElementQuery changes as span

### DIFF
--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/button/v1/button/_cq_editConfig.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/button/v1/button/_cq_editConfig.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="cq:EditConfig"
+          cq:actions="[edit,-,copymove,delete,-,insert,-]"
+          cq:dialogMode="floating"
+          cq:layout="editbar"
+          cq:disableTargeting="{Boolean}true">
+    <cq:actionConfigs jcr:primaryType="nt:unstructured">
+        <editexpression
+                jcr:primaryType="nt:unstructured"
+                handler="CQ.FormsCoreComponents.editorhooks.openRuleEditor"
+                order="after CONFIGURE"
+                icon="bidRule"
+                text="Edit Rules"/>
+        <replace
+                jcr:primaryType="nt:unstructured"
+                condition="CQ.FormsCoreComponents.editorhooks.isReplaceable"
+                handler="CQ.FormsCoreComponents.editorhooks.replace"
+                icon="shuffle"
+                text="Replace"/>
+    </cq:actionConfigs>
+    <cq:inplaceEditing
+            jcr:primaryType="cq:InplaceEditingConfig"
+            active="{Boolean}true"
+            configPath="inplaceEditingConfig"
+            editorType="plaintext">
+        <inplaceEditingConfig
+                jcr:primaryType="nt:unstructured"
+                editElementQuery="span:first"
+                textPropertyName="jcr:title"/>
+    </cq:inplaceEditing>
+</jcr:root>

--- a/ui.tests/test-module/specs/button/button.authoring.spec.js
+++ b/ui.tests/test-module/specs/button/button.authoring.spec.js
@@ -84,12 +84,9 @@ describe('Button - Authoring', function () {
         getContentIframeBody().find('.cmp-adaptiveform-button__text').then(($span) => {
             $span[0].textContent = '';
           });
-          cy.get('body').click( 0,0);
-          cy.get('span.sidepanel-tree-item-label label.name').as('labelElement');
-          cy.get('@labelElement').should('not.have.text', '');
-    
-
-
+          cy.get('body').click(0,0);
+          cy.get('[role="button"]').click();
+          cy.get("[data-path='/content/forms/af/core-components-it/blank/jcr:content/guideContainer/button']").should('exist').should('not.have.text', '');
     }
 
 
@@ -114,7 +111,7 @@ describe('Button - Authoring', function () {
             });
         });
 
-        it.only ('open Inline edit dialog of Button',{ retries: 3 }, function(){
+        it ('open Inline edit dialog of Button',{ retries: 3 }, function(){
             cy.cleanTest(buttonDrop).then(function(){
                 testButtonBehaviourInilineEdit(buttonEditPathSelector, buttonDrop);
                 cy.deleteComponentByPath(buttonDrop);

--- a/ui.tests/test-module/specs/button/button.authoring.spec.js
+++ b/ui.tests/test-module/specs/button/button.authoring.spec.js
@@ -85,7 +85,6 @@ describe('Button - Authoring', function () {
             $span[0].textContent = '';
           });
           cy.get('body').click(0,0);
-          cy.get('[role="button"]').click();
           cy.get("[data-path='/content/forms/af/core-components-it/blank/jcr:content/guideContainer/button']").should('exist').should('not.have.text', '');
     }
 

--- a/ui.tests/test-module/specs/button/button.authoring.spec.js
+++ b/ui.tests/test-module/specs/button/button.authoring.spec.js
@@ -103,16 +103,16 @@ describe('Button - Authoring', function () {
             cy.openAuthoring(pagePath);
         });
 
-        // it('insert Button in form container', function () {
-        //     dropButtonInContainer();
-        //     cy.deleteComponentByPath(buttonDrop);
-        // });
+        it('insert Button in form container', function () {
+            dropButtonInContainer();
+            cy.deleteComponentByPath(buttonDrop);
+        });
 
-        // it ('open edit dialog of Button',{ retries: 3 }, function(){
-        //     cy.cleanTest(buttonDrop).then(function(){
-        //         testButtonBehaviour(buttonEditPathSelector, buttonDrop);
-        //     });
-        // });
+        it ('open edit dialog of Button',{ retries: 3 }, function(){
+            cy.cleanTest(buttonDrop).then(function(){
+                testButtonBehaviour(buttonEditPathSelector, buttonDrop);
+            });
+        });
 
         it.only ('open Inline edit dialog of Button',{ retries: 3 }, function(){
             cy.cleanTest(buttonDrop).then(function(){
@@ -133,14 +133,14 @@ describe('Button - Authoring', function () {
             cy.openAuthoring(pagePath);
         });
 
-        // it('insert aem forms Button', function () {
-        //     dropButtonInSites();
-        //     cy.deleteComponentByPath(buttonDrop);
-        // });
+        it('insert aem forms Button', function () {
+            dropButtonInSites();
+            cy.deleteComponentByPath(buttonDrop);
+        });
 
-        // it('open edit dialog of aem forms Button', function() {
-        //     testButtonBehaviour(buttonEditPathSelector, buttonDrop, true);
-        // });
+        it('open edit dialog of aem forms Button', function() {
+            testButtonBehaviour(buttonEditPathSelector, buttonDrop, true);
+        });
 
     });
 });

--- a/ui.tests/test-module/specs/button/button.authoring.spec.js
+++ b/ui.tests/test-module/specs/button/button.authoring.spec.js
@@ -117,7 +117,7 @@ describe('Button - Authoring', function () {
         it.only ('open Inline edit dialog of Button',{ retries: 3 }, function(){
             cy.cleanTest(buttonDrop).then(function(){
                 testButtonBehaviourInilineEdit(buttonEditPathSelector, buttonDrop);
-                
+                cy.deleteComponentByPath(buttonDrop);
             });
         })
     })

--- a/ui.tests/test-module/specs/button/button.authoring.spec.js
+++ b/ui.tests/test-module/specs/button/button.authoring.spec.js
@@ -40,6 +40,15 @@ describe('Button - Authoring', function () {
         cy.get('body').click( 0,0);
     }
 
+    const getContentIframeBody = () => {
+        // get the iframe > document > body
+        // and retry until the body element is not empty
+        return cy
+            .get('iframe#ContentFrame')
+            .its('0.contentDocument.body').should('not.be.empty')
+            .then(cy.wrap)
+      }
+    
     const testButtonBehaviour = function(buttonEditPathSelector, buttonDrop, isSites) {
         if (isSites) {
             dropButtonInSites();
@@ -64,6 +73,26 @@ describe('Button - Authoring', function () {
         cy.deleteComponentByPath(buttonDrop);
     }
 
+    const testButtonBehaviourInilineEdit = function(buttonEditPathSelector, buttonDrop, isSites) {
+        if (isSites) {
+            dropButtonInSites();
+        } else {
+            dropButtonInContainer();
+        }
+        cy.openEditableToolbar(sitesSelectors.overlays.overlay.component + buttonEditPathSelector);
+        cy.invokeEditableAction("[data-action='EDIT']");
+        getContentIframeBody().find('.cmp-adaptiveform-button__text').then(($span) => {
+            $span[0].textContent = '';
+          });
+          cy.get('body').click( 0,0);
+          cy.get('span.sidepanel-tree-item-label label.name').as('labelElement');
+          cy.get('@labelElement').should('not.have.text', '');
+    
+
+
+    }
+
+
     context('Open Forms Editor', function() {
         const pagePath = "/content/forms/af/core-components-it/blank",
             buttonEditPath = pagePath + afConstants.FORM_EDITOR_FORM_CONTAINER_SUFFIX + "/button",
@@ -74,14 +103,21 @@ describe('Button - Authoring', function () {
             cy.openAuthoring(pagePath);
         });
 
-        it('insert Button in form container', function () {
-            dropButtonInContainer();
-            cy.deleteComponentByPath(buttonDrop);
-        });
+        // it('insert Button in form container', function () {
+        //     dropButtonInContainer();
+        //     cy.deleteComponentByPath(buttonDrop);
+        // });
 
-        it ('open edit dialog of Button',{ retries: 3 }, function(){
+        // it ('open edit dialog of Button',{ retries: 3 }, function(){
+        //     cy.cleanTest(buttonDrop).then(function(){
+        //         testButtonBehaviour(buttonEditPathSelector, buttonDrop);
+        //     });
+        // });
+
+        it.only ('open Inline edit dialog of Button',{ retries: 3 }, function(){
             cy.cleanTest(buttonDrop).then(function(){
-                testButtonBehaviour(buttonEditPathSelector, buttonDrop);
+                testButtonBehaviourInilineEdit(buttonEditPathSelector, buttonDrop);
+                
             });
         })
     })
@@ -97,14 +133,14 @@ describe('Button - Authoring', function () {
             cy.openAuthoring(pagePath);
         });
 
-        it('insert aem forms Button', function () {
-            dropButtonInSites();
-            cy.deleteComponentByPath(buttonDrop);
-        });
+        // it('insert aem forms Button', function () {
+        //     dropButtonInSites();
+        //     cy.deleteComponentByPath(buttonDrop);
+        // });
 
-        it('open edit dialog of aem forms Button', function() {
-            testButtonBehaviour(buttonEditPathSelector, buttonDrop, true);
-        });
+        // it('open edit dialog of aem forms Button', function() {
+        //     testButtonBehaviour(buttonEditPathSelector, buttonDrop, true);
+        // });
 
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

the editElementQuery was label initially but in button it should be span as we have used span for the title in place of label 
added the necessary test cases for the particular change.

## Related Issue

FORMS-3342 Title issue is while inline editing the title for Button, Reset and Submit button.
<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
