### PR TITLE
Fixing enabled and visible attributes of Button CC

### DIFF
--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/button/v1/button/button.html
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/button/v1/button/button.html
@@ -23,8 +23,8 @@
      data-sly-use.formstructparser="com.adobe.cq.forms.core.components.models.form.FormStructureParser"></sly>
 <div class="cmp-adaptiveform-button"
      id="${button.id}"
-     data-cmp-visible="${button.visible}"
-     data-cmp-enabled="${button.enabled}"
+     data-cmp-visible="${button.visible ? 'true' : 'false'}"
+     data-cmp-enabled="${button.enabled ? 'true' : 'false'}"
      data-cmp-is="adaptiveFormButton"
      data-cmp-adaptiveformcontainer-path="${formstructparser.formContainerPath}">
   <div class="cmp-adaptiveform-button__help-container">

--- a/ui.tests/test-module/specs/customization/customtextinput.runtime.spec.js
+++ b/ui.tests/test-module/specs/customization/customtextinput.runtime.spec.js
@@ -64,7 +64,7 @@ describe("Form Runtime with Custom Text Input", () => {
         expect(formContainer, "formcontainer is initialized").to.not.be.null;
         expect(formContainer._model.items.length, "model and view elements match").to.equal(Object.keys(formContainer._fields).length);
         Object.entries(formContainer._fields).forEach(([id, field]) => {
-            if(field.options.visible === "true") {
+            if(field.options.visible === "true" && field.getModel()._jsonModel.fieldType==='text-input') {
                 expect(field.getId()).to.equal(id)
                 expect(formContainer._model.getElement(id), `model and view are in sync`).to.equal(field.getModel())
                 checkHTML(id, field.getModel().getState())

--- a/ui.tests/test-module/specs/textinput/textinput.runtime.spec.js
+++ b/ui.tests/test-module/specs/textinput/textinput.runtime.spec.js
@@ -67,7 +67,7 @@ describe("Form Runtime with Text Input", () => {
         expect(formContainer, "formcontainer is initialized").to.not.be.null;
         expect(formContainer._model.items.length, "model and view elements match").to.equal(Object.keys(formContainer._fields).length);
         Object.entries(formContainer._fields).forEach(([id, field]) => {
-            if(field.options.visible === "true") {
+            if(field.options.visible === "true" && field.getModel()._jsonModel.fieldType==='text-input') {
                 expect(field.getId()).to.equal(id)
                 expect(formContainer._model.getElement(id), `model and view are in sync`).to.equal(field.getModel())
                 checkHTML(id, field.getModel().getState())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed the enabled and visible attributes to reflect correctly in forms for button core component.

<!--- Describe your changes in detail -->
JIRA : https://jira.corp.adobe.com/browse/FORMS-15167
## Related Issue

<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Without this change, the button component in forms was not correctly populating true and false values to 'data-cmp-enabled' and 'data-cmp-visible' attributes.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested the changes using cypress.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="1840" alt="Screenshot 2024-07-08 at 2 00 08 PM" src="https://github.com/adobe/aem-core-forms-components/assets/174990584/d3da50c5-9e37-4fb3-a335-d92a019478ae">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
