### PR TITLE
FORMS-16264: Remove same instantiation of datetimepicker calendar element

### DIFF
--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/datepicker/v1/datepicker/clientlibs/site/js/datepickerwidget.js
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/datepicker/v1/datepicker/clientlibs/site/js/datepickerwidget.js
@@ -181,7 +181,6 @@ if (typeof window.DatePickerWidget === 'undefined') {
       }
       html += this.#clearButtonTemplate;
 
-      this.#dp = document.getElementsByClassName("datetimepicker")[0];
       if (!this.#dp) {
         this.#dp = document.createElement("div");
         this.#dp.classList.add("datetimepicker", "datePickerTarget");

--- a/ui.tests/test-module/specs/datepicker/datepicker.runtime.cy.js
+++ b/ui.tests/test-module/specs/datepicker/datepicker.runtime.cy.js
@@ -355,4 +355,22 @@ describe("Form Runtime with Date Picker", () => {
             })
         })
     });
+
+    it.only("should create and attach an unique datepicker calendar if it doesn't exist", () => {
+        const [datePicker4, datePicker4FieldView] = Object.entries(formContainer._fields)[4];
+        const [datePicker6, datePicker6FieldView] = Object.entries(formContainer._fields)[6];
+        const input = "2023-01-01";
+
+        cy.get(`#${datePicker4}`).find("input").clear().type(input).should('have.value', '2023-01-01').blur();
+        cy.get(`#${datePicker6}`).find(".cmp-adaptiveform-datepicker__calendar-icon").click().then(x => {
+            cy.get(".datetimepicker").should("be.visible");
+            cy.get('.datetimepicker .dp-header .dp-caption').then(($element) => {
+                $element[0].addEventListener('click', () => {
+                    console.log('Test message: Element was clicked');
+                })
+            });
+            cy.get('.datetimepicker .dp-header .dp-caption').eq(1).click();
+            cy.get('.datetimepicker').should('be.visible');
+        });
+    })
 })

--- a/ui.tests/test-module/specs/datepicker/datepicker.runtime.cy.js
+++ b/ui.tests/test-module/specs/datepicker/datepicker.runtime.cy.js
@@ -356,7 +356,7 @@ describe("Form Runtime with Date Picker", () => {
         })
     });
 
-    it.only("should create and attach an unique datepicker calendar if it doesn't exist", () => {
+    it("should create and attach an unique datepicker calendar if it doesn't exist", () => {
         const [datePicker4, datePicker4FieldView] = Object.entries(formContainer._fields)[4];
         const [datePicker6, datePicker6FieldView] = Object.entries(formContainer._fields)[6];
         const input = "2023-01-01";


### PR DESCRIPTION
## Description
DateTime Picker Element calendar was closing if more than one instance of the widget is created due to same calendar being instantiated for every individual datetimepicker widget.

## Related Issue
[FORMS-16264](https://jira.corp.adobe.com/browse/FORMS-16264)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
