### PR TITLE
FORMS-18646: Desktop, RWD Tablet, RWD Mobile - State: Expand/collapse state of the element is missing or incorrect @sunnym @vavarshn

### DIFF
--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/af-commons/v1/fieldTemplates/questionMark.html
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/af-commons/v1/fieldTemplates/questionMark.html
@@ -1,4 +1,4 @@
 <template data-sly-template.questionMark="${@ componentId, longDescription, bemBlock}">
-  <button class="${bemBlock}__questionmark" data-sly-test="${longDescription}" title="Help text">
+  <button class="${bemBlock}__questionmark" data-sly-test="${longDescription}" aria-expanded="false" title="Help text">
   </button>
 </template>

--- a/ui.frontend/src/view/FormFieldBase.js
+++ b/ui.frontend/src/view/FormFieldBase.js
@@ -751,11 +751,13 @@ class FormFieldBase extends FormField {
                     if (tooltipAlwaysVisible) {
                         self.#showHideTooltipDiv(false);
                     }
+                    questionMarkDiv.setAttribute('aria-expanded', true);
                 } else {
                     self.#showHideLongDescriptionDiv(false);
                     if (tooltipAlwaysVisible) {
                         self.#showHideTooltipDiv(true);
                     }
+                    questionMarkDiv.setAttribute('aria-expanded', false);
                 }
             });
         }

--- a/ui.tests/test-module/libs/support/commands.js
+++ b/ui.tests/test-module/libs/support/commands.js
@@ -662,6 +662,9 @@ Cypress.Commands.add("toggleDescriptionTooltip", (bemBlock, fieldId, shortDescri
     //initially long description should have data-cmp-visible="false" to avoid flickering on page load
     cy.get(`#${fieldId}`).find(`.${bemBlock}__longdescription`).invoke('attr', 'data-cmp-visible')
     .should('eq', 'false');
+    // check if questiionmark is collapsed
+    cy.get(`#${fieldId}`).find(`.${bemBlock}__questionmark`).invoke('attr', 'aria-expanded')
+    .should('eq', 'false');
     // click on ? mark
     cy.get(`#${fieldId}`).find(`.${bemBlock}__questionmark`).click();
     // long description should be shown
@@ -672,6 +675,9 @@ Cypress.Commands.add("toggleDescriptionTooltip", (bemBlock, fieldId, shortDescri
     // short description should be hidden.
     cy.get(`#${fieldId}`).find(`.${bemBlock}__shortdescription`).invoke('attr', 'data-cmp-visible')
     .should('eq', 'false');
+    // check if questiionmark is expanded
+    cy.get(`#${fieldId}`).find(`.${bemBlock}__questionmark`).invoke('attr', 'aria-expanded')
+    .should('eq', 'true');
 });
 
 Cypress.Commands.add("openSidePanelTab", (tab) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/FORMS-18646

<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/8e9525e5-50c6-4053-8d75-9c40d8d72898


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
