### PR TITLE
Feat: added the loader to avoid multiple submits and tests

### DIFF
--- a/ui.tests/test-module/specs/actions/submit/submit.runtime.cy.js
+++ b/ui.tests/test-module/specs/actions/submit/submit.runtime.cy.js
@@ -197,4 +197,23 @@ describe("Form with Submit Button", () => {
             cy.get(`.cmp-adaptiveform-button__widget`).should('have.attr', 'type', 'submit');
         });
     }
+
+    it("Loader shows on submit and hides on success with thank you", () => {
+        cy.previewForm(customSubmitPagePath);
+
+        let requestStarted = false;
+        cy.intercept('POST', '**/adobe/forms/af/submit/*', (req) => {
+            requestStarted = true;
+            return Cypress.Promise.delay(3000).then(() =>  req.continue())
+        }).as('afSubmission');
+
+        cy.get(`.cmp-adaptiveform-button__widget`).click();
+
+        cy.get('form.cmp-adaptiveform-container').should('have.class', 'cmp-adaptiveform-container--loading')
+
+        cy.wait('@afSubmission').then(() => {
+            cy.contains("Thank you for submitting the form.");
+            cy.get('.cmp-adaptiveform-container__loader').should('not.exist');
+        });
+    });
 })


### PR DESCRIPTION
# Added loader to prevent multiple form submits 

<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR addresses [Issue #1215](https://github.com/adobe/aem-core-forms-components/issues/1215), which reported that clicking the **Submit** button multiple times triggered multiple form submissions, resulting in duplicate entries.

To resolve this, a loader has been introduced that appears on form submission. While the loader is active, the form is disabled, preventing duplicate submits until the process is complete.

## Related Issue

- Fixes [Issue #1215](https://github.com/adobe/aem-core-forms-components/issues/1215)

## Motivation and Context

Multiple submissions from repeated clicks on the **Submit** button were leading to duplicate form entries, which negatively impacted both user experience and backend data integrity.  
By introducing a loader that disables the form during submission, this fix ensures that only one submission is processed at a time.

## How Has This Been Tested?

- Added Cypress tests to verify that the loader class appears when the form is submitted.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
