### PR TITLE
UE: Supporting custom viewType in sling models

### DIFF
--- a/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/util/AbstractBaseImpl.java
+++ b/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/util/AbstractBaseImpl.java
@@ -49,6 +49,8 @@ public abstract class AbstractBaseImpl extends AbstractFormComponentImpl impleme
 
     private static final String PN_TOOLTIP = "tooltip";
 
+    private static final String PN_VIEWTYPE = "fd:viewType";
+
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
     @Nullable
     protected String dorTemplateRef;
@@ -119,6 +121,10 @@ public abstract class AbstractBaseImpl extends AbstractFormComponentImpl impleme
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
     protected String lang;
+
+    @Nullable
+    @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL, name = PN_VIEWTYPE)
+    protected String viewType;
 
     /** End **/
 
@@ -466,6 +472,9 @@ public abstract class AbstractBaseImpl extends AbstractFormComponentImpl impleme
 
     @Override
     public @NotNull String getExportedType() {
+        if (viewType != null) {
+            return viewType;
+        }
         return resource.getResourceType();
     }
 

--- a/bundles/af-core/src/test/java/com/adobe/cq/forms/core/components/internal/models/v1/form/TextInputImplTest.java
+++ b/bundles/af-core/src/test/java/com/adobe/cq/forms/core/components/internal/models/v1/form/TextInputImplTest.java
@@ -59,6 +59,8 @@ public class TextInputImplTest {
     private static final String PATH_TEXTINPUT_BLANK_VALIDATIONEXPRESSION = CONTENT_ROOT + "/textinput-blank-validationExpression";
     private static final String PATH_TEXTINPUT_DISPLAY_VALUE_EXPRESSION = CONTENT_ROOT + "/textinput-displayValueExpression";
     private static final String PATH_TEXTINPUT_PLACEHOLDER_AUTOCOMPLETE = CONTENT_ROOT + "/textinput-placeholder-autocomplete";
+    private static final String PATH_TEXTINPUT_WITH_VIEWTYPE = CONTENT_ROOT + "/textinput-with-viewtype";
+
 
     private final AemContext context = FormsCoreComponentTestContext.newAemContext();
 
@@ -455,5 +457,12 @@ public class TextInputImplTest {
     void testJSONExportForDisplayValueExpression() throws Exception {
         TextInput textInput = Utils.getComponentUnderTest(PATH_TEXTINPUT_DISPLAY_VALUE_EXPRESSION, TextInput.class, context);
         Utils.testJSONExport(textInput, Utils.getTestExporterJSONPath(BASE, PATH_TEXTINPUT_DISPLAY_VALUE_EXPRESSION));
+    }
+
+    @Test
+    void testExportTypeWithViewType() throws Exception {
+        TextInput textInput = Utils.getComponentUnderTest(PATH_TEXTINPUT_WITH_VIEWTYPE, TextInput.class, context);
+        Utils.testJSONExport(textInput, Utils.getTestExporterJSONPath(BASE, PATH_TEXTINPUT_WITH_VIEWTYPE));
+        assertEquals("some/custom/value", textInput.getExportedType());
     }
 }

--- a/bundles/af-core/src/test/java/com/adobe/cq/forms/core/components/internal/models/v1/form/TextInputImplTest.java
+++ b/bundles/af-core/src/test/java/com/adobe/cq/forms/core/components/internal/models/v1/form/TextInputImplTest.java
@@ -61,7 +61,6 @@ public class TextInputImplTest {
     private static final String PATH_TEXTINPUT_PLACEHOLDER_AUTOCOMPLETE = CONTENT_ROOT + "/textinput-placeholder-autocomplete";
     private static final String PATH_TEXTINPUT_WITH_VIEWTYPE = CONTENT_ROOT + "/textinput-with-viewtype";
 
-
     private final AemContext context = FormsCoreComponentTestContext.newAemContext();
 
     @BeforeEach

--- a/bundles/af-core/src/test/resources/form/textinput/exporter-textinput-with-viewtype.json
+++ b/bundles/af-core/src/test/resources/form/textinput/exporter-textinput-with-viewtype.json
@@ -1,0 +1,22 @@
+{
+  "id": "textinput-af83154b9e",
+  "fieldType": "text-input",
+  "name": "abc",
+  "type": "string",
+  "label": {
+    "value": "def"
+  },
+  "events": {
+    "custom:setProperty": [
+      "$event.payload"
+    ]
+  },
+  "properties": {
+    "fd:dor": {
+      "dorExclusion": false
+    },
+    "fd:path": "/content/textinput-with-viewtype"
+  },
+  "placeholder": "test-placeholder",
+  ":type": "some/custom/value"
+}

--- a/bundles/af-core/src/test/resources/form/textinput/test-content.json
+++ b/bundles/af-core/src/test/resources/form/textinput/test-content.json
@@ -173,5 +173,14 @@
     "fieldType": "text-input",
     "placeholder": "test-placeholder",
     "autocomplete": "given-name"
+  },
+  "textinput-with-viewtype" : {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType"    : "core/fd/components/form/textinput/v1/textinput",
+    "name" : "abc",
+    "jcr:title" : "def",
+    "fieldType": "text-input",
+    "placeholder": "test-placeholder",
+    "fd:viewType": "some/custom/value"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is a UE usecase, to override `:type` of the json by providing `fd:viewType` property in the jcr node of any component.
<!--- Describe your changes in detail -->

## Related Issue

<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
