### PR TITLE
FORMS-13810: Add the field to allow custom message for format in date…

### DIFF
--- a/it/content/src/main/content/jcr_root/content/dam/formsanddocuments/core-components-it/samples/datepicker/basic/.content.xml
+++ b/it/content/src/main/content/jcr_root/content/dam/formsanddocuments/core-components-it/samples/datepicker/basic/.content.xml
@@ -2,21 +2,22 @@
 <jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:dam="http://www.day.com/dam/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:fd="http://www.adobe.com/aemfd/fd/1.0"
           jcr:primaryType="dam:Asset">
     <jcr:content
-            jcr:lastModified="{Date}2023-01-20T15:28:03.292+05:30"
+            jcr:lastModified="{Date}2024-04-03T17:09:20.123+05:30"
             jcr:primaryType="dam:AssetContent"
             sling:resourceType="fd/fm/af/render"
             guide="1"
             type="guide">
         <metadata
                 fd:version="2.1"
-                themeRef="/libs/fd/af/themes/canvas"
                 jcr:primaryType="nt:unstructured"
                 allowedRenderFormat="HTML"
                 author="admin"
                 availableInMobileApp="{Boolean}false"
+                dorTemplateChanged="Boolean"
                 dorType="none"
                 formmodel="none"
                 hasCustomThumbnail="{Boolean}false"
+                themeRef="/libs/fd/af/themes/canvas"
                 title="Adaptive Form V2 (IT)"/>
     </jcr:content>
 </jcr:root>

--- a/it/content/src/main/content/jcr_root/content/forms/af/core-components-it/samples/datepicker/basic/.content.xml
+++ b/it/content/src/main/content/jcr_root/content/forms/af/core-components-it/samples/datepicker/basic/.content.xml
@@ -119,7 +119,7 @@
                     hideTitle="false"
                     name="datepicker7"
                     readOnly="{Boolean}false"
-                    textIsRich="[true,true,true]"
+                    textIsRich="[true,true]"
                     unboundFormElement="{Boolean}false"
                     visible="{Boolean}true"/>
             <datepicker_1911670949

--- a/it/content/src/main/content/jcr_root/content/forms/af/core-components-it/samples/datepicker/basic/.content.xml
+++ b/it/content/src/main/content/jcr_root/content/forms/af/core-components-it/samples/datepicker/basic/.content.xml
@@ -3,7 +3,7 @@
           jcr:primaryType="cq:Page">
     <jcr:content
             cq:deviceGroups="[mobile/groups/responsive]"
-            cq:lastModified="{Date}2024-03-18T15:08:02.397+05:30"
+            cq:lastModified="{Date}2024-04-03T17:09:19.976+05:30"
             cq:lastModifiedBy="admin"
             cq:template="/conf/core-components-examples/settings/wcm/templates/af-blank-v2"
             jcr:language="en"
@@ -17,13 +17,14 @@
                 jcr:lastModifiedBy="admin"
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="forms-components-examples/components/form/container"
-                themeRef="/libs/fd/af/themes/canvas"
                 clientLibRef="corecomponent.it.customfunction"
+                dorType="none"
                 fieldType="form"
                 schemaType="none"
                 textIsRich="true"
                 thankYouMessage="Thank you for submitting the form."
-                thankYouOption="page">
+                thankYouOption="page"
+                themeRef="/libs/fd/af/themes/canvas">
             <dateinput1
                     jcr:primaryType="nt:unstructured"
                     jcr:title="Date Input 1"
@@ -103,7 +104,7 @@
             <datepicker
                     jcr:created="{Date}2023-08-10T15:45:30.311+05:30"
                     jcr:createdBy="admin"
-                    jcr:lastModified="{Date}2023-08-10T15:47:00.344+05:30"
+                    jcr:lastModified="{Date}2024-04-03T17:07:16.009+05:30"
                     jcr:lastModifiedBy="admin"
                     jcr:primaryType="nt:unstructured"
                     jcr:title="Date Picker with edit and display formats"
@@ -114,10 +115,11 @@
                     editPatternType="d/M/y"
                     enabled="{Boolean}true"
                     fieldType="date-input"
+                    formatMessage="Date format expected is d/M/y"
                     hideTitle="false"
                     name="datepicker7"
                     readOnly="{Boolean}false"
-                    textIsRich="[true,true]"
+                    textIsRich="[true,true,true]"
                     unboundFormElement="{Boolean}false"
                     visible="{Boolean}true"/>
             <datepicker_1911670949

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/datepicker/v1/datepicker/_cq_dialog/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/datepicker/v1/datepicker/_cq_dialog/.content.xml
@@ -215,6 +215,13 @@
                                                             fieldLabel="Edit Format"
                                                             name="./editFormat">
                                                     </editFormat>
+                                                    <maximumMessage
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/textarea"
+                                                            fieldDescription="Error message shown when the date format is incorrect."
+                                                            granite:class="cmp-adaptiveform-datepicker__formatmessage"
+                                                            fieldLabel="Format error message"
+                                                            name="./formatMessage"/>
                                                 </items>
                                             </editPatternGroup>
                                         </items>

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/datepicker/v1/datepicker/_cq_dialog/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/datepicker/v1/datepicker/_cq_dialog/.content.xml
@@ -215,7 +215,7 @@
                                                             fieldLabel="Edit Format"
                                                             name="./editFormat">
                                                     </editFormat>
-                                                    <maximumMessage
+                                                    <formatMessage
                                                             jcr:primaryType="nt:unstructured"
                                                             sling:resourceType="granite/ui/components/coral/foundation/form/textarea"
                                                             fieldDescription="Error message shown when the date format is incorrect."

--- a/ui.tests/test-module/specs/datepicker/datepicker.runtime.spec.js
+++ b/ui.tests/test-module/specs/datepicker/datepicker.runtime.spec.js
@@ -256,15 +256,16 @@ describe("Form Runtime with Date Picker", () => {
         }
     });
 
-    it(" Test custom error message when incorrect date format is entered", () => {
-        const [datePicker5, datePicker5FieldView] = Object.entries(formContainer._fields)[6];
-        const incorrectInput = "01-01-2023";
-
-        cy.get(`#${datePicker5}`).find("input").should('have.attr',"type", "text");
-        cy.get(`#${datePicker5}`).find("input").clear().type(incorrectInput).blur().then(x => {
-            cy.get(`#${datePicker5}`).find(".cmp-adaptiveform-datepicker__errormessage").should('have.text',"Date format expected is d/M/y")
-        })
-
+    it.only("Test custom error message when incorrect date format is entered", () => {
+        const [datePicker7, datePicker7FieldView] = Object.entries(formContainer._fields)[6];
+        const incorrectInputs = ["adfasdfa", "29/2/2023", "32/1/2023", "1/32/23", "1-1-2023"];
+        incorrectInputs.forEach(incorrectInput => {
+            cy.get(`#${datePicker7}`).find("input").should('have.attr',"type", "text");
+            cy.get(`#${datePicker7}`).find("input").clear().wait(1000).type(incorrectInput).trigger('input').blur()
+                .then(x => {
+                cy.get(`#${datePicker7}`).find("input").should('have.value', incorrectInput); // Check if the input is the same
+                cy.get(`#${datePicker7}`).find(".cmp-adaptiveform-datepicker__errormessage").should('have.text',"Date format expected is d/M/y")
+            });
+        });
     });
-
 })

--- a/ui.tests/test-module/specs/datepicker/datepicker.runtime.spec.js
+++ b/ui.tests/test-module/specs/datepicker/datepicker.runtime.spec.js
@@ -256,4 +256,15 @@ describe("Form Runtime with Date Picker", () => {
         }
     });
 
+    it(" Test custom error message when incorrect date format is entered", () => {
+        const [datePicker5, datePicker5FieldView] = Object.entries(formContainer._fields)[6];
+        const incorrectInput = "01-01-2023";
+
+        cy.get(`#${datePicker5}`).find("input").should('have.attr',"type", "text");
+        cy.get(`#${datePicker5}`).find("input").clear().type(incorrectInput).blur().then(x => {
+            cy.get(`#${datePicker5}`).find(".cmp-adaptiveform-datepicker__errormessage").should('have.text',"Date format expected is d/M/y")
+        })
+
+    });
+
 })


### PR DESCRIPTION
… picker

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue
[FORMS-13810](https://jira.corp.adobe.com/browse/FORMS-13810)

<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
When no custom message provided
<img width="1728" alt="Screenshot 2024-04-03 at 12 36 13 PM" src="https://github.com/adobe/aem-core-forms-components/assets/110378842/672a16bb-2911-4c73-971c-e0e035d25daf">

Added a field to add custom message for format

<img width="1728" alt="Screenshot 2024-04-03 at 1 10 42 PM" src="https://github.com/adobe/aem-core-forms-components/assets/110378842/c417931e-337b-4d6b-a0dc-699344125a8c">

After custom message is added
<img width="1728" alt="Screenshot 2024-04-03 at 1 10 58 PM" src="https://github.com/adobe/aem-core-forms-components/assets/110378842/5c7a5a6e-84bf-4631-850a-604b19a1fb4c">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
