### PR TITLE
FORMS-15484: fix translataion issue with email autocomplete config options

### DIFF
--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/emailinput/v1/emailinput/_cq_dialog/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/emailinput/v1/emailinput/_cq_dialog/.content.xml
@@ -62,14 +62,11 @@
                                             </autocomplete>
                                             <autocomplete-email
                                                     jcr:primaryType="nt:unstructured"
-                                                    sling:resourceType="granite/ui/components/coral/foundation/form/autocomplete"
+                                                    sling:resourceType="granite/ui/components/coral/foundation/form/select"
                                                     fieldLabel="Autofill attribute"
                                                     forceSelection="{Boolean}true"
                                                     name="./autocomplete"
                                                     value="">
-                                                <options
-                                                        jcr:primaryType="nt:unstructured"
-                                                        sling:resourceType="granite/ui/components/coral/foundation/form/autocomplete/list"/>
                                                 <items jcr:primaryType="nt:unstructured">
                                                     <empty
                                                             jcr:primaryType="nt:unstructured"


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

autocomplete is deprecated by granite

## Related Issue: [FORMS-15484](https://jira.corp.adobe.com/browse/FORMS-15484)

<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
