### PR TITLE
Adding support to cache fragment initial HTML state. (#1507)

### DIFF
--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/fragment/v1/fragment/fragment.html
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/fragment/v1/fragment/fragment.html
@@ -27,8 +27,11 @@
          id="${fragment.id}"
          data-cmp-is="adaptiveFormFragment"
          data-cmp-adaptiveformcontainer-path="${formstructparser.formContainerPath}"
+         data-cmp-visible="${fragment.visible ? 'true' : 'false'}"
+         data-cmp-enabled="${fragment.enabled ? 'true' : 'false'}"
+         data-cmp-readonly="${fragment.readOnly ? 'true' : 'false'}"
          class="cmp-container${wcmmode.edit ? ' {0}': '' @ format=[allowed.cssClass]}"
-         title="${panel.tooltipVisible ? '' : panel.tooltipText}"
+         title="${fragment.tooltipVisible ? '' : fragment.tooltipText}"
          role="${container.roleAttribute}"
          style="${container.backgroundStyle @ context='styleString'}">
         <div class="cmp-adaptiveform-fragment__label-container">


### PR DESCRIPTION
* Adding support to cache fragment initial HTML state.

* Adding support to cache fragment initial HTML state.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
