### PR TITLE
Feat: added the loader to avoid multiple submits and tests

### DIFF
--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/actions/submit/v1/submit/README.md
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/actions/submit/v1/submit/README.md
@@ -46,7 +46,7 @@ It should be added to a relevant site client library using the `embed` property.
 
 When the Submit button is activated and the form begins submission, the form container gets a loading state so users receive visual feedback:
 
-- The form element `form.cmp-adaptiveform-container` toggles the CSS class `cmp-adaptiveform-container--loading` for the duration of the network request.
+- The form element `form.cmp-adaptiveform-container` toggles the CSS class `cmp-adaptiveform-container--submitting` for the duration of the network request.
 - A loader element inside the form (with class `cmp-adaptiveform-container__loader`) becomes visible while submitting.
 - The loading class is removed and the loader hides when validation fails, the submission succeeds, or an error occurs.
 

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/actions/submit/v1/submit/README.md
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/actions/submit/v1/submit/README.md
@@ -49,11 +49,6 @@ When the Submit button is activated and the form begins submission, the form con
 - The form element `form.cmp-adaptiveform-container` toggles the CSS class `cmp-adaptiveform-container--submitting` for the duration of the network request.
 - The loading class is removed and the loader hides when validation fails, the submission succeeds, or an error occurs.
 
-```
-During submit (loader visible to avoid multiple submits)
-
-form.cmp-adaptiveform-container.cmp-adaptiveform-container--loading .cmp-adaptiveform-container__loader { display: block; }
-```
 
 ## BEM Description
 ```

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/actions/submit/v1/submit/README.md
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/actions/submit/v1/submit/README.md
@@ -23,6 +23,7 @@ Adaptive Form Submit Button component written in HTL.
 * Custom description/tooltip for help
 * Out of the box Submit rule in the button to submit the form
 * Allows replacing this component with other component (as mentioned below).
+* Shows a loader on the form container during submission
 
 ### Use Object
 The submit button component uses the `com.adobe.cq.forms.core.components.models.form.Button` Sling Model for its Use-object.
@@ -40,6 +41,20 @@ The button has a default property of `buttonType` set to `submit` which is used 
 ## Client Libraries
 The component provides a `core.forms.components.button.v1.runtime` client library category that contains the Javascript runtime for the component. 
 It should be added to a relevant site client library using the `embed` property.
+
+### Loader behavior on submit
+
+When the Submit button is activated and the form begins submission, the form container gets a loading state so users receive visual feedback:
+
+- The form element `form.cmp-adaptiveform-container` toggles the CSS class `cmp-adaptiveform-container--loading` for the duration of the network request.
+- A loader element inside the form (with class `cmp-adaptiveform-container__loader`) becomes visible while submitting.
+- The loading class is removed and the loader hides when validation fails, the submission succeeds, or an error occurs.
+
+```
+During submit (loader visible to avoid multiple submits)
+
+form.cmp-adaptiveform-container.cmp-adaptiveform-container--loading .cmp-adaptiveform-container__loader { display: block; }
+```
 
 ## BEM Description
 ```
@@ -84,6 +99,3 @@ We support replace feature that allows replacing Reset Button component to any o
 * **Version**: v1
 * **Compatibility**: Cloud
 * **Status**: production-ready
-
-
-

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/actions/submit/v1/submit/README.md
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/actions/submit/v1/submit/README.md
@@ -47,7 +47,6 @@ It should be added to a relevant site client library using the `embed` property.
 When the Submit button is activated and the form begins submission, the form container gets a loading state so users receive visual feedback:
 
 - The form element `form.cmp-adaptiveform-container` toggles the CSS class `cmp-adaptiveform-container--submitting` for the duration of the network request.
-- A loader element inside the form (with class `cmp-adaptiveform-container__loader`) becomes visible while submitting.
 - The loading class is removed and the loader hides when validation fails, the submission succeeds, or an error occurs.
 
 ```

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/button/v1/button/clientlibs/site/js/buttonview.js
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/button/v1/button/clientlibs/site/js/buttonview.js
@@ -69,14 +69,14 @@
         _showLoader() {
             const container = this._getContainer();
             if (container) {
-                container.classList.add('cmp-adaptiveform-container--loading');
+                container.classList.add('cmp-adaptiveform-container--submitting');
             }
         }
 
         _hideLoader() {
             const container = this._getContainer();
             if (container) {
-                container.classList.remove('cmp-adaptiveform-container--loading');
+                container.classList.remove('cmp-adaptiveform-container--submitting');
             }
         }
 

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/button/v1/button/clientlibs/site/js/buttonview.js
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/button/v1/button/clientlibs/site/js/buttonview.js
@@ -36,7 +36,27 @@
             tooltipDiv: `.${Button.bemBlock}__shortdescription`
         };
 
-        _formEventHandlersInstalled = false;
+        constructor(params) {
+            super(params);
+            const formModel = this.formContainer?.getModel?.();
+            if (!formModel) { return; }
+            
+            formModel.subscribe((action) => { // hide loader if validation fails (no submit performed)
+                const errors = action?.payload;
+                if (Array.isArray(errors) && errors.length > 0) {
+                    this._hideLoader();
+                }
+            }, 'validationComplete');
+
+            formModel.subscribe(() => { // hide loader on submit success
+                this._hideLoader();
+            }, 'submitSuccess');
+            
+            formModel.subscribe(() => { // hide loader on submit error
+                this._hideLoader();
+            }, 'submitError');
+        }
+
         _container = null;
 
         _getContainer() {
@@ -51,7 +71,6 @@
             if (container) {
                 container.classList.add('cmp-adaptiveform-container--loading');
             }
-            this._installFormEventHandlers();
         }
 
         _hideLoader() {
@@ -60,34 +79,6 @@
                 container.classList.remove('cmp-adaptiveform-container--loading');
             }
         }
-
-        _installFormEventHandlers() {
-            if (this._formEventHandlersInstalled) { return; }
-            try {
-                const formModel = this.formContainer?.getModel?.();
-                if (!formModel) { return; }
-
-                // End loading if validation fails (no submit performed)
-                formModel.subscribe((action) => {
-                    const errors = action?.payload;
-                    if (Array.isArray(errors) && errors.length > 0) {
-                        this._hideLoader();
-                    }
-                }, 'validationComplete');
-
-                // End loading on submit outcomes
-                formModel.subscribe(() => {
-                    this._hideLoader();
-                }, 'submitSuccess');
-
-                formModel.subscribe(() => {
-                    this._hideLoader();
-                }, 'submitError');
-
-                this._formEventHandlersInstalled = true;
-            } catch (e) { /* no-op */ }
-        }
-        // End: Loading state management
 
         getQuestionMarkDiv() {
             return this.element.querySelector(Button.selectors.qm);

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/button/v1/button/clientlibs/site/js/buttonview.js
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/button/v1/button/clientlibs/site/js/buttonview.js
@@ -13,7 +13,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-  (function() {
+(function() {
 
     "use strict";
     class Button extends FormView.FormFieldBase {

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v2/container/README.md
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v2/container/README.md
@@ -89,7 +89,7 @@ Apply a `data-cmp-is="adaptiveFormContainer"` attribute to the `cmp-adaptiveform
 
 Applying `data-cmp-adaptiveform-container-loader` attribute to the div specifically for applying the loader class on it, it is to ensure that the loading icon should not appear over components. 
 
-During the form submission, the form element `form.cmp-adaptiveform-container` toggles the class `cmp-adaptiveform-container--loading` and the loader inside becomes visible. The class is removed once validation fails, submission succeeds or errors out, or the thank you page/message is shown.
+During the form submission, the form element `form.cmp-adaptiveform-container` toggles the class `cmp-adaptiveform-container--submitting` and the loader inside becomes visible. The class is removed once validation fails, submission succeeds or errors out, or the thank you page/message is shown.
 
 Applying `data-cmp-custom-functions-module-url` attribute to the div to point to the edge delivery URL of the custom functions file. Custom Functions exported from this file will be registered in Function Runtime. 
 This Url should whitelist the AEM author/publish domain in the Cross Origin Resource Sharing (CORS) configuration.

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v2/container/README.md
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v2/container/README.md
@@ -25,6 +25,7 @@ Adaptive Form container written in HTL.
 * Thank you message
 * Ability to drop other adaptive form components
 * Auto save feature for Drafts
+* Loader overlay during form submission to prevent multiple submits
 
 ### Use Object
 The Adaptive Form Container component uses the `com.adobe.cq.forms.core.components.models.form.FormContainer` Sling Model for its Use-object.
@@ -86,7 +87,9 @@ BLOCK cmp-adaptiveform-container
 
 Apply a `data-cmp-is="adaptiveFormContainer"` attribute to the `cmp-adaptiveform-container` block to enable initialization of the JavaScript component.
 
-Applying `data-cmp-adaptiveform-container-loader` attribute to the div specifically for applying the loader class on it, it is to ensure that the loading icon should not appear over components.
+Applying `data-cmp-adaptiveform-container-loader` attribute to the div specifically for applying the loader class on it, it is to ensure that the loading icon should not appear over components. 
+
+During the form submission, the form element `form.cmp-adaptiveform-container` toggles the class `cmp-adaptiveform-container--loading` and the loader inside becomes visible. The class is removed once validation fails, submission succeeds or errors out, or the thank you page/message is shown.
 
 Applying `data-cmp-custom-functions-module-url` attribute to the div to point to the edge delivery URL of the custom functions file. Custom Functions exported from this file will be registered in Function Runtime. 
 This Url should whitelist the AEM author/publish domain in the Cross Origin Resource Sharing (CORS) configuration.

--- a/ui.tests/test-module/specs/actions/submit/submit.runtime.cy.js
+++ b/ui.tests/test-module/specs/actions/submit/submit.runtime.cy.js
@@ -197,4 +197,23 @@ describe("Form with Submit Button", () => {
             cy.get(`.cmp-adaptiveform-button__widget`).should('have.attr', 'type', 'submit');
         });
     }
+
+    it("Loader shows on submit and hides on success with thank you", () => {
+        cy.previewForm(customSubmitPagePath);
+
+        let requestStarted = false;
+        cy.intercept('POST', '**/adobe/forms/af/submit/*', (req) => {
+            requestStarted = true;
+            return Cypress.Promise.delay(3000).then(() =>  req.continue())
+        }).as('afSubmission');
+
+        cy.get(`.cmp-adaptiveform-button__widget`).click();
+
+        cy.get('form.cmp-adaptiveform-container').should('have.class', 'cmp-adaptiveform-container--loading')
+
+        cy.wait('@afSubmission').then(() => {
+            cy.contains("Thank you for submitting the form.");
+            cy.get('.cmp-adaptiveform-container__loader').should('not.exist');
+        });
+    });
 })

--- a/ui.tests/test-module/specs/actions/submit/submit.runtime.cy.js
+++ b/ui.tests/test-module/specs/actions/submit/submit.runtime.cy.js
@@ -209,11 +209,10 @@ describe("Form with Submit Button", () => {
 
         cy.get(`.cmp-adaptiveform-button__widget`).click();
 
-        cy.get('form.cmp-adaptiveform-container').should('have.class', 'cmp-adaptiveform-container--loading')
+        cy.get('form.cmp-adaptiveform-container').should('have.class', 'cmp-adaptiveform-container--submitting')
 
         cy.wait('@afSubmission').then(() => {
             cy.contains("Thank you for submitting the form.");
-            cy.get('.cmp-adaptiveform-container__loader').should('not.exist');
         });
     });
 })


### PR DESCRIPTION
# Added loader to prevent multiple form submits 

<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR addresses [Issue #1215](https://github.com/adobe/aem-core-forms-components/issues/1215), which reported that clicking the **Submit** button multiple times triggered multiple form submissions, resulting in duplicate entries.

To resolve this, a loader has been introduced that appears on form submission. While the loader is active, the form is disabled, preventing duplicate submits until the process is complete.

## Related Issue

- Fixes [Issue #1215](https://github.com/adobe/aem-core-forms-components/issues/1215)

## Motivation and Context

Multiple submissions from repeated clicks on the **Submit** button were leading to duplicate form entries, which negatively impacted both user experience and backend data integrity.  
By introducing a loader that disables the form during submission, this fix ensures that only one submission is processed at a time.

## How Has This Been Tested?

- Added Cypress tests to verify that the loader class appears when the form is submitted.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
