### PR TITLE
[Sample] Enable validation message only on submit (behind FT - FT_FORMS-11541) [#donotmerge]

### DIFF
--- a/it/apps/src/main/content/jcr_root/apps/forms-core-components-it/clientlibs/clientlib-it-ruleeditor/js/functions.js
+++ b/it/apps/src/main/content/jcr_root/apps/forms-core-components-it/clientlibs/clientlib-it-ruleeditor/js/functions.js
@@ -28,6 +28,16 @@ function testSetProperty(input1, normalField, globals)
     globals.functions.setProperty(normalField, {label : {value : 'Changed Label'}});
 }
 
+/**
+ * enableValidationMessageOnlyOnSubmit
+ * @name enableValidationMessageOnlyOnSubmit
+ * @param {scope} globals
+ */
+function enableValidationMessageOnlyOnSubmit(globals) {
+    globals.functions.setProperty(globals.form, {'properties' : {'enableValidationMessage' : true}})
+}
+
+
 
 
 

--- a/it/content/src/main/content/jcr_root/content/dam/formsanddocuments/core-components-it/samples/ruleeditor/af2-custom-function/validationmessage/.content.xml
+++ b/it/content/src/main/content/jcr_root/content/dam/formsanddocuments/core-components-it/samples/ruleeditor/af2-custom-function/validationmessage/.content.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:dam="http://www.day.com/dam/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:fd="http://www.adobe.com/aemfd/fd/1.0"
+    jcr:primaryType="dam:Asset">
+    <jcr:content
+        jcr:lastModified="{Date}2024-03-01T09:52:48.024Z"
+        jcr:primaryType="dam:AssetContent"
+        sling:resourceType="fd/fm/af/render"
+        guide="1"
+        type="guide">
+        <metadata
+            fd:version="2.1"
+            jcr:primaryType="nt:unstructured"
+            allowedRenderFormat="HTML"
+            author="admin"
+            availableInMobileApp="{Boolean}false"
+            dorType="none"
+            formmodel="none"
+            hasCustomThumbnail="{Boolean}false"
+            title="Validation Message (on submit) (IT)"/>
+    </jcr:content>
+</jcr:root>

--- a/it/content/src/main/content/jcr_root/content/forms/af/core-components-it/samples/ruleeditor/af2-custom-function/validationmessage/.content.xml
+++ b/it/content/src/main/content/jcr_root/content/forms/af/core-components-it/samples/ruleeditor/af2-custom-function/validationmessage/.content.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:fd="http://www.adobe.com/aemfd/fd/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        cq:deviceGroups="[mobile/groups/responsive]"
+        cq:lastModified="{Date}2024-03-01T09:52:48.013Z"
+        cq:lastModifiedBy="admin"
+        cq:template="/conf/core-components-examples/settings/wcm/templates/af-blank-v2"
+        jcr:language="en"
+        jcr:primaryType="cq:PageContent"
+        jcr:title="Adaptive Form V2 (IT)"
+        sling:resourceType="forms-components-examples/components/page">
+        <guideContainer
+            fd:version="2.1"
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="forms-components-examples/components/form/container"
+            clientLibRef="corecomponent.it.customfunction2"
+            fieldType="form"
+            thankYouMessage="Thank you for submitting the form."
+            thankYouOption="message">
+            <textinput
+                jcr:lastModified="{Date}2023-05-26T15:34:29.160+05:30"
+                jcr:lastModifiedBy="admin"
+                jcr:primaryType="nt:unstructured"
+                jcr:title="Text Input 1"
+                sling:resourceType="forms-components-examples/components/form/textinput"
+                autocomplete="off"
+                enabled="{Boolean}true"
+                fieldType="text-input"
+                hideTitle="false"
+                name="textinput1"
+                readOnly="{Boolean}false"
+                textIsRich="[true,true]"
+                unboundFormElement="{Boolean}false"
+                visible="{Boolean}true">
+            </textinput>
+            <text
+                jcr:primaryType="nt:unstructured"
+                jcr:title="Text 1"
+                sling:resourceType="forms-components-examples/components/form/text"
+                fieldType="text"
+                name="text1"
+                value="Custom Text"/>
+            <button
+                jcr:created="{Date}2024-03-01T09:25:14.489Z"
+                jcr:createdBy="admin"
+                jcr:lastModified="{Date}2024-03-01T09:25:19.075Z"
+                jcr:lastModifiedBy="admin"
+                jcr:primaryType="nt:unstructured"
+                jcr:title="Button"
+                sling:resourceType="forms-components-examples/components/form/button"
+                dorExclusion="true"
+                enabled="{Boolean}true"
+                fieldType="button"
+                hideTitle="false"
+                name="button1709285114563"
+                textIsRich="[true,true]"
+                unboundFormElement="{Boolean}false"
+                visible="{Boolean}true">
+                <fd:rules
+                    fd:click="[{&quot;nodeName&quot;:&quot;ROOT&quot;\,&quot;items&quot;:[{&quot;nodeName&quot;:&quot;STATEMENT&quot;\,&quot;choice&quot;:{&quot;nodeName&quot;:&quot;EVENT_SCRIPTS&quot;\,&quot;items&quot;:[{&quot;nodeName&quot;:&quot;EVENT_CONDITION&quot;\,&quot;choice&quot;:{&quot;nodeName&quot;:&quot;EVENT_AND_COMPARISON&quot;\,&quot;items&quot;:[{&quot;nodeName&quot;:&quot;COMPONENT&quot;\,&quot;value&quot;:{&quot;id&quot;:&quot;$form.button1709285114563&quot;\,&quot;type&quot;:&quot;BUTTON&quot;\,&quot;name&quot;:&quot;button1709285114563&quot;}}\,{&quot;nodeName&quot;:&quot;EVENT_AND_COMPARISON_OPERATOR&quot;\,&quot;choice&quot;:{&quot;nodeName&quot;:&quot;is clicked&quot;\,&quot;value&quot;:null}}\,{&quot;nodeName&quot;:&quot;PRIMITIVE_EXPRESSION&quot;\,&quot;choice&quot;:null}]}\,&quot;nested&quot;:false}\,{&quot;nodeName&quot;:&quot;Then&quot;\,&quot;value&quot;:null}\,{&quot;nodeName&quot;:&quot;BLOCK_STATEMENTS&quot;\,&quot;items&quot;:[{&quot;nodeName&quot;:&quot;BLOCK_STATEMENT&quot;\,&quot;choice&quot;:{&quot;nodeName&quot;:&quot;FUNCTION_CALL&quot;\,&quot;parentNodeName&quot;:&quot;BLOCK_STATEMENT&quot;\,&quot;functionName&quot;:{&quot;id&quot;:&quot;testSubmitFormPreprocessor&quot;\,&quot;displayName&quot;:&quot;testSubmitFormPreprocessor&quot;\,&quot;type&quot;:&quot;STRING|NUMBER|BOOLEAN|DATE|ARRAY|OBJECT&quot;\,&quot;isDuplicate&quot;:false\,&quot;displayPath&quot;:&quot;&quot;\,&quot;args&quot;:[]\,&quot;impl&quot;:&quot;$0()&quot;}\,&quot;params&quot;:[]}}]}]}}]\,&quot;isValid&quot;:true\,&quot;enabled&quot;:true\,&quot;version&quot;:1\,&quot;script&quot;:[&quot;testSubmitFormPreprocessor()&quot;]\,&quot;eventName&quot;:&quot;Click&quot;\,&quot;ruleType&quot;:&quot;&quot;\,&quot;description&quot;:&quot;&quot;}]"
+                    jcr:primaryType="nt:unstructured"
+                    validationStatus="valid"/>
+                <fd:events
+                    jcr:primaryType="nt:unstructured"
+                    click="[testSubmitFormPreprocessor()]"/>
+            </button>
+        </guideContainer>
+    </jcr:content>
+</jcr:root>

--- a/ui.frontend/package-lock.json
+++ b/ui.frontend/package-lock.json
@@ -11365,7 +11365,8 @@
     },
     "@babel/plugin-proposal-private-property-in-object": {
       "version": "7.21.0-placeholder-for-preset-env.2",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
@@ -13303,7 +13304,8 @@
     },
     "@webpack-cli/configtest": {
       "version": "1.2.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@webpack-cli/info": {
       "version": "1.5.0",
@@ -13314,7 +13316,8 @@
     },
     "@webpack-cli/serve": {
       "version": "1.7.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -13348,7 +13351,8 @@
     },
     "acorn-import-assertions": {
       "version": "1.9.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -13384,7 +13388,8 @@
     },
     "ajv-keywords": {
       "version": "3.5.2",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -15750,7 +15755,8 @@
     },
     "jest-pnp-resolver": {
       "version": "1.2.3",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "26.0.0",
@@ -18232,7 +18238,8 @@
     },
     "ws": {
       "version": "8.16.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml-name-validator": {
       "version": "4.0.0",

--- a/ui.frontend/src/view/FormFieldBase.js
+++ b/ui.frontend/src/view/FormFieldBase.js
@@ -460,7 +460,7 @@ class FormFieldBase extends FormField {
      * @param {Object} state - The state object.
      */
     updateValidationMessage(validationMessage, state) {
-        if (this.errorDiv) {
+        if (this.errorDiv && this.formContainer.getModel()?.properties?.enableValidationMessage === true) {
             // Check if the validationMessage is different from the current content
             if (this.errorDiv.innerHTML !== state.validationMessage) {
                 this.errorDiv.innerHTML = state.validationMessage;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
