### PR TITLE
CQ-4348557 adding another div to stop footer getting resized

### DIFF
--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/footer/v1/footer/footer.html
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/footer/v1/footer/footer.html
@@ -16,7 +16,7 @@
 
 <div class="cmp-adaptiveform-footer">
     <sly data-sly-list.child="${resource.listChildren}">
-        <div class="cmp-adaptiveform-footer__text" data-sly-resource="${child.path}" ></div>
+        <div class="cmp-adaptiveform-footer__text"><div data-sly-resource="${child.path}"></div></div>
 
     </sly>
 </div>

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/footer/v1/footer/footer.html
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/footer/v1/footer/footer.html
@@ -17,6 +17,5 @@
 <div class="cmp-adaptiveform-footer">
     <sly data-sly-list.child="${resource.listChildren}">
         <div class="cmp-adaptiveform-footer__text"><div data-sly-resource="${child.path}"></div></div>
-
     </sly>
 </div>


### PR DESCRIPTION
Footer resizes on editing content. It was happening because RTE inline editor changes the parent div class "cq-Editable-dom" to "section text cq-Editable-dom" and remove all other classes. We are adding another div element to keep the css and wrapping child components in separate div.