### PR TITLE
made changes in getId method where currentPage is null in case of resource adaptation

### DIFF
--- a/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/internal/models/v2/form/FormContainerImpl.java
+++ b/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/internal/models/v2/form/FormContainerImpl.java
@@ -216,7 +216,8 @@ public class FormContainerImpl extends AbstractContainerImpl implements FormCont
                 return ComponentUtils.getEncodedPath(getPath());
             }
         } else {
-            return super.getId();
+            String pagePath = getParentPagePath();
+            return (StringUtils.isNotBlank(pagePath))? ComponentUtils.getEncodedPath(pagePath) : super.getId();
         }
     }
 
@@ -239,23 +240,13 @@ public class FormContainerImpl extends AbstractContainerImpl implements FormCont
 
     @Override
     public String getAction() {
-        if (getCurrentPage() != null) {
-            return getContextPath() + ADOBE_GLOBAL_API_ROOT + FORMS_RUNTIME_API_GLOBAL_ROOT + "/submit/" + getId();
-        } else {
-            return null;
-        }
+        return getContextPath() + ADOBE_GLOBAL_API_ROOT + FORMS_RUNTIME_API_GLOBAL_ROOT + "/submit/" + getId();
     }
 
     @Override
     @JsonIgnore
     public String getDataUrl() {
-        if (getCurrentPage() != null) {
-            return getContextPath() + ADOBE_GLOBAL_API_ROOT + FORMS_RUNTIME_API_GLOBAL_ROOT + "/data/" + ComponentUtils.getEncodedPath(
-                getCurrentPage()
-                    .getPath());
-        } else {
-            return null;
-        }
+        return getContextPath() + ADOBE_GLOBAL_API_ROOT + FORMS_RUNTIME_API_GLOBAL_ROOT + "/data/" + getId();
     }
 
     @Override

--- a/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/internal/models/v2/form/FormContainerImpl.java
+++ b/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/internal/models/v2/form/FormContainerImpl.java
@@ -209,15 +209,11 @@ public class FormContainerImpl extends AbstractContainerImpl implements FormCont
 
     @Override
     public String getId() {
-        if (getCurrentPage() != null) {
-            if (GuideWCMUtils.isForms(getCurrentPage().getPath())) {
-                return ComponentUtils.getEncodedPath(getCurrentPage().getPath());
-            } else {
-                return ComponentUtils.getEncodedPath(getPath());
-            }
+        String parentPagePath = getParentPagePath();
+        if (GuideWCMUtils.isForms(parentPagePath)) {
+            return ComponentUtils.getEncodedPath(parentPagePath);
         } else {
-            String pagePath = getParentPagePath();
-            return (StringUtils.isNotBlank(pagePath)) ? ComponentUtils.getEncodedPath(pagePath) : super.getId();
+            return ComponentUtils.getEncodedPath(getPath());
         }
     }
 

--- a/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/internal/models/v2/form/FormContainerImpl.java
+++ b/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/internal/models/v2/form/FormContainerImpl.java
@@ -217,7 +217,7 @@ public class FormContainerImpl extends AbstractContainerImpl implements FormCont
             }
         } else {
             String pagePath = getParentPagePath();
-            return (StringUtils.isNotBlank(pagePath))? ComponentUtils.getEncodedPath(pagePath) : super.getId();
+            return (StringUtils.isNotBlank(pagePath)) ? ComponentUtils.getEncodedPath(pagePath) : super.getId();
         }
     }
 

--- a/ui.tests/test-module/specs/page/pagev2.runtime.spec.js
+++ b/ui.tests/test-module/specs/page/pagev2.runtime.spec.js
@@ -43,9 +43,13 @@ describe("Form with Page component version 2 for eds rendering", () => {
             const encodedJson=$codeEle.get()[0].innerHTML;
             const formJson=JSON.parse(JSON.parse(encodedJson));
             expect(formJson).to.have.property("id");
+            expect(formJson["id"]).to.equal("L2NvbnRlbnQvZm9ybXMvYWYvY29yZS1jb21wb25lbnRzLWl0L3NhbXBsZXMvcGFnZS9hZnYy");
             expect(formJson).to.have.property("fieldType");
             expect(formJson).to.have.property(":items");
             expect(formJson).to.have.property("title");
+            expect(formJson).to.have.property("action");
+            expect(formJson["action"]).to.equal("/adobe/forms/af/submit/L2NvbnRlbnQvZm9ybXMvYWYvY29yZS1jb21wb25lbnRzLWl0L3NhbXBsZXMvcGFnZS9hZnYy");
+
 
         })
     })


### PR DESCRIPTION
When migrating from eds to master. 

- We moved the getFormDefinition Api from formContainer to FormStructParser. In doing so , we adapted the resource to FormContainer object and then generated the json.
- Before since the context was with request object the currentPage variable was initiated from request obj but now this was null resulting in wrong id getting generated in eds json.

cc:- @nit23uec , @jalagari , @rismehta  