### PR TITLE
Adding more HTML input types to FieldType

### DIFF
--- a/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/models/form/FieldType.java
+++ b/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/models/form/FieldType.java
@@ -38,7 +38,9 @@ public enum FieldType {
     IMAGE("image"),
     TELEPHONE("tel"),
     PASSWORD("password"),
-    RANGE("range");
+    RANGE("range"),
+    COLOR("color"),
+    URL("url");
 
     private String value;
 

--- a/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/models/form/FieldType.java
+++ b/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/models/form/FieldType.java
@@ -40,7 +40,8 @@ public enum FieldType {
     PASSWORD("password"),
     RANGE("range"),
     COLOR("color"),
-    URL("url");
+    URL("url"),
+    HIDDEN("hidden");
 
     private String value;
 

--- a/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/models/form/FormContainer.java
+++ b/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/models/form/FormContainer.java
@@ -64,7 +64,7 @@ public interface FormContainer extends Container {
      */
     String PN_CLIENT_LIB_REF = GuideConstants.CLIENT_LIB_REF;
 
-    String DEFAULT_FORMS_SPEC_VERSION = "0.14.1";
+    String DEFAULT_FORMS_SPEC_VERSION = "0.14.2";
 
     /**
      * Returns form metadata {@link FormMetaData}

--- a/bundles/af-core/src/test/java/com/adobe/cq/forms/core/Utils.java
+++ b/bundles/af-core/src/test/java/com/adobe/cq/forms/core/Utils.java
@@ -125,14 +125,14 @@ public class Utils {
         // create an instance of the JsonSchemaFactory using version flag
         JsonSchemaFactory schemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7);
         try {
-            InputStream schemaStream = Utils.class.getResourceAsStream("/schema/0.14.1/adaptive-form.schema.json");
+            InputStream schemaStream = Utils.class.getResourceAsStream("/schema/0.14.2/adaptive-form.schema.json");
             JsonSchema schema = schemaFactory.getSchema(schemaStream);
             // read data from the stream and store it into JsonNode
             JsonNode json = objectMapper.readTree(jsonStream);
             // if there is a version bump of schema, then it needs to be validated against its corresponding sling model here
             // by explicitly checking the model implementation
             if (!(model instanceof FormContainerImpl)) {
-                InputStream formContainerTemplate = Utils.class.getResourceAsStream("/schema/0.14.1/form.json");
+                InputStream formContainerTemplate = Utils.class.getResourceAsStream("/schema/0.14.2/form.json");
                 JsonNode formContainerTemplateNode = objectMapper.readTree(formContainerTemplate);
                 ((ObjectNode) formContainerTemplateNode).putArray("items").add(json);
                 json = formContainerTemplateNode;

--- a/bundles/af-core/src/test/java/com/adobe/cq/forms/core/components/internal/models/v2/form/FormContainerImplTest.java
+++ b/bundles/af-core/src/test/java/com/adobe/cq/forms/core/components/internal/models/v2/form/FormContainerImplTest.java
@@ -163,7 +163,7 @@ public class FormContainerImplTest {
     void testGetAdaptiveFormDefaultVersion() throws Exception {
         FormContainer formContainer = Utils.getComponentUnderTest(PATH_FORM_1, FormContainer.class, context);
         assertNotNull(formContainer.getAdaptiveFormVersion());
-        assertEquals("0.14.1", formContainer.getAdaptiveFormVersion());
+        assertEquals("0.14.2", formContainer.getAdaptiveFormVersion());
     }
 
     @Test

--- a/bundles/af-core/src/test/resources/form/formcontainer/exporter-formcontainerv2.json
+++ b/bundles/af-core/src/test/resources/form/formcontainer/exporter-formcontainerv2.json
@@ -25,7 +25,7 @@
   ":itemsOrder": [
     "textinput"
   ],
-  "adaptiveform": "0.14.1",
+  "adaptiveform": "0.14.2",
   "metadata": {
     "version": "1.0.0",
     "grammar": "json-formula-1.0.0"

--- a/bundles/af-core/src/test/resources/schema/0.14.2/adaptive-form-aem-allowed-components.schema.json
+++ b/bundles/af-core/src/test/resources/schema/0.14.2/adaptive-form-aem-allowed-components.schema.json
@@ -1,0 +1,18 @@
+{
+  "$id": "classpath:/schema/0.14.2/adaptive-form-aem-allowed-components.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Allowed Components object for the current panel.",
+  "description": "This is applicable only if the panel's layout is grid system. This property is useful if needs to show list of allowed components in the client while authoring the panel.",
+  "properties": {
+    "components": {
+      "type": "array",
+      "title": "List of simple objects representing all Allowed Components for the given panel"
+    },
+    "applicable": {
+      "type": "boolean",
+      "title": "Is the given panel contained by a page, with authored template structure and is the given panel set as editable (unlocked)",
+      "description": "true if the template has structure support and the panel is editable, false otherwise"
+    }
+  }
+}

--- a/bundles/af-core/src/test/resources/schema/0.14.2/adaptive-form-aem-responsive-grid-properties.schema.json
+++ b/bundles/af-core/src/test/resources/schema/0.14.2/adaptive-form-aem-responsive-grid-properties.schema.json
@@ -1,0 +1,52 @@
+{
+  "$id": "classpath:/schema/0.14.2/adaptive-form-aem-responsive-grid-properties.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "allowedComponents": {
+      "$ref": "./adaptive-form-aem-allowed-components.schema.json"
+    },
+    "appliedCssClassNames": {
+      "title": "CSS classes delimited using a SPACE character",
+      "description": "Describes the style system information associated with the current form element",
+      "type": "string",
+      "examples": [
+        {
+          "appliedCssClassNames": "outlined red-border"
+        }
+      ]
+    },
+    "gridClassNames": {
+      "title": "The CSS class names to be applied to the current panel delimited using a SPACE character",
+      "description": "This is applicable only if the panel's layout is grid system.",
+      "type": "string",
+      "examples": [
+        {
+          "gridClassNames": "aem-Grid aem-Grid--12 aem-Grid--default--12"
+        }
+      ]
+    },
+    "columnClassNames": {
+      "title": "The CSS class names associated with each responsive grid column and listed by column name",
+      "description": "This is applicable only if the panel's layout is grid system.",
+      "type": "object",
+      "examples": [
+        {
+          "columnClassNames": {
+            "title_v3": "aem-GridColumn aem-GridColumn--default--12"
+          }
+        }
+      ]
+    },
+    "columnCount": {
+      "title": "The number of columns available for direct children in the panel.",
+      "description": "This is applicable only if the panel's layout is grid system.",
+      "type": "number",
+      "examples": [
+        {
+          "columnCount": 12
+        }
+      ]
+    }
+  }
+}

--- a/bundles/af-core/src/test/resources/schema/0.14.2/adaptive-form-container-dor-properties.schema.json
+++ b/bundles/af-core/src/test/resources/schema/0.14.2/adaptive-form-container-dor-properties.schema.json
@@ -1,0 +1,41 @@
+{
+  "$id": "classpath:/schema/0.14.2/adaptive-form-container-dor-properties.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "dorType": {
+      "title": "DOR Type",
+      "description": "Describes the type of Document of Record (DOR)",
+      "type": "string",
+      "enum": [
+        "generate",
+        "select"
+      ],
+      "examples": [
+        {
+          "dorType": "generate"
+        }
+      ]
+    },
+    "dorTemplateRef": {
+      "title": "DOR Template Reference",
+      "description": "Reference to the template for the Document of Record (DOR).",
+      "type": "string",
+      "examples": [
+        {
+          "dorTemplateRef": "/content/dam/formsanddocuments/acro form conversion.pdf"
+        }
+      ]
+    },
+    "dorTemplateType": {
+      "title": "DOR Template Type",
+      "description": "Type of the template for the Document of Record (DOR).",
+      "enum": [
+        "acroform",
+        "xfa"
+      ],
+      "type": "string"
+    }
+  }
+}

--- a/bundles/af-core/src/test/resources/schema/0.14.2/adaptive-form-data-constraints.schema.json
+++ b/bundles/af-core/src/test/resources/schema/0.14.2/adaptive-form-data-constraints.schema.json
@@ -1,0 +1,143 @@
+{
+  "$id": "classpath:/schema/0.14.2/adaptive-form-data-constraints.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Constraints applicable to fields",
+  "type": "object",
+  "properties": {
+    "accept": {
+      "title": "The constraint is applicable for fields having type file or with fields having type string and format as data-url / binary. It signifies the list of IANA media types that fields can accept.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "enforceEnum": {
+      "title": "Whether a user can enter a value that is not present in the enum array",
+      "description": "If set to true, a user will be able to enter any other value that is not in the list of enum. That generally means that enum is used a aid for users to enter the value but is not a validation constraint.",
+      "type": "boolean"
+    },
+    "exclusiveMaximum": {
+      "title": "maximum value or date (exclusive)",
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "exclusiveMinimum": {
+      "title": "minimum value or date (exclusive)",
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "format": {
+      "title": "formats as specified in JSON Schema. The constraint is applicable only for string data types",
+      "type": "string",
+      "enum": [
+        "date",
+        "email",
+        "date-time",
+        "data-url"
+      ]
+    },
+    "maxFileSize": {
+      "title": "The constraint is applicable for fields having type file or with fields having type string and format as data-url / binary. It signifies the maximum file size as per IEC specification",
+      "type": "string"
+    },
+    "maximum": {
+      "title": "maximum value or date (inclusive)",
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "maxItems": {
+      "title": "Maximum number of items in a field/panel capturing array data",
+      "type": "number"
+    },
+    "maxOccur": {
+      "title": "Maximum number of occurrence of repeating panel - capturing array data,",
+      "type": "number"
+    },
+    "maxLength": {
+      "title": "Maximum Length of the data. The constraint is applicable only for string data types",
+      "type": "number"
+    },
+    "minimum": {
+      "title": "minimum value or date (inclusive)",
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "minItems": {
+      "title": "Minimum number of items in a field/panel capturing array data",
+      "type": "number"
+    },
+    "minOccur": {
+      "title": "Minimum number of occurrence of repeating panel - capturing array data",
+      "type": "number"
+    },
+    "minLength": {
+      "title": "Minimum Length of the data. The constraint is applicable only for string data types",
+      "type": "number"
+    },
+    "pattern": {
+      "title": "The regular expression against which the value will be compared against",
+      "type": "string",
+      "format": "regex"
+    },
+    "required": {
+      "type": "boolean",
+      "title": "Indicates whether the value is required or not"
+    },
+    "step": {
+      "title": "The constraint is applicable for fields having type number. It signifies the value should be a multipleOf some number",
+      "type": "number"
+    },
+    "type": {
+      "title": "Data Type of the value that this field captures. When submitting the value will be coerced into the format specified by the type",
+      "type": "string",
+      "enum": [
+        "string",
+        "file",
+        "number",
+        "array",
+        "object",
+        "string[]",
+        "file[]",
+        "number[]",
+        "boolean[]",
+        "boolean"
+      ]
+    },
+    "uniqueItems": {
+      "title": "Array items must be unique",
+      "type": "boolean"
+    },
+    "validationExpression": {
+      "type": "string",
+      "format": "json-formula"
+    }
+  }
+}

--- a/bundles/af-core/src/test/resources/schema/0.14.2/adaptive-form-data-layer.schema.json
+++ b/bundles/af-core/src/test/resources/schema/0.14.2/adaptive-form-data-layer.schema.json
@@ -1,0 +1,60 @@
+{
+  "$id": "classpath:/schema/0.14.2/adaptive-form-data-layer.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "@id": {
+      "type": "string",
+      "title": "Id of the form element"
+    },
+    "@type": {
+      "type": "string",
+      "title": "Type of the form element used in the data layer"
+    },
+    "repo:modifyDate": {
+      "type": "string",
+      "title": "Last modified date using ISO 8601 standard"
+    },
+    "parentId": {
+      "type": "string",
+      "title": "Parent id of the form element"
+    },
+    "dc:title": {
+      "type": "string",
+      "title": "Label of the form element used in the data layer"
+    },
+    "dc:description": {
+      "type": "string",
+      "title": "Description of the form element used in the data layer"
+    },
+    "xdm:text": {
+      "type": "string",
+      "title": "Text of the form element used in the data layer"
+    },
+    "xdm:linkURL": {
+      "type": "string",
+      "title": "Link URL of the form element used in the data layer"
+    },
+    "fieldType": {
+      "title": "Type of widget to show to the user for capturing the data",
+      "enum": [
+        "text-input",
+        "number-input",
+        "date-input",
+        "file-input",
+        "multiline-input",
+        "drop-down",
+        "radio-group",
+        "checkbox-group",
+        "checkbox",
+        "switch",
+        "plain-text",
+        "button",
+        "panel",
+        "image",
+        "email",
+        "captcha"
+      ]
+    }
+  }
+}

--- a/bundles/af-core/src/test/resources/schema/0.14.2/adaptive-form-defaults.schema.json
+++ b/bundles/af-core/src/test/resources/schema/0.14.2/adaptive-form-defaults.schema.json
@@ -1,0 +1,255 @@
+{
+  "$id": "classpath:/schema/0.14.2/adaptive-form-defaults.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "The schema defines the default field types for Form Fields",
+  "allOf": [
+    {
+      "title": "Default field for capturing date types is date-input",
+      "if": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "const": "string"
+          },
+          "format": {
+            "const": "date"
+          }
+        },
+        "required": [
+          "type",
+          "format"
+        ]
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "default": "date-input"
+          }
+        }
+      }
+    },
+    {
+      "title": "Default field for capturing file types is file-input",
+      "if": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "enum": [
+              "file",
+              "file[]"
+            ]
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "default": "file-input"
+          }
+        }
+      }
+    },
+    {
+      "title": "Default field for capturing file types is file-input",
+      "if": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "const": "string"
+          },
+          "format": {
+            "enum": [
+              "binary",
+              "data-url"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "format"
+        ]
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "default": "file-input"
+          }
+        }
+      }
+    },
+    {
+      "title": "Default field for capturing string type is text-input",
+      "if": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "const": "string"
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "default": "text-input"
+          }
+        }
+      }
+    },
+    {
+      "title": "Default Field for capturing number types is number-input",
+      "if": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "const": "number"
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "default": "number-input"
+          }
+        }
+      }
+    },
+    {
+      "title": "Default field for capturing data that can be only be one of two values is checkbox",
+      "if": {
+        "type": "object",
+        "properties": {
+          "enum": {
+            "type": "array",
+            "maxItems": 2
+          }
+        },
+        "required": [
+          "enum"
+        ]
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "default": "checkbox"
+          }
+        }
+      }
+    },
+    {
+      "title": "Default field for capturing boolean data is checkbox",
+      "if": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "const": "boolean"
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "default": "checkbox"
+          },
+          "enum": {
+            "default": [
+              true,
+              false
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "Default field for capturing data that allows only a set of options is drop-down",
+      "if": {
+        "type": "object",
+        "properties": {
+          "enum": {
+            "type": "array",
+            "minItems": 3
+          }
+        },
+        "required": [
+          "enum"
+        ]
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "default": "drop-down"
+          }
+        }
+      }
+    },
+    {
+      "title": "Default field for capturing complex types is panel",
+      "if": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": [
+              "array",
+              "object"
+            ]
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "default": "panel"
+          }
+        }
+      }
+    },
+    {
+      "title": "Default value of dataRef for static text is none",
+      "if": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "enum": [
+              "button",
+              "plain-text"
+            ]
+          }
+        },
+        "required": [
+          "fieldType"
+        ]
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "dataRef": {
+            "default": "none"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/bundles/af-core/src/test/resources/schema/0.14.2/adaptive-form-dor-properties.schema.json
+++ b/bundles/af-core/src/test/resources/schema/0.14.2/adaptive-form-dor-properties.schema.json
@@ -1,0 +1,58 @@
+{
+  "$id": "classpath:/schema/0.14.2/adaptive-form-dor-properties.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "dorColspan": {
+      "title": "DOR Colspan",
+      "description": "Specifies the colspan attribute for the Document of Record (DOR). This attribute controls the number of columns a form element should span.",
+      "type": "string"
+    },
+    "breakAfterText": {
+      "title": "Break After Text",
+      "description": "Indicates whether a break should occur after the text content of the Document of Record (DOR). This affects the layout and presentation of the DOR.",
+      "type": "string"
+    },
+    "breakBeforeText": {
+      "title": "Break Before Text",
+      "description": "Indicates whether a break should occur before the text content of the Document of Record (DOR). This influences the layout and presentation of the DOR.",
+      "type": "string"
+    },
+    "overflowText": {
+      "title": "Overflow Text",
+      "description": "Specifies how overflow should be handled for the text content of the Document of Record (DOR). This property controls how text exceeding the available space is displayed.",
+      "type": "string"
+    },
+    "dorLayoutType": {
+      "title": "DOR Layout Type",
+      "description": "Defines the layout type for the Document of Record (DOR). This property determines how the DOR elements are arranged and presented.",
+      "type": "string"
+    },
+    "dorNumCols": {
+      "title": "DOR Number of Columns",
+      "description": "Specifies the number of columns for the layout of the Document of Record (DOR). This property determines how the DOR elements are arranged and presented in columns.",
+      "type": "string"
+    },
+    "dorBindRef": {
+      "title": "DOR Binding Reference",
+      "description": "Specifies the binding reference for the Document of Record (DOR). This property determines how the DOR elements are bound to data.",
+      "type": "string"
+    },
+    "dorExclusion": {
+      "title": "DOR Exclusion.",
+      "description": "Exclusion flag for the Document of Record (DOR).",
+      "type": "boolean"
+    },
+    "dorExcludeTitle": {
+      "title": "Exclude Title in DOR.",
+      "description": "Flag to exclude title in the Document of Record (DOR).",
+      "type": "boolean"
+    },
+    "dorExcludeDescription": {
+      "title": "Exclude Description in DOR.",
+      "description": "Flag to exclude description in the Document of Record (DOR).",
+      "type": "boolean"
+    }
+  }
+}

--- a/bundles/af-core/src/test/resources/schema/0.14.2/adaptive-form-events.schema.json
+++ b/bundles/af-core/src/test/resources/schema/0.14.2/adaptive-form-events.schema.json
@@ -1,0 +1,79 @@
+{
+  "$id": "classpath:/schema/0.14.2/adaptive-form-events.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Specify what operations to perform on certain user or custom events.",
+  "description": "Events is a dictionary of eventName to the actions to perform. Whenever the event is dispatched the expressions defined on that event are evaluated. The return value of that expression is applied to the field. The return value of the expression can be either of\n  * null, literal or array: The value property of the field is set to the return value\n  * dictionary: The field json is merged with the returned dictionary\n  * empty dictionary: the field should not be modified.",
+  "$defs": {
+    "SingleEventHandler": {
+      "type": "string",
+      "format": "json-formula"
+    },
+    "EventHandler": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/SingleEventHandler"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SingleEventHandler"
+          }
+        }
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "click": {
+      "$ref": "#/$defs/EventHandler"
+    },
+    "initialize": {
+      "$ref": "#/$defs/EventHandler"
+    },
+    "focus": {
+      "$ref": "#/$defs/EventHandler"
+    },
+    "blur": {
+      "$ref": "#/$defs/EventHandler"
+    },
+    "change": {
+      "$ref": "#/$defs/EventHandler"
+    },
+    "submit": {
+      "$ref": "#/$defs/EventHandler"
+    }
+  },
+  "propertyNames": {
+    "anyOf": [
+      {
+        "enum": [
+          "click",
+          "initialize",
+          "focus",
+          "blur",
+          "change",
+          "submit",
+          "submitError",
+          "submitFailure",
+          "submitSuccess"
+        ]
+      },
+      {
+        "pattern": "custom:[a-zA-Z0-9]+"
+      }
+    ],
+    "errorMessage": "${0} is not a valid Event Name. It should be either click, initialize, focus, blur, change, submitError, submitFailure, submitSuccess or a custom event"
+  },
+  "examples": [
+    {
+      "Terms&Conditions": [
+        {
+          "name": "terms"
+        },
+        {
+          "click": "{value: true}"
+        }
+      ]
+    }
+  ]
+}

--- a/bundles/af-core/src/test/resources/schema/0.14.2/adaptive-form-label.schema.json
+++ b/bundles/af-core/src/test/resources/schema/0.14.2/adaptive-form-label.schema.json
@@ -1,0 +1,24 @@
+{
+  "$id": "classpath:/schema/0.14.2/adaptive-form-label.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "richText": {
+      "type": "boolean",
+      "default": false,
+      "title": "If the value of the label is to be considered as rich text or plain text"
+    },
+    "visible": {
+      "type": "boolean",
+      "title": "If the field's visible property is false, this property is ignored.",
+      "default": true
+    },
+    "value": {
+      "type": "string",
+      "title": "The content of the label. If the rich text property is set to true, the contents will be considered as Rich Text"
+    }
+  },
+  "required": [
+    "value"
+  ]
+}

--- a/bundles/af-core/src/test/resources/schema/0.14.2/adaptive-form-properties.schema.json
+++ b/bundles/af-core/src/test/resources/schema/0.14.2/adaptive-form-properties.schema.json
@@ -1,0 +1,329 @@
+{
+  "$id": "classpath:/schema/0.14.2/adaptive-form-properties.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "$defs": {
+    "SingleEventHandler": {
+      "type": "string",
+      "format": "json-formula"
+    },
+    "EventHandler": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/SingleEventHandler"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SingleEventHandler"
+          }
+        }
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "./adaptive-form-aem-responsive-grid-properties.schema.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        ":type": {
+          "type": "string",
+          "title": "A hint to the rendering engine for rendering custom components."
+        },
+        "altText": {
+          "title": "For images an alternate string to be displayed in case image cannot be shown",
+          "type": "string"
+        },
+        "autocomplete": {
+          "title": "Provide assistance to the end users to autocomplete values saved during previous form filling sessions",
+          "type": "string"
+        },
+        "checked": {
+          "title": "Indicates the checked status of the checkbox. The property is available only for fieldType checkbox If the value of this property is true, then the checkbox is selected and its value is set to on value. This value overrides the default property in case of a conflict.",
+          "type": "boolean"
+        },
+        "constraintMessages": {
+          "title": "An object containing the custom error messages to be shown to the end user on different constraint validation",
+          "type": "object",
+          "propertyNames": {
+            "enum": [
+              "type",
+              "required",
+              "minimum",
+              "maximum",
+              "minLength",
+              "maxLength",
+              "step",
+              "format",
+              "pattern",
+              "minItems",
+              "maxItems",
+              "maxOccur",
+              "minOccur",
+              "maxFileSize",
+              "accept",
+              "uniqueItems",
+              "enforceEnum",
+              "validationExpression"
+            ],
+            "errorMessage": "${0} is not a valid constraintMessage"
+          }
+        },
+        "dataFormat": {
+          "type": "string",
+          "title": "The format in which the value will be exported or submitted. Applicable for date and number types."
+        },
+        "dataRef": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "title": "The jsonpath of the data instance that is mapped to the field's value.",
+          "description": "It will be defined relative to the parent's dataRef property except for the two conditions. * null signifying don't save the data of this field or panel. * jsonpath begining with \"$.\" signifying that the jsonpath is not relative to the parent's dataRef property.\nIf the parent's dataRef is set to \"none\", then it will be relative to the"
+        },
+        "default": {
+          "title": "The value of the field when no value is provided by the end user or data model.",
+          "description": "The type of this property should match the value of the `type` property defined in the Field. If not, then a type coercion will be tried and if that fails, the value will be set to null.",
+          "oneOf": [
+            {
+              "type": [
+                "string",
+                "number",
+                "boolean"
+              ]
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": [
+                  "string",
+                  "number",
+                  "boolean"
+                ]
+              }
+            }
+          ]
+        },
+        "description": {
+          "type": "string",
+          "title": "Extra description to be shown to the user to aid in form filling experience. It can be rich text. Can be used as help text for a field or a top level description for a Panel"
+        },
+        "displayFormat": {
+          "type": "string",
+          "title": "The format in which the value will be displayed to the user on screen in the field.",
+          "description": "The format in which the value will be displayed to the user on screen in the field. Applicable for date and number types. For example when using a currency field, the currency sign should be shown to the user."
+        },
+        "editFormat": {
+          "type": "string",
+          "title": "The format in which the value will be edited by the user.",
+          "description": "The format in which the value will be edited by the user. Applicable for date and number types. For instance users in Germany would want to interchange decimal (.) and comma (,) when entering numerical values."
+        },
+        "displayValueExpression": {
+          "type": "string",
+          "title": "The json-formula expression which when evaluated will return the value that will be displayed to the user on screen in the field.",
+          "description": "The json-formula expression which when evaluated will return the value that will be displayed to the user on screen in the field. Applicable for date,number, text, email and telephone input fields. For instance users might need to mask certain chars in the input."
+        },
+        "emptyValue": {
+          "type": [
+            "string"
+          ],
+          "title": "The value when user has not entered any value in the field",
+          "description": "Determines what value should be saved when user has not entered any value in the field. Can be one of\n   * null\n   * undefined\n   * \"\" (empty string) (only valid for dataType = string)",
+          "enum": [
+            "null",
+            "undefined",
+            ""
+          ]
+        },
+        "enabled": {
+          "type": "boolean",
+          "title": "whether the field is enabled and takes part in rules, events etc. A disabled field can have calculations and custom events"
+        },
+        "enum": {
+          "title": "A list of options to put restrictions on the possible values of the field",
+          "description": "The type of values in the enum array must match the value of the `type` property defined in the field. For array type fields, the type of element in the In case the `type` property is not defined, then the type of elements in the enum becomes the value of the `type` property. If the value of the `type` property doesn't match with the type of values in the `enum` array, then a type coercion will be made to match the `type` property. If the coercion is not possible, then the value will be set to null",
+          "type": "array",
+          "items": {
+            "type": [
+              "string",
+              "boolean",
+              "number"
+            ]
+          },
+          "uniqueItems": true
+        },
+        "enumNames": {
+          "title": "A user friendly text to display for the possible options to be shown to the end user.",
+          "description": "The length of enum and enumNames array must match. In case the length of enum is greator, then those will be used as display text for the user. If the length of enumNames is greator, those will be discarded. enumNames will be an array of rich text strings.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "events": {
+          "$ref": "./adaptive-form-events.schema.json"
+        },
+        "fieldType": {
+          "title": "Type of widget to show to the user for capturing the data",
+          "description": "It must be one of the types from the list * text-input * number-input * date-input * file-input * drop-down * radio-group * plain-text * checkbox * button * plain-text * panel * multiline-input * panel * image * email * captcha * tel * password * range * color * hidden * url",
+          "enum": [
+            "text-input",
+            "number-input",
+            "date-input",
+            "file-input",
+            "multiline-input",
+            "drop-down",
+            "radio-group",
+            "checkbox-group",
+            "checkbox",
+            "switch",
+            "plain-text",
+            "button",
+            "panel",
+            "image",
+            "email",
+            "captcha",
+            "tel",
+            "password",
+            "range",
+            "color",
+            "hidden",
+            "url"
+          ]
+        },
+        "label": {
+          "$ref": "./adaptive-form-label.schema.json"
+        },
+        "lang": {
+          "type": "string",
+          "title": "The language to use for formatting the field.",
+          "description": "The language needs to be defined as per the [BCP 47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) tag"
+        },
+        "dataLayer": {
+          "$ref": "./adaptive-form-data-layer.schema.json"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name of the element. It is also the key in the JSON data, if dataRef is not defined explicitly, that the form produces. If two fields/panels under a same panel have the same name, their values will be same"
+        },
+        "placeholder": {
+          "type": "string",
+          "title": "The placeholder to show on the widget."
+        },
+        "properties": {
+          "title": "An object containing custom properties that can be modified via rules as well.",
+          "type": "object",
+          "properties": {
+            "fd:dor": {
+              "$ref": "./adaptive-form-dor-properties.schema.json"
+            }
+          },
+          "additionalProperties": true
+        },
+        "readOnly": {
+          "type": "boolean",
+          "title": "whether the field should be readOnly to author or not",
+          "description": "Determines how an element is treated: 'readOnly=true' means it cannot be modified by user. It will participate in all the events."
+        },
+        "richText": {
+          "type": "boolean",
+          "description": "whether the content of the text to be treated as rich text or not"
+        },
+        "rules": {
+          "type": "object",
+          "title": "Rules that modify the property of the object dynamically",
+          "description": "An author can dynamically change any property that is defined in the spec as modifiable. The rules are evaluated whenever the dependency changes. Apart from properties defined on the field, rules can have an extra key `value` which auto computes the value of the field",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "propertyNames": {
+            "not": {
+              "enum": [
+                "name",
+                "default",
+                "type",
+                "fieldType",
+                "items",
+                "displayFormat",
+                "editFormat",
+                "rules",
+                "events",
+                "props"
+              ]
+            }
+          },
+          "examples": [
+            {
+              "rules": {
+                "required": "$form.maritalStatus.value == 'married'"
+              }
+            },
+            {
+              "lastName": {
+                "name": "lastName",
+                "rules": {
+                  "value": "$form.firstName.value & ' ' & $form.lastName.value"
+                }
+              }
+            }
+          ]
+        },
+        "screenReaderText": {
+          "type": "string",
+          "title": "a string to indicate the text to be read by screen readers"
+        },
+        "tooltip": {
+          "type": "string",
+          "title": "Tooltip of the form element"
+        },
+        "visible": {
+          "type": "boolean",
+          "title": "whether the field should be visible to author or not"
+        },
+        "id": {
+          "type": "string",
+          "title": "unique identifier for a form element"
+        },
+        "items": {
+          "title": "Fields/Panels inside a Panel",
+          "description": "If the Fields inside a panel are repeatable then the items should be an array containing only 1 field",
+          "type": "array",
+          "errorMessage": {
+            "oneOf": "Items must be an array with atleast 1 field"
+          }
+        },
+        "repeatable": {
+          "type": "boolean",
+          "title": "whether the field/panel should be repeatable or not",
+          "description": "If the property is present on a field, then the data would be generated as an array depending upon the type property on the field and if the property is present on a panel then the data would be an array of object/array depending upon the value of the type property. If the type is object, then items must have a name property. If type is array, then name property in the items would be ignored."
+        },
+        ":items": {
+          "title": "Fields/Panels inside a Panel",
+          "description": "If the Fields inside a panel are repeatable then the items should be an array containing only 1 field",
+          "type": "object",
+          "errorMessage": {
+            "oneOf": "Items must be an object with atleast 1 field"
+          }
+        },
+        ":itemsOrder": {
+          "title": "Order of Fields/Panels inside a Panel",
+          "description": "Order of items in the object specified by :items",
+          "type": "array",
+          "errorMessage": {
+            "oneOf": "Items Order must be an array with atleast 1 field"
+          },
+          "examples": [
+            {
+              ":itemsOrder": [
+                "firstName",
+                "lastName"
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/bundles/af-core/src/test/resources/schema/0.14.2/adaptive-form-property-restrictions.schema.json
+++ b/bundles/af-core/src/test/resources/schema/0.14.2/adaptive-form-property-restrictions.schema.json
@@ -1,0 +1,396 @@
+{
+  "$id": "classpath:/schema/0.14.2/adaptive-form-property-restrictions.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$defs": {
+    "Date": {
+      "title": "property with type date",
+      "type": "string",
+      "format": "date"
+    },
+    "DateField": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "string",
+            "string[]"
+          ]
+        },
+        "format": {
+          "const": "date"
+        }
+      },
+      "required": [
+        "type",
+        "format"
+      ]
+    },
+    "NumberField": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "number",
+            "number[]"
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "DateOrNumberField": {
+      "type": "object",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/NumberField"
+        },
+        {
+          "$ref": "#/$defs/DateField"
+        }
+      ]
+    },
+    "StringTypeField": {
+      "title": "field having type string",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "string",
+            "string[]"
+          ]
+        }
+      }
+    },
+    "FileTypeField": {
+      "title": "field with type file having format as data-url or binary",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "string",
+            "string[]"
+          ]
+        },
+        "format": {
+          "enum": [
+            "binary",
+            "data-url"
+          ]
+        }
+      }
+    },
+    "OptimizedFileTypeField": {
+      "title": "field having type file",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "file",
+            "file[]"
+          ]
+        }
+      }
+    }
+  },
+  "title": "The schema defines constraints on which Headless Adaptive Form properties can be used together",
+  "allOf": [
+    {
+      "title": "minimum constraint is valid only for numeric or date types",
+      "type": "object",
+      "dependencies": {
+        "minimum": {
+          "oneOf": [
+            {
+              "allOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "minimum": {
+                      "type": "number"
+                    }
+                  }
+                },
+                {
+                  "$ref": "#/$defs/NumberField"
+                }
+              ]
+            },
+            {
+              "allOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "minimum": {
+                      "$ref": "#/$defs/Date"
+                    }
+                  }
+                },
+                {
+                  "$ref": "#/$defs/DateField"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "errorMessage": "minimum constraint is valid only for numeric or date types"
+    },
+    {
+      "title": "exclusiveMinimum constraint is valid only for numeric or date types",
+      "type": "object",
+      "dependencies": {
+        "exclusiveMinimum": {
+          "oneOf": [
+            {
+              "allOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "exclusiveMinimum": {
+                      "type": "number"
+                    }
+                  }
+                },
+                {
+                  "$ref": "#/$defs/NumberField"
+                }
+              ]
+            },
+            {
+              "allOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "exclusiveMinimum": {
+                      "$ref": "#/$defs/Date"
+                    }
+                  }
+                },
+                {
+                  "$ref": "#/$defs/DateField"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "errorMessage": "exclusiveMinimum constraint is valid only for numeric or date types"
+    },
+    {
+      "title": "maximum constraint is valid only for numeric or date types",
+      "type": "object",
+      "dependencies": {
+        "maximum": {
+          "oneOf": [
+            {
+              "allOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "maximum": {
+                      "type": "number"
+                    }
+                  }
+                },
+                {
+                  "$ref": "#/$defs/NumberField"
+                }
+              ]
+            },
+            {
+              "allOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "maximum": {
+                      "$ref": "#/$defs/Date"
+                    }
+                  }
+                },
+                {
+                  "$ref": "#/$defs/DateField"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "errorMessage": "maximum constraint is valid only for numeric or date types"
+    },
+    {
+      "title": "exclusiveMaximum constraint is valid only for numeric or date types",
+      "type": "object",
+      "dependencies": {
+        "exclusiveMinimum": {
+          "oneOf": [
+            {
+              "allOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "exclusiveMinimum": {
+                      "type": "number"
+                    }
+                  }
+                },
+                {
+                  "$ref": "#/$defs/NumberField"
+                }
+              ]
+            },
+            {
+              "allOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "exclusiveMinimum": {
+                      "$ref": "#/$defs/Date"
+                    }
+                  }
+                },
+                {
+                  "$ref": "#/$defs/DateField"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "errorMessage": "exclusiveMaximum constraint is valid only for numeric or date types"
+    },
+    {
+      "title": "step constraint is valid only for number type or date types",
+      "type": "object",
+      "dependencies": {
+        "step": {
+          "$ref": "#/$defs/DateOrNumberField"
+        }
+      },
+      "errorMessage": "step constraint is valid only for date and number type"
+    },
+    {
+      "title": "format, pattern, minLength and maxLength constraint are valid only for fields with type string",
+      "type": "object",
+      "dependencies": {
+        "format": {
+          "$ref": "#/$defs/StringTypeField"
+        },
+        "pattern": {
+          "$ref": "#/$defs/StringTypeField"
+        },
+        "minLength": {
+          "$ref": "#/$defs/StringTypeField"
+        },
+        "maxLength": {
+          "$ref": "#/$defs/StringTypeField"
+        }
+      },
+      "errorMessage": "format, pattern, minLength and maxLength constraint are valid only for fields with type string"
+    },
+    {
+      "title": "enforceEnum is valid only if enum property is defined",
+      "type": "object",
+      "dependencies": {
+        "enforceEnum": {
+          "type": "object",
+          "required": [
+            "enum"
+          ]
+        }
+      },
+      "errorMessage": "enforceEnum is valid only if enum property is defined"
+    },
+    {
+      "title": "minItems, maxItems, uniqueItems are valid only for type array",
+      "type": "object",
+      "dependencies": {
+        "minItems": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": [
+                "array",
+                "string[]",
+                "boolean[]",
+                "number[]",
+                "file[]"
+              ]
+            }
+          }
+        },
+        "maxItems": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": [
+                "array",
+                "string[]",
+                "boolean[]",
+                "number[]",
+                "file[]"
+              ]
+            }
+          }
+        },
+        "uniqueItems": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": [
+                "array",
+                "string[]",
+                "boolean[]",
+                "number[]",
+                "file[]"
+              ]
+            }
+          }
+        }
+      },
+      "errorMessage": "minItems, maxItems are valid only for type array"
+    },
+    {
+      "title": "maxFileSize, accept are valid only for file types",
+      "type": "object",
+      "dependencies": {
+        "maxFileSize": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/OptimizedFileTypeField"
+            },
+            {
+              "$ref": "#/$defs/FileTypeField"
+            }
+          ]
+        },
+        "accept": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/OptimizedFileTypeField"
+            },
+            {
+              "$ref": "#/$defs/FileTypeField"
+            }
+          ]
+        }
+      },
+      "errorMessage": "maxFileSize, accept are valid only for file types"
+    },
+    {
+      "title": "editFormat, displayFormat, dataFormat are valid only for fields with type date or number",
+      "type": "object",
+      "dependencies": {
+        "editFormat": {
+          "$ref": "#/$defs/DateOrNumberField"
+        },
+        "displayFormat": {
+          "$ref": "#/$defs/DateOrNumberField"
+        },
+        "dataFormat": {
+          "$ref": "#/$defs/DateOrNumberField"
+        }
+      }
+    }
+  ]
+}

--- a/bundles/af-core/src/test/resources/schema/0.14.2/adaptive-form-sign-properties.schema.json
+++ b/bundles/af-core/src/test/resources/schema/0.14.2/adaptive-form-sign-properties.schema.json
@@ -1,0 +1,25 @@
+{
+  "$id": "classpath:/schema/0.14.2/adaptive-form-sign-properties.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "firstSignerFormFiller": {
+      "title": "First Signer Form Filler",
+      "description": "Specifies whether the signer is the first form filler.",
+      "type": "boolean"
+    },
+    "workflowType": {
+      "title": "Workflow Type",
+      "enum": [
+        "SEQUENTIAL",
+        "PARALLEL"
+      ],
+      "description": "Specifies the type of workflow for the sign.",
+      "type": "string"
+    },
+    "signers": {
+      "$ref": "./adaptive-form-signer-properties.schema.json"
+    }
+  }
+}

--- a/bundles/af-core/src/test/resources/schema/0.14.2/adaptive-form-signer-properties.schema.json
+++ b/bundles/af-core/src/test/resources/schema/0.14.2/adaptive-form-signer-properties.schema.json
@@ -1,0 +1,83 @@
+{
+  "$id": "classpath:/schema/0.14.2/adaptive-form-signer-properties.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Signers Information",
+  "description": "Represents information about signers.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "signerTitle": {
+      "title": "Signer Title",
+      "description": "The title or name of the signer.",
+      "type": "string"
+    },
+    "email": {
+      "title": "Email Information",
+      "description": "Information about the signer's email address.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "title": "Email Type",
+          "description": "Indicates whether the email value is sourced from form data or form configuration.",
+          "type": "string",
+          "enum": [
+            "data",
+            "form"
+          ]
+        },
+        "value": {
+          "title": "Email Address",
+          "description": "The email address value.",
+          "type": "string"
+        }
+      }
+    },
+    "countryCode": {
+      "title": "Country Code",
+      "description": "Information about the country code for the phone number.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "title": "Country Code Type",
+          "description": "Indicates whether the country code value is sourced from form data or form configuration.",
+          "type": "string",
+          "enum": [
+            "data",
+            "form"
+          ]
+        },
+        "value": {
+          "title": "Country Code Value",
+          "description": "The country code value.",
+          "type": "string"
+        }
+      }
+    },
+    "phone": {
+      "title": "Phone Number",
+      "description": "Information about the signer's phone number.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "title": "Phone Number Type",
+          "description": "Indicates whether the phone number value is sourced from form data or form configuration.",
+          "type": "string",
+          "enum": [
+            "data",
+            "form"
+          ]
+        },
+        "value": {
+          "title": "Phone Number Value",
+          "description": "The phone number value.",
+          "type": "string"
+        }
+      }
+    },
+    "securityOption": {
+      "title": "Security Option",
+      "description": "Specifies the security option for the signer.",
+      "type": "string"
+    }
+  }
+}

--- a/bundles/af-core/src/test/resources/schema/0.14.2/adaptive-form.schema.json
+++ b/bundles/af-core/src/test/resources/schema/0.14.2/adaptive-form.schema.json
@@ -1,0 +1,1441 @@
+{
+  "$id": "classpath:/schema/0.14.2/adaptive-form.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$defs": {
+    "FormElement": {
+      "allOf": [
+        {
+          "$ref": "./adaptive-form-properties.schema.json"
+        },
+        {
+          "$ref": "./adaptive-form-data-constraints.schema.json"
+        },
+        {
+          "$ref": "./adaptive-form-property-restrictions.schema.json"
+        }
+      ]
+    },
+    "TextField": {
+      "if": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "enum": [
+              "text-input",
+              "multiline-input"
+            ]
+          }
+        },
+        "required": [
+          "fieldType"
+        ]
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "enum": [
+              "text-input",
+              "multiline-input"
+            ]
+          },
+          "rules": {
+            "type": "object",
+            "propertyNames": {
+              "enum": [
+                "description",
+                "enabled",
+                "enum",
+                "enumNames",
+                "label",
+                "properties",
+                "readOnly",
+                "required",
+                "value",
+                "visible"
+              ]
+            }
+          }
+        },
+        "propertyNames": {
+          "enum": [
+            ":type",
+            "appliedCssClassNames",
+            "autocomplete",
+            "constraintMessages",
+            "dataFormat",
+            "dataLayer",
+            "dataRef",
+            "default",
+            "description",
+            "displayFormat",
+            "displayValueExpression",
+            "editFormat",
+            "emptyValue",
+            "enforceEnum",
+            "enabled",
+            "enum",
+            "enumNames",
+            "events",
+            "exclusiveMaximum",
+            "exclusiveMinimum",
+            "fieldType",
+            "format",
+            "id",
+            "label",
+            "lang",
+            "maximum",
+            "maxLength",
+            "minimum",
+            "minLength",
+            "name",
+            "pattern",
+            "placeholder",
+            "properties",
+            "readOnly",
+            "required",
+            "rules",
+            "screenReaderText",
+            "type",
+            "tooltip",
+            "validationExpression",
+            "visible"
+          ],
+          "errorMessage": {
+            "enum": "${0} property is not allowed in text-input"
+          }
+        },
+        "errorMessage": {
+          "properties": {
+            "fieldType": "${0/fieldType} is not a valid TextField field type. It should be text-input"
+          }
+        }
+      }
+    },
+    "NumberField": {
+      "if": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "const": "number-input"
+          }
+        },
+        "required": [
+          "fieldType"
+        ]
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "enum": [
+              "number",
+              "integer"
+            ]
+          },
+          "fieldType": {
+            "const": "number-input"
+          },
+          "rules": {
+            "type": "object",
+            "propertyNames": {
+              "enum": [
+                "description",
+                "enabled",
+                "enum",
+                "enumNames",
+                "label",
+                "maximum",
+                "minimum",
+                "properties",
+                "readOnly",
+                "required",
+                "value",
+                "visible"
+              ]
+            }
+          }
+        },
+        "propertyNames": {
+          "enum": [
+            ":type",
+            "appliedCssClassNames",
+            "autocomplete",
+            "constraintMessages",
+            "dataFormat",
+            "dataLayer",
+            "dataRef",
+            "default",
+            "description",
+            "displayFormat",
+            "displayValueExpression",
+            "editFormat",
+            "enabled",
+            "enforceEnum",
+            "enum",
+            "enumNames",
+            "events",
+            "exclusiveMaximum",
+            "exclusiveMinimum",
+            "fieldType",
+            "id",
+            "label",
+            "lang",
+            "maximum",
+            "maxLength",
+            "minimum",
+            "minLength",
+            "name",
+            "pattern",
+            "placeholder",
+            "properties",
+            "readOnly",
+            "required",
+            "rules",
+            "screenReaderText",
+            "step",
+            "type",
+            "tooltip",
+            "validationExpression",
+            "visible"
+          ],
+          "errorMessage": {
+            "enum": "${0} property is not allowed in NumberField"
+          }
+        }
+      }
+    },
+    "SwitchField": {
+      "if": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "enum": [
+              "switch",
+              "checkbox"
+            ]
+          }
+        },
+        "required": [
+          "fieldType"
+        ]
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "enum": [
+              "switch",
+              "checkbox"
+            ]
+          },
+          "enum": {
+            "type": "array",
+            "maxItems": 2
+          },
+          "rules": {
+            "type": "object",
+            "propertyNames": {
+              "enum": [
+                "description",
+                "enabled",
+                "enum",
+                "enumNames",
+                "label",
+                "checked",
+                "properties",
+                "readOnly",
+                "required",
+                "value",
+                "visible"
+              ]
+            }
+          }
+        },
+        "propertyNames": {
+          "enum": [
+            ":type",
+            "appliedCssClassNames",
+            "checked",
+            "constraintMessages",
+            "dataFormat",
+            "dataLayer",
+            "dataRef",
+            "default",
+            "description",
+            "enabled",
+            "enforceEnum",
+            "enum",
+            "enumNames",
+            "events",
+            "fieldType",
+            "id",
+            "label",
+            "name",
+            "properties",
+            "readOnly",
+            "required",
+            "rules",
+            "screenReaderText",
+            "tooltip",
+            "type",
+            "validationExpression",
+            "visible"
+          ],
+          "errorMessage": {
+            "enum": "${0} property is not allowed in SwitchField"
+          }
+        },
+        "errorMessage": {
+          "properties": {
+            "fieldType": "${0/fieldType} is not a valid SwitchField field type. It should be either switch or checkbox"
+          }
+        },
+        "anyOf": [
+          {
+            "type": "object",
+            "required": [
+              "enum"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "const": "boolean"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          }
+        ]
+      }
+    },
+    "DateField": {
+      "if": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "const": "date-input"
+          }
+        },
+        "required": [
+          "fieldType"
+        ]
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "const": "date-input"
+          },
+          "type": {
+            "const": "string"
+          },
+          "format": {
+            "const": "date"
+          },
+          "rules": {
+            "type": "object",
+            "propertyNames": {
+              "enum": [
+                "description",
+                "enabled",
+                "enum",
+                "enumNames",
+                "label",
+                "maximum",
+                "minimum",
+                "properties",
+                "readOnly",
+                "required",
+                "value",
+                "visible"
+              ]
+            }
+          }
+        },
+        "propertyNames": {
+          "enum": [
+            ":type",
+            "appliedCssClassNames",
+            "constraintMessages",
+            "dataFormat",
+            "dataLayer",
+            "dataRef",
+            "default",
+            "description",
+            "displayFormat",
+            "displayValueExpression",
+            "editFormat",
+            "enabled",
+            "enforceEnum",
+            "enum",
+            "enumNames",
+            "events",
+            "exclusiveMaximum",
+            "exclusiveMinimum",
+            "fieldType",
+            "format",
+            "id",
+            "label",
+            "lang",
+            "maximum",
+            "minimum",
+            "name",
+            "placeholder",
+            "properties",
+            "readOnly",
+            "required",
+            "rules",
+            "screenReaderText",
+            "step",
+            "tooltip",
+            "type",
+            "validationExpression",
+            "visible"
+          ],
+          "errorMessage": {
+            "enum": "${0} property is not allowed in DateField"
+          }
+        },
+        "errorMessage": {
+          "properties": {
+            "fieldType": "${0/fieldType} is not a valid DateField field type. It should be date-input"
+          }
+        }
+      }
+    },
+    "EmailField": {
+      "if": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "const": "email"
+          }
+        },
+        "required": [
+          "fieldType"
+        ]
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "const": "email"
+          },
+          "type": {
+            "const": "string"
+          },
+          "format": {
+            "const": "email"
+          },
+          "rules": {
+            "type": "object",
+            "propertyNames": {
+              "enum": [
+                "description",
+                "enabled",
+                "enum",
+                "enumNames",
+                "label",
+                "maximum",
+                "minimum",
+                "properties",
+                "readOnly",
+                "required",
+                "value",
+                "visible"
+              ]
+            }
+          }
+        },
+        "propertyNames": {
+          "enum": [
+            ":type",
+            "appliedCssClassNames",
+            "constraintMessages",
+            "dataLayer",
+            "dataRef",
+            "default",
+            "description",
+            "enabled",
+            "enforceEnum",
+            "enum",
+            "enumNames",
+            "events",
+            "fieldType",
+            "id",
+            "label",
+            "maxItems",
+            "minItems",
+            "name",
+            "placeholder",
+            "properties",
+            "readOnly",
+            "required",
+            "rules",
+            "screenReaderText",
+            "tooltip",
+            "type",
+            "uniqueItems",
+            "validationExpression",
+            "visible"
+          ],
+          "errorMessage": {
+            "enum": "${0} property is not allowed in EmailFIeld"
+          }
+        },
+        "errorMessage": {
+          "properties": {
+            "fieldType": "${0/fieldType} is not a valid EmailField field type. It should be email"
+          }
+        }
+      }
+    },
+    "SelectionField": {
+      "if": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "enum": [
+              "drop-down",
+              "checkbox-group"
+            ]
+          }
+        },
+        "required": [
+          "fieldType"
+        ]
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "enum": [
+              "drop-down",
+              "checkbox-group"
+            ]
+          },
+          "type": {
+            "enum": [
+              "string",
+              "number",
+              "boolean",
+              "string[]",
+              "number[]",
+              "boolean[]"
+            ]
+          },
+          "rules": {
+            "type": "object",
+            "propertyNames": {
+              "enum": [
+                "description",
+                "enabled",
+                "enum",
+                "enumNames",
+                "label",
+                "properties",
+                "readOnly",
+                "required",
+                "value",
+                "visible"
+              ]
+            }
+          }
+        },
+        "propertyNames": {
+          "enum": [
+            ":type",
+            "appliedCssClassNames",
+            "constraintMessages",
+            "dataLayer",
+            "dataRef",
+            "default",
+            "description",
+            "enabled",
+            "enforceEnum",
+            "enum",
+            "enumNames",
+            "events",
+            "fieldType",
+            "id",
+            "label",
+            "maxItems",
+            "minItems",
+            "name",
+            "placeholder",
+            "properties",
+            "readOnly",
+            "required",
+            "rules",
+            "screenReaderText",
+            "tooltip",
+            "type",
+            "uniqueItems",
+            "validationExpression",
+            "visible"
+          ],
+          "errorMessage": {
+            "enum": "${0} property is not allowed in SelectionField"
+          }
+        },
+        "required": [
+          "enum"
+        ],
+        "errorMessage": {
+          "required": {
+            "enum": "Options are missing from selection. Add an empty enum array"
+          },
+          "properties": {
+            "fieldType": "${0/fieldType} is not a valid SelectionField field type. It should be either drop-down or checkbox-group"
+          }
+        }
+      }
+    },
+    "RadioGroupField": {
+      "if": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "const": "radio-group"
+          }
+        },
+        "required": [
+          "fieldType"
+        ]
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "const": "radio-group"
+          },
+          "type": {
+            "enum": [
+              "string",
+              "number",
+              "boolean"
+            ]
+          },
+          "rules": {
+            "type": "object",
+            "propertyNames": {
+              "enum": [
+                "description",
+                "enabled",
+                "enum",
+                "enumNames",
+                "label",
+                "properties",
+                "readOnly",
+                "required",
+                "value",
+                "visible"
+              ]
+            }
+          }
+        },
+        "propertyNames": {
+          "enum": [
+            ":type",
+            "appliedCssClassNames",
+            "constraintMessages",
+            "dataLayer",
+            "dataRef",
+            "default",
+            "description",
+            "enabled",
+            "enforceEnum",
+            "enum",
+            "enumNames",
+            "events",
+            "fieldType",
+            "id",
+            "label",
+            "name",
+            "placeholder",
+            "properties",
+            "readOnly",
+            "required",
+            "rules",
+            "screenReaderText",
+            "tooltip",
+            "type",
+            "validationExpression",
+            "visible"
+          ],
+          "errorMessage": {
+            "enum": "${0} property is not allowed in RadioGroupField"
+          }
+        },
+        "required": [
+          "enum"
+        ],
+        "errorMessage": {
+          "properties": {
+            "fieldType": "${0/fieldType} is not a valid radio group field type. It should be radio-group"
+          }
+        }
+      }
+    },
+    "FileField": {
+      "if": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "const": "file-input"
+          }
+        },
+        "required": [
+          "fieldType"
+        ]
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "enum": [
+              "file-input"
+            ]
+          },
+          "rules": {
+            "type": "object",
+            "propertyNames": {
+              "enum": [
+                "description",
+                "enabled",
+                "enum",
+                "enumNames",
+                "label",
+                "properties",
+                "readOnly",
+                "required",
+                "value",
+                "visible"
+              ]
+            }
+          }
+        },
+        "propertyNames": {
+          "enum": [
+            ":type",
+            "accept",
+            "appliedCssClassNames",
+            "constraintMessages",
+            "dataLayer",
+            "dataRef",
+            "default",
+            "description",
+            "enabled",
+            "enum",
+            "enumNames",
+            "events",
+            "fieldType",
+            "format",
+            "id",
+            "label",
+            "maxFileSize",
+            "maxItems",
+            "minItems",
+            "name",
+            "placeholder",
+            "properties",
+            "readOnly",
+            "required",
+            "rules",
+            "screenReaderText",
+            "tooltip",
+            "type",
+            "uniqueItems",
+            "validationExpression",
+            "visible"
+          ],
+          "errorMessage": {
+            "enum": "${0} property is not allowed in file-input"
+          }
+        }
+      }
+    },
+    "Button": {
+      "title": "Clickable Button Field",
+      "if": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "enum": [
+              "button"
+            ]
+          }
+        },
+        "required": [
+          "fieldType"
+        ]
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "const": "button"
+          },
+          "rules": {
+            "type": "object",
+            "propertyNames": {
+              "enum": [
+                "description",
+                "enabled",
+                "label",
+                "properties",
+                "value",
+                "visible"
+              ]
+            }
+          }
+        },
+        "propertyNames": {
+          "enum": [
+            ":type",
+            "appliedCssClassNames",
+            "dataLayer",
+            "dataRef",
+            "description",
+            "enabled",
+            "events",
+            "fieldType",
+            "id",
+            "label",
+            "name",
+            "properties",
+            "rules",
+            "screenReaderText",
+            "tooltip",
+            "visible"
+          ],
+          "errorMessage": {
+            "enum": "${0} property is not allowed in Button"
+          }
+        }
+      }
+    },
+    "StaticField": {
+      "title": "Static Field represents the Field that do not capture value from the user but can be",
+      "if": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "enum": [
+              "plain-text"
+            ]
+          }
+        },
+        "required": [
+          "fieldType"
+        ]
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "enum": [
+              "plain-text"
+            ]
+          },
+          "rules": {
+            "type": "object",
+            "propertyNames": {
+              "enum": [
+                "properties",
+                "value",
+                "visible"
+              ]
+            }
+          }
+        },
+        "propertyNames": {
+          "enum": [
+            ":type",
+            "appliedCssClassNames",
+            "dataLayer",
+            "dataRef",
+            "events",
+            "fieldType",
+            "id",
+            "name",
+            "properties",
+            "richText",
+            "rules",
+            "value",
+            "visible"
+          ],
+          "errorMessage": {
+            "enum": "${0} property is not allowed in StaticField"
+          }
+        }
+      }
+    },
+    "Image": {
+      "title": "Image Component",
+      "if": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "enum": [
+              "image"
+            ]
+          }
+        },
+        "required": [
+          "fieldType"
+        ]
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "enum": [
+              "image"
+            ]
+          },
+          "rules": {
+            "type": "object",
+            "propertyNames": {
+              "enum": [
+                "altText",
+                "description",
+                "properties",
+                "value",
+                "visible"
+              ]
+            }
+          }
+        },
+        "propertyNames": {
+          "enum": [
+            ":type",
+            "altText",
+            "appliedCssClassNames",
+            "dataLayer",
+            "dataRef",
+            "description",
+            "events",
+            "fieldType",
+            "id",
+            "name",
+            "properties",
+            "rules",
+            "value",
+            "visible"
+          ],
+          "errorMessage": {
+            "enum": "${0} property is not allowed in Image"
+          }
+        }
+      }
+    },
+    "Panel": {
+      "if": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "const": "panel"
+          }
+        },
+        "required": [
+          "fieldType"
+        ]
+      },
+      "then": {
+        "allOf": [
+          {
+            "$ref": "#/$defs/Container"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "fieldType": {
+                "enum": [
+                  "panel"
+                ]
+              },
+              "type": {
+                "enum": [
+                  "object",
+                  "array"
+                ]
+              },
+              "rules": {
+                "type": "object",
+                "propertyNames": {
+                  "enum": [
+                    "description",
+                    "enabled",
+                    "label",
+                    "maxItems",
+                    "minItems",
+                    "maxOccur",
+                    "minOccur",
+                    "repeatable",
+                    "properties",
+                    "required",
+                    "value",
+                    "visible"
+                  ]
+                }
+              }
+            },
+            "propertyNames": {
+              "enum": [
+                ":type",
+                ":items",
+                ":itemsOrder",
+                "allowedComponents",
+                "appliedCssClassNames",
+                "columnClassNames",
+                "columnCount",
+                "constraintMessages",
+                "dataLayer",
+                "dataRef",
+                "description",
+                "enabled",
+                "events",
+                "fieldType",
+                "id",
+                "items",
+                "label",
+                "lang",
+                "maxItems",
+                "maxOccur",
+                "minItems",
+                "minOccur",
+                "name",
+                "properties",
+                "readOnly",
+                "repeatable",
+                "required",
+                "rules",
+                "screenReaderText",
+                "tooltip",
+                "type",
+                "uniqueItems",
+                "validationExpression",
+                "visible"
+              ],
+              "errorMessage": {
+                "enum": "${0} property is not allowed in Panel"
+              }
+            },
+            "anyOf": [
+              {
+                "required": [
+                  "items"
+                ]
+              },
+              {
+                "required": [
+                  ":items",
+                  ":itemsOrder"
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "Captcha": {
+      "title": "Captcha Component",
+      "if": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "enum": [
+              "captcha"
+            ]
+          }
+        },
+        "required": [
+          "fieldType"
+        ]
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "fieldType": {
+            "enum": [
+              "captcha"
+            ]
+          }
+        },
+        "propertyNames": {
+          "enum": [
+            ":type",
+            "appliedCssClassNames",
+            "dataLayer",
+            "description",
+            "enabled",
+            "events",
+            "fieldType",
+            "id",
+            "label",
+            "name",
+            "properties",
+            "readOnly",
+            "required",
+            "tooltip",
+            "type",
+            "validationExpression",
+            "visible",
+            "captchaDisplayMode",
+            "captchaProvider",
+            "captchaSiteKey"
+          ],
+          "errorMessage": {
+            "enum": "${0} property is not allowed in Captcha"
+          }
+        }
+      }
+    },
+    "CustomElement": {
+      "if": {
+        "allOf": [
+          {
+            "type": "object",
+            "not": {
+              "required": [
+                "fieldType"
+              ]
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              ":type"
+            ]
+          }
+        ]
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          ":type": {
+            "type": "string"
+          },
+          ":itemsOrder": {
+            "$ref": "#/$defs/ColonItemsOrder"
+          },
+          ":items": {
+            "$ref": "#/$defs/ColonItems"
+          }
+        },
+        "required": [
+          ":type"
+        ],
+        "additionalProperties": true,
+        "dependencies": {
+          ":items": {
+            "type": "object",
+            "required": [
+              ":type",
+              ":itemsOrder"
+            ]
+          }
+        }
+      }
+    },
+    "Child": {
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "type": "object",
+              "required": [
+                "fieldType"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                ":type"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "enum"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "items"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                ":items",
+                ":itemsOrder"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FormElement"
+            },
+            {
+              "$ref": "#/$defs/FileField"
+            },
+            {
+              "$ref": "#/$defs/NumberField"
+            },
+            {
+              "$ref": "#/$defs/DateField"
+            },
+            {
+              "$ref": "#/$defs/EmailField"
+            },
+            {
+              "$ref": "#/$defs/SwitchField"
+            },
+            {
+              "$ref": "#/$defs/SelectionField"
+            },
+            {
+              "$ref": "#/$defs/RadioGroupField"
+            },
+            {
+              "$ref": "#/$defs/TextField"
+            },
+            {
+              "$ref": "#/$defs/Panel"
+            },
+            {
+              "$ref": "#/$defs/Button"
+            },
+            {
+              "$ref": "#/$defs/StaticField"
+            },
+            {
+              "$ref": "#/$defs/Image"
+            },
+            {
+              "$ref": "#/$defs/Captcha"
+            },
+            {
+              "$ref": "#/$defs/CustomElement"
+            }
+          ]
+        }
+      ],
+      "errorMessage": "Object doesn't match any field type"
+    },
+    "Items": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Child"
+      }
+    },
+    "ColonItems": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/Child"
+      }
+    },
+    "ColonItemsOrder": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "Container": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "$ref": "#/$defs/Items"
+        },
+        ":items": {
+          "$ref": "#/$defs/ColonItems"
+        },
+        ":itemsOrder": {
+          "$ref": "#/$defs/ColonItemsOrder"
+        },
+        "anyOf": [
+          {
+            "required": [
+              "items"
+            ]
+          },
+          {
+            "required": [
+              ":items",
+              ":itemsOrder"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "./adaptive-form-aem-responsive-grid-properties.schema.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object"
+        },
+        "events": {
+          "type": "object",
+          "propertyNames": {
+            "anyOf": [
+              {
+                "enum": [
+                  "submit",
+                  "reset",
+                  "initialize"
+                ]
+              },
+              {
+                "pattern": "custom:[a-zA-Z0-9]+"
+              }
+            ]
+          }
+        },
+        ":type": {
+          "type": "string",
+          "title": "A hint to the rendering engine for rendering custom components."
+        },
+        "action": {
+          "title": "URL indicating the endpoint where the data would be submitted when submit event is triggered",
+          "type": "string"
+        },
+        "adaptiveform": {
+          "anyOf": [
+            {
+              "const": "0.11.0-Pre"
+            },
+            {
+              "const": "0.12.0"
+            },
+            {
+              "const": "0.12.1"
+            },
+            {
+              "const": "0.12.5"
+            },
+            {
+              "const": "0.13.0"
+            },
+            {
+              "const": "0.14.0"
+            },
+            {
+              "const": "0.14.1"
+            },
+            {
+              "const": "0.14.2"
+            }
+          ]
+        },
+        "description": {
+          "type": "string",
+          "title": "A user friendly description of the form"
+        },
+        "fieldType": {
+          "const": "form"
+        },
+        "id": {
+          "type": "string",
+          "title": "unique identifier for a form element"
+        },
+        "items": {
+          "$ref": "#/$defs/Items"
+        },
+        ":items": {
+          "$ref": "#/$defs/ColonItems"
+        },
+        ":itemsOrder": {
+          "$ref": "#/$defs/ColonItemsOrder"
+        },
+        "lang": {
+          "type": "string",
+          "title": "The language in which the Form was authored.",
+          "description": "The language needs to be defined as per the [BCP 47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) tag"
+        },
+        "metadata": {
+          "type": "object",
+          "properties": {
+            "version": {
+              "type": "string"
+            },
+            "grammar": {
+              "const": "json-formula-1.0.0"
+            },
+            "formattingLanguage": {
+              "const": "xfa-picture-clause"
+            }
+          },
+          "required": [
+            "version"
+          ]
+        },
+        "properties": {
+          "title": "An object containing custom properties that can be modified via rules as well.",
+          "type": "object",
+          "properties": {
+            "fd:dor": {
+              "$ref": "./adaptive-form-container-dor-properties.schema.json"
+            },
+            "fd:signerInfo": {
+              "$ref": "./adaptive-form-sign-properties.schema.json"
+            }
+          },
+          "additionalProperties": true
+        },
+        "rules": {
+          "type": "object",
+          "propertyNames": {
+            "enum": [
+              "properties"
+            ]
+          }
+        },
+        "title": {
+          "type": "string",
+          "maxLength": 140,
+          "title": "A user friendly one line title for the form"
+        }
+      }
+    }
+  ],
+  "anyOf": [
+    {
+      "required": [
+        "metadata",
+        "items",
+        "adaptiveform",
+        "fieldType"
+      ]
+    },
+    {
+      "required": [
+        "metadata",
+        ":items",
+        ":itemsOrder",
+        "adaptiveform",
+        "fieldType"
+      ]
+    }
+  ]
+}

--- a/bundles/af-core/src/test/resources/schema/0.14.2/form.json
+++ b/bundles/af-core/src/test/resources/schema/0.14.2/form.json
@@ -1,0 +1,14 @@
+{
+  "items": [
+  ],
+  "fieldType" : "form",
+  "metadata": {
+    "action": "/a/b",
+    "dataUrl": "/c/d",
+    "locale": "en-us",
+    "grammar": "json-formula-1.0.0",
+    "version": "1.0.0"
+  },
+  "adaptiveform":"0.14.2",
+  ":type": "core/fd/components/form/container/v2/container"
+}

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v2/container/_cq_dialog/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v2/container/_cq_dialog/.content.xml
@@ -83,7 +83,7 @@
                                         sling:resourceType="granite/ui/components/coral/foundation/form/hidden"
                                         ignoreData="{Boolean}true"
                                         name="./specVersion"
-                                        value="0.14.1"/>
+                                        value="0.14.2"/>
                                 </items>
                             </container>
                         </items>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
More standard HTML input types being added to the list of exclusive fieldTypes.
Still defaults to text-input when unrecognised.
<!--- Describe your changes in detail -->

## Related Issue

<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
