### PR TITLE
CM build is failing as 2.24.4 version is not available

### DIFF
--- a/.circleci/docker-compose.yml
+++ b/.circleci/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     entrypoint: tail -f /dev/null  # Keeps the container running
 
   circleci-aem-cloudready:
-    image: docker-adobe-cif-release.dr-uw2.adobeitc.com/circleci-aem-cloudready:15860-1-openjdk11
+    image: docker-adobe-cif-release.dr-uw2.adobeitc.com/circleci-aem-cloudready:7f6c9fff9b-openjdk11
     depends_on:
       - circleci-qp
     # Add any additional configurations or environment variables if needed

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -88,8 +88,8 @@
         <slf4j.version>1.7.6</slf4j.version>
         <jacoco.version>0.7.9</jacoco.version>
 
-        <core.wcm.components.version>2.24.4</core.wcm.components.version>
-        <core.wcm.components.library.version>2.24.4</core.wcm.components.library.version>
+        <core.wcm.components.version>2.24.2</core.wcm.components.version>
+        <core.wcm.components.library.version>2.24.2</core.wcm.components.library.version>
 
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/ui.tests/test-module/specs/wizard/wizard.locale.spec.js
+++ b/ui.tests/test-module/specs/wizard/wizard.locale.spec.js
@@ -15,7 +15,7 @@
  ******************************************************************************/
 const afConstants = require("../../libs/commons/formsConstants");
 const sitesSelectors = require("../../libs/commons/sitesSelectors");
-describe.skip('Locale - Authoring Test', function () {
+describe('Locale - Authoring Test', function () {
     if(cy.af.isLatestAddon()) {
         context('Test Wizard Component String Language', function () {
             beforeEach(() => {


### PR DESCRIPTION
Revert "Moving to 15860 image (#1212)"

This reverts commit c2270016979584dfdb635a25b1995b8e91eac3c8.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
