### PR TITLE
Fix default behaviour of enter press leading to form submission in core components.

### DIFF
--- a/ui.frontend/src/view/FormContainer.js
+++ b/ui.frontend/src/view/FormContainer.js
@@ -35,6 +35,23 @@ class FormContainer {
         this._fields = {};
         this._deferredParents = {};
         this._element = params._element;
+
+        // Prevent default behaviour on form container.
+        this.#preventDefaultSubmit();
+    }
+
+    /**
+     * Prevents the default behavior of the Enter key on components within the formContainer
+     * from triggering a form submission and redirecting to the Thank-You Page.
+     */
+    #preventDefaultSubmit(){
+        if(this._element) {
+            this._element.addEventListener('keydown', (event) => {
+                if (event.key === 'Enter') {
+                    event.preventDefault();
+                }
+            });
+        }
     }
 
     /**

--- a/ui.tests/test-module/specs/formcontainer.spec.js
+++ b/ui.tests/test-module/specs/formcontainer.spec.js
@@ -289,7 +289,7 @@ describe('Page/Form Authoring', function () {
         });
 
         context("Check default behaviour in Form Editor", function () {
-            const pagePath = "/content/forms/af/core-components-it/samples/emailinput/basic.html";
+            const pagePath = "/content/forms/af/core-components-it/samples/numberinput/validation.html";
 
             beforeEach(function () {
                 cy.previewForm(pagePath);
@@ -305,8 +305,17 @@ describe('Page/Form Authoring', function () {
 
             it('should prevent form submission by default', function () {
                 cy.get('.cmp-adaptiveform-container').then((formContainer) => {
-                    cy.get('.cmp-adaptiveform-emailinput__widget').eq(0).type('{enter}');
-                    cy.get('.cmp-adaptiveform-emailinput__widget').eq(0).should('be.visible');
+                    // Trigger enter on button
+                    cy.get('.cmp-adaptiveform-container button').eq(0).type('{enter}');
+                    cy.get('.cmp-adaptiveform-container button').eq(0).should('be.visible');
+
+                    // Trigger enter on first input where display:none is not present
+                    cy.get('.cmp-adaptiveform-container input').eq(3).type('{enter}');
+                    cy.get('.cmp-adaptiveform-container input').eq(3).should('be.visible');
+
+                    // Trigger enter on numberinput widget
+                    cy.get('.cmp-adaptiveform-numberinput__widget').eq(0).type('{enter}');
+                    cy.get('.cmp-adaptiveform-numberinput__widget').eq(0).should('be.visible');
                 });
             });
         });

--- a/ui.tests/test-module/specs/formcontainer.spec.js
+++ b/ui.tests/test-module/specs/formcontainer.spec.js
@@ -287,4 +287,27 @@ describe('Page/Form Authoring', function () {
             });
 
         });
+
+        context("Check default behaviour in Form Editor", function () {
+            const pagePath = "/content/forms/af/core-components-it/samples/emailinput/basic.html";
+
+            beforeEach(function () {
+                cy.previewForm(pagePath);
+            });
+
+            it('check the preventDefaultSubmit method by simulating keydown event on the form', function () {
+                cy.get('.cmp-adaptiveform-container').then((formContainer) => {
+                    cy.stub(formContainer[0], 'onsubmit').as('submit');
+                    cy.get('form').trigger('keydown', {key: 'Enter'});
+                    cy.get('@submit').should('not.be.called');
+                });
+            });
+
+            it('should prevent form submission by default', function () {
+                cy.get('.cmp-adaptiveform-container').then((formContainer) => {
+                    cy.get('.cmp-adaptiveform-emailinput__widget').eq(0).type('{enter}');
+                    cy.get('.cmp-adaptiveform-emailinput__widget').eq(0).should('be.visible');
+                });
+            });
+        });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Pressing enter on core components redirects to thankyou page which is not the correct behaviour. This fix prevents the default behaviour of enter press on form level.

<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/FORMS-15630
<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested on localhost deployment and test cases tested using cypress.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
