### PR TITLE
Updating style selectors for theme editor CC

### DIFF
--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/accordion/v1/accordion/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/accordion/v1/accordion/_cq_styleConfig/.content.xml
@@ -23,25 +23,25 @@
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Label"
                                 id="af2_accordionlabel"
-                                cssSelector=".cmp-accordion__label"
+                                cssSelector=".cmp-accordion__label-container .cmp-accordion__label"
                                 longTitle="Accordion Label"
                                 propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                             <states jcr:primaryType="nt:unstructured">
                                 <hover
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Hover"
-                                        cssSelector=".cmp-accordion__label:hover"/>
+                                        cssSelector=".cmp-accordion__label-container .cmp-accordion__label:hover"/>
                                 <focus
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Focus"
-                                        cssSelector=".cmp-accordion__label:focus"/>
+                                        cssSelector=".cmp-accordion__label-container .cmp-accordion__label:focus"/>
                             </states>
                         </accordionLabel>
                         <accordionHelpIcon
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Help Icon"
                                 id="af2_accordionhelpicon"
-                                cssSelector=".cmp-accordion__questionmark"
+                                cssSelector=".cmp-accordion__label-container .cmp-accordion__questionmark"
                                 longTitle="Accordion Help Icon"
                                 propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
                                 secondarySelectors="af2_guideContainer:af2_helpicon">
@@ -49,15 +49,15 @@
                                 <focus
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Focus"
-                                        cssSelector=".cmp-accordion__questionmark:focus"/>
+                                        cssSelector=".cmp-accordion__label-container .cmp-accordion__questionmark:focus"/>
                                 <hover
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Hover"
-                                        cssSelector=".cmp-accordion__questionmark:hover"/>
+                                        cssSelector=".cmp-accordion__label-container .cmp-accordion__questionmark:hover"/>
                                 <disabled
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Disabled"
-                                        cssSelector=".cmp-accordion__questionmark:disabled"/>
+                                        cssSelector=".cmp-accordion__label-container .cmp-accordion__questionmark:disabled"/>
                             </states>
                         </accordionHelpIcon>
                     </items>
@@ -91,6 +91,15 @@
                         cssSelector=".cmp-accordion__longdescription"
                         longTitle="Accordion Long Description"
                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                    <items jcr:primaryType="nt:unstructured">
+                        <accordionDescriptionLongParagraph
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Long Description Paragraph"
+                                id="af2_accordiondescriptionlongparagraph"
+                                cssSelector=".cmp-accordion__longdescription p"
+                                longTitle="Accordion Long Description Paragraph"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                    </items>
                     <states jcr:primaryType="nt:unstructured">
                         <focus
                                 jcr:primaryType="nt:unstructured"
@@ -170,6 +179,14 @@
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Hover"
                                                 cssSelector=".cmp-accordion__icon:hover"/>
+                                        <rtl
+                                                jcr:primaryType="nt:unstructured"
+                                                jcr:title="RTL"
+                                                cssSelector="[dir=&quot;rtl&quot;] .cmp-accordion__icon"/>
+                                        <expanded
+                                                jcr:primaryType="nt:unstructured"
+                                                jcr:title="Expanded"
+                                                cssSelector=".cmp-accordion__button.cmp-accordion__button--expanded .cmp-accordion__icon"/>
                                     </states>
                                 </accordionHeaderIcon>
                             </items>
@@ -200,6 +217,10 @@
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Hover"
                                         cssSelector=".cmp-accordion__panel:hover"/>
+                                <hidden
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Hidden"
+                                        cssSelector=".cmp-accordion__panel--hidden"/>
                             </states>
                         </accordionPanelWidget>
                     </items>
@@ -214,6 +235,30 @@
                                 cssSelector=".cmp-accordion__item:hover"/>
                     </states>
                 </accordionPanelItem>
+                <accordionRepeatableButtons
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Repeatable Buttons"
+                        id="af2_accordionrepeatablebuttons"
+                        cssSelector=".cmp-accordion__repeatable-buttons"
+                        longTitle="Accordion Repeatable Buttons"
+                        propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                    <items jcr:primaryType="nt:unstructured">
+                        <accordionAddButton
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Add Button"
+                                id="af2_accordionaddbutton"
+                                cssSelector=".cmp-accordion__add-button"
+                                longTitle="Accordion Add Button"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                        <accordionRemoveButton
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Remove Button"
+                                id="af2_accordionremovebutton"
+                                cssSelector=".cmp-accordion__remove-button"
+                                longTitle="Accordion Remove Button"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                    </items>
+                </accordionRepeatableButtons>
             </items>
         </accordionPanel>
     </items>

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/accordion/v1/accordion/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/accordion/v1/accordion/_cq_styleConfig/.content.xml
@@ -92,7 +92,7 @@
                         longTitle="Accordion Long Description"
                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                     <items jcr:primaryType="nt:unstructured">
-                        <accordionDescriptionLongParagraph
+                        <longDescriptionParagraph
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Long Description Paragraph"
                                 id="af2_accordiondescriptionlongparagraph"

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/actions/reset/v2/reset/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/actions/reset/v2/reset/_cq_styleConfig/.content.xml
@@ -62,7 +62,7 @@
                         longTitle="Reset Button Long Description"
                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                     <items jcr:primaryType="nt:unstructured">
-                        <buttonDescriptionLongParagraph
+                        <longDescriptionParagraph
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Long Description Paragraph"
                                 id="af2_resetbuttondescriptionlongparagraph"
@@ -81,6 +81,45 @@
                                 cssSelector=".reset .cmp-adaptiveform-button__longdescription:required"/>
                     </states>
                 </buttonDescriptionLong>
+                <buttonHelpContainer
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Help Container"
+                        id="af2_resetbuttonhelpcontainer"
+                        cssSelector=".reset .cmp-adaptiveform-button__help-container"
+                        longTitle="Reset Button Help Container"
+                        propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                    <items jcr:primaryType="nt:unstructured">
+                        <buttonHelpIcon
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Help Icon"
+                                id="af2_resetbuttonhelpicon"
+                                cssSelector=".reset .cmp-adaptiveform-button__help-container .cmp-adaptiveform-button__questionmark"
+                                longTitle="Reset Button Help Icon"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
+                                secondarySelectors="af2_guideContainer:af2_helpicon">
+                            <states jcr:primaryType="nt:unstructured">
+                                <focus
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Focus"
+                                        cssSelector=".reset .cmp-adaptiveform-button__help-container .cmp-adaptiveform-button__questionmark:focus"/>
+                                <hover
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Hover"
+                                        cssSelector=".reset .cmp-adaptiveform-button__help-container .cmp-adaptiveform-button__questionmark:hover"/>
+                            </states>
+                        </buttonHelpIcon>
+                    </items>
+                    <states jcr:primaryType="nt:unstructured">
+                        <focus
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Focus"
+                                cssSelector=".reset .cmp-adaptiveform-button__help-container:focus"/>
+                        <hover
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Hover"
+                                cssSelector=".reset .cmp-adaptiveform-button__help-container:hover"/>
+                    </states>
+                </buttonHelpContainer>
             </items>
             <states jcr:primaryType="nt:unstructured">
                 <focus

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/actions/reset/v2/reset/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/actions/reset/v2/reset/_cq_styleConfig/.content.xml
@@ -3,6 +3,13 @@
     jcr:primaryType="nt:unstructured"
     jcr:title="Button">
     <items jcr:primaryType="nt:unstructured">
+        <buttonRoot
+            jcr:primaryType="nt:unstructured"
+            jcr:title="Reset Button Container"
+            id="af2_resetbuttonroot"
+            cssSelector=".reset .cmp-adaptiveform-button"
+            longTitle="Reset Button Container"
+            propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
         <button
             jcr:primaryType="nt:unstructured"
             jcr:title="Reset"
@@ -54,6 +61,15 @@
                         cssSelector=".reset .cmp-adaptiveform-button__longdescription"
                         longTitle="Reset Button Long Description"
                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                    <items jcr:primaryType="nt:unstructured">
+                        <buttonDescriptionLongParagraph
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Long Description Paragraph"
+                                id="af2_resetbuttondescriptionlongparagraph"
+                                cssSelector=".reset .cmp-adaptiveform-button__longdescription p"
+                                longTitle="Reset Button Long Description Paragraph"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                    </items>
                     <states jcr:primaryType="nt:unstructured">
                         <focus
                                 jcr:primaryType="nt:unstructured"
@@ -65,43 +81,6 @@
                                 cssSelector=".reset .cmp-adaptiveform-button__longdescription:required"/>
                     </states>
                 </buttonDescriptionLong>
-                <buttonHelpContainer
-                        jcr:primaryType="nt:unstructured"
-                        jcr:title="Help Container"
-                        id="af2_resetbuttonhelpcontainer"
-                        cssSelector=".reset .cmp-adaptiveform-button__help-container"
-                        longTitle="Reset Button Help Container"
-                        propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
-                    <states jcr:primaryType="nt:unstructured">
-                        <focus
-                                jcr:primaryType="nt:unstructured"
-                                jcr:title="Focus"
-                                cssSelector=".reset .cmp-adaptiveform-button__help-container:focus"/>
-                        <hover
-                                jcr:primaryType="nt:unstructured"
-                                jcr:title="Hover"
-                                cssSelector=".reset .cmp-adaptiveform-button__help-container:hover"/>
-                    </states>
-                </buttonHelpContainer>
-                <buttonHelpIcon
-                        jcr:primaryType="nt:unstructured"
-                        jcr:title="Help Icon"
-                        id="af2_resetbuttonhelpicon"
-                        cssSelector=".reset .cmp-adaptiveform-button__questionmark"
-                        longTitle="Reset Button Help Icon"
-                        propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
-                        secondarySelectors="af2_guideContainer:af2_helpicon">
-                    <states jcr:primaryType="nt:unstructured">
-                        <focus
-                                jcr:primaryType="nt:unstructured"
-                                jcr:title="Focus"
-                                cssSelector=".reset .cmp-adaptiveform-button__questionmark:focus"/>
-                        <hover
-                                jcr:primaryType="nt:unstructured"
-                                jcr:title="Hover"
-                                cssSelector=".reset .cmp-adaptiveform-button__questionmark:hover"/>
-                    </states>
-                </buttonHelpIcon>
             </items>
             <states jcr:primaryType="nt:unstructured">
                 <focus
@@ -120,6 +99,10 @@
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Hover"
                         cssSelector=".reset .cmp-adaptiveform-button__widget:hover"/>
+                <componentDisabled
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Component Disabled"
+                        cssSelector=".reset [data-cmp-enabled]:not([data-cmp-enabled=true]) .cmp-adaptiveform-button__widget"/>
                 <error
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Error"

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/actions/submit/v2/submit/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/actions/submit/v2/submit/_cq_styleConfig/.content.xml
@@ -62,7 +62,7 @@
                         longTitle="Submit Button Long Description"
                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                     <items jcr:primaryType="nt:unstructured">
-                        <buttonDescriptionLongParagraph
+                        <longDescriptionParagraph
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Long Description Paragraph"
                                 id="af2_submitbuttondescriptionlongparagraph"
@@ -81,6 +81,45 @@
                                 cssSelector=".submit .cmp-adaptiveform-button__longdescription:required"/>
                     </states>
                 </buttonDescriptionLong>
+                <buttonHelpContainer
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Help Container"
+                        id="af2_submitbuttonhelpcontainer"
+                        cssSelector=".submit .cmp-adaptiveform-button__help-container"
+                        longTitle="Submit Button Help Container"
+                        propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                    <items jcr:primaryType="nt:unstructured">
+                        <buttonHelpIcon
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Help Icon"
+                                id="af2_submitbuttonhelpicon"
+                                cssSelector=".submit .cmp-adaptiveform-button__help-container .cmp-adaptiveform-button__questionmark"
+                                longTitle="Submit Button Help Icon"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
+                                secondarySelectors="af2_guideContainer:af2_helpicon">
+                            <states jcr:primaryType="nt:unstructured">
+                                <focus
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Focus"
+                                        cssSelector=".submit .cmp-adaptiveform-button__help-container .cmp-adaptiveform-button__questionmark:focus"/>
+                                <hover
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Hover"
+                                        cssSelector=".submit .cmp-adaptiveform-button__help-container .cmp-adaptiveform-button__questionmark:hover"/>
+                            </states>
+                        </buttonHelpIcon>
+                    </items>
+                    <states jcr:primaryType="nt:unstructured">
+                        <focus
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Focus"
+                                cssSelector=".submit .cmp-adaptiveform-button__help-container:focus"/>
+                        <hover
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Hover"
+                                cssSelector=".submit .cmp-adaptiveform-button__help-container:hover"/>
+                    </states>
+                </buttonHelpContainer>
             </items>
             <states jcr:primaryType="nt:unstructured">
                 <focus

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/actions/submit/v2/submit/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/actions/submit/v2/submit/_cq_styleConfig/.content.xml
@@ -3,6 +3,13 @@
     jcr:primaryType="nt:unstructured"
     jcr:title="Button">
     <items jcr:primaryType="nt:unstructured">
+        <buttonRoot
+            jcr:primaryType="nt:unstructured"
+            jcr:title="Submit Button Container"
+            id="af2_submitbuttonroot"
+            cssSelector=".submit .cmp-adaptiveform-button"
+            longTitle="Submit Button Container"
+            propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
         <button
             jcr:primaryType="nt:unstructured"
             jcr:title="Submit"
@@ -54,6 +61,15 @@
                         cssSelector=".submit .cmp-adaptiveform-button__longdescription"
                         longTitle="Submit Button Long Description"
                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                    <items jcr:primaryType="nt:unstructured">
+                        <buttonDescriptionLongParagraph
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Long Description Paragraph"
+                                id="af2_submitbuttondescriptionlongparagraph"
+                                cssSelector=".submit .cmp-adaptiveform-button__longdescription p"
+                                longTitle="Submit Button Long Description Paragraph"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                    </items>
                     <states jcr:primaryType="nt:unstructured">
                         <focus
                                 jcr:primaryType="nt:unstructured"
@@ -65,43 +81,6 @@
                                 cssSelector=".submit .cmp-adaptiveform-button__longdescription:required"/>
                     </states>
                 </buttonDescriptionLong>
-                <buttonHelpContainer
-                        jcr:primaryType="nt:unstructured"
-                        jcr:title="Help Container"
-                        id="af2_submitbuttonhelpcontainer"
-                        cssSelector=".submit .cmp-adaptiveform-button__help-container"
-                        longTitle="Submit Button Help Container"
-                        propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
-                    <states jcr:primaryType="nt:unstructured">
-                        <focus
-                                jcr:primaryType="nt:unstructured"
-                                jcr:title="Focus"
-                                cssSelector=".submit .cmp-adaptiveform-button__help-container:focus"/>
-                        <hover
-                                jcr:primaryType="nt:unstructured"
-                                jcr:title="Hover"
-                                cssSelector=".submit .cmp-adaptiveform-button__help-container:hover"/>
-                    </states>
-                </buttonHelpContainer>
-                <buttonHelpIcon
-                        jcr:primaryType="nt:unstructured"
-                        jcr:title="Help Icon"
-                        id="af2_submitbuttonhelpicon"
-                        cssSelector=".submit .cmp-adaptiveform-button__questionmark"
-                        longTitle="Submit Button Help Icon"
-                        propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
-                        secondarySelectors="af2_guideContainer:af2_helpicon">
-                    <states jcr:primaryType="nt:unstructured">
-                        <focus
-                                jcr:primaryType="nt:unstructured"
-                                jcr:title="Focus"
-                                cssSelector=".submit .cmp-adaptiveform-button__questionmark:focus"/>
-                        <hover
-                                jcr:primaryType="nt:unstructured"
-                                jcr:title="Hover"
-                                cssSelector=".submit .cmp-adaptiveform-button__questionmark:hover"/>
-                    </states>
-                </buttonHelpIcon>
             </items>
             <states jcr:primaryType="nt:unstructured">
                 <focus
@@ -120,6 +99,10 @@
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Hover"
                         cssSelector=".submit .cmp-adaptiveform-button__widget:hover"/>
+                <componentDisabled
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Component Disabled"
+                        cssSelector=".submit [data-cmp-enabled]:not([data-cmp-enabled=true]) .cmp-adaptiveform-button__widget"/>
                 <error
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Error"

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/button/v2/button/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/button/v2/button/_cq_styleConfig/.content.xml
@@ -60,7 +60,7 @@
                         longTitle="Button Long Description"
                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                     <items jcr:primaryType="nt:unstructured">
-                        <buttonDescriptionLongParagraph
+                        <longDescriptionParagraph
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Long Description Paragraph"
                                 id="af2_buttondescriptionlongparagraph"

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/button/v2/button/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/button/v2/button/_cq_styleConfig/.content.xml
@@ -3,6 +3,13 @@
     jcr:primaryType="nt:unstructured"
     jcr:title="Button">
     <items jcr:primaryType="nt:unstructured">
+        <buttonRoot
+            jcr:primaryType="nt:unstructured"
+            jcr:title="Button Container"
+            id="af2_buttonroot"
+            cssSelector=".cmp-adaptiveform-button"
+            longTitle="Button Container"
+            propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
         <button
             jcr:primaryType="nt:unstructured"
             jcr:title="All Buttons"
@@ -52,6 +59,15 @@
                         cssSelector=".cmp-adaptiveform-button__longdescription"
                         longTitle="Button Long Description"
                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                    <items jcr:primaryType="nt:unstructured">
+                        <buttonDescriptionLongParagraph
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Long Description Paragraph"
+                                id="af2_buttondescriptionlongparagraph"
+                                cssSelector=".cmp-adaptiveform-button__longdescription p"
+                                longTitle="Button Long Description Paragraph"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                    </items>
                     <states jcr:primaryType="nt:unstructured">
                         <focus
                                 jcr:primaryType="nt:unstructured"
@@ -70,6 +86,27 @@
                         cssSelector=".cmp-adaptiveform-button__help-container"
                         longTitle="Button Help Container"
                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                    <items jcr:primaryType="nt:unstructured">
+                        <buttonHelpIcon
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Help Icon"
+                                id="af2_buttonhelpicon"
+                                cssSelector=".cmp-adaptiveform-button__help-container .cmp-adaptiveform-button__questionmark"
+                                longTitle="Button Help Icon"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
+                                secondarySelectors="af2_guideContainer:af2_helpicon">
+                            <states jcr:primaryType="nt:unstructured">
+                                <focus
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Focus"
+                                        cssSelector=".cmp-adaptiveform-button__help-container .cmp-adaptiveform-button__questionmark:focus"/>
+                                <hover
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Hover"
+                                        cssSelector=".cmp-adaptiveform-button__help-container .cmp-adaptiveform-button__questionmark:hover"/>
+                            </states>
+                        </buttonHelpIcon>
+                    </items>
                     <states jcr:primaryType="nt:unstructured">
                         <focus
                                 jcr:primaryType="nt:unstructured"
@@ -81,25 +118,6 @@
                                 cssSelector=".cmp-adaptiveform-button__help-container:hover"/>
                     </states>
                 </buttonHelpContainer>
-                <buttonHelpIcon
-                        jcr:primaryType="nt:unstructured"
-                        jcr:title="Help Icon"
-                        id="af2_buttonhelpicon"
-                        cssSelector=".cmp-adaptiveform-button__questionmark"
-                        longTitle="Button Help Icon"
-                        propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
-                        secondarySelectors="af2_guideContainer:af2_helpicon">
-                    <states jcr:primaryType="nt:unstructured">
-                        <focus
-                                jcr:primaryType="nt:unstructured"
-                                jcr:title="Focus"
-                                cssSelector=".cmp-adaptiveform-button__questionmark:focus"/>
-                        <hover
-                                jcr:primaryType="nt:unstructured"
-                                jcr:title="Hover"
-                                cssSelector=".cmp-adaptiveform-button__questionmark:hover"/>
-                    </states>
-                </buttonHelpIcon>
             </items>
             <states jcr:primaryType="nt:unstructured">
                 <focus
@@ -118,6 +136,10 @@
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Hover"
                         cssSelector=".cmp-adaptiveform-button__widget:hover"/>
+                <componentDisabled
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Component Disabled"
+                        cssSelector="[data-cmp-enabled]:not([data-cmp-enabled=true]) .cmp-adaptiveform-button__widget"/>
                 <error
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Error"

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/checkbox/v1/checkbox/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/checkbox/v1/checkbox/_cq_styleConfig/.content.xml
@@ -90,6 +90,15 @@
                                         cssSelector=".cmp-adaptiveform-checkbox__longdescription"
                                         longTitle="Checkbox Long Description"
                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                    <items jcr:primaryType="nt:unstructured">
+                        <longDescriptionParagraph
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Checkbox Long Description Paragraph"
+                                id="af2_checkboxdescriptionlongparagraph"
+                                cssSelector=".cmp-adaptiveform-checkbox__longdescription p"
+                                longTitle="Checkbox Long Description Paragraph"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                    </items>
                                     <states jcr:primaryType="nt:unstructured">
                                         <focus
                                             jcr:primaryType="nt:unstructured"
@@ -108,6 +117,31 @@
                                         cssSelector=".cmp-adaptiveform-checkbox__help-container"
                                         longTitle="Checkbox Help Container"
                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                                    <items jcr:primaryType="nt:unstructured">
+                                        <checkBoxHelpIcon
+                                                jcr:primaryType="nt:unstructured"
+                                                jcr:title="Help Icon"
+                                                id="af2_checkboxhelpicon"
+                                                cssSelector=".cmp-adaptiveform-checkbox__help-container .cmp-adaptiveform-checkbox__questionmark"
+                                                longTitle="Checkbox Help Icon"
+                                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
+                                                secondarySelectors="af2_guideContainer:af2_helpicon">
+                                            <states jcr:primaryType="nt:unstructured">
+                                                <focus
+                                                        jcr:primaryType="nt:unstructured"
+                                                        jcr:title="Focus"
+                                                        cssSelector=".cmp-adaptiveform-checkbox__help-container .cmp-adaptiveform-checkbox__questionmark:focus"/>
+                                                <hover
+                                                        jcr:primaryType="nt:unstructured"
+                                                        jcr:title="Hover"
+                                                        cssSelector=".cmp-adaptiveform-checkbox__help-container .cmp-adaptiveform-checkbox__questionmark:hover"/>
+                                                <disabled
+                                                        jcr:primaryType="nt:unstructured"
+                                                        jcr:title="Disabled"
+                                                        cssSelector=".cmp-adaptiveform-checkbox__help-container .cmp-adaptiveform-checkbox__questionmark:disabled"/>
+                                            </states>
+                                        </checkBoxHelpIcon>
+                                    </items>
                                     <states jcr:primaryType="nt:unstructured">
                                         <focus
                                             jcr:primaryType="nt:unstructured"
@@ -123,29 +157,6 @@
                                             cssSelector=".cmp-adaptiveform-checkbox__help-container:disabled"/>
                                     </states>
                                 </checkBoxHelpContainer>
-                                <checkBoxHelpIcon
-                                        jcr:primaryType="nt:unstructured"
-                                        jcr:title="Help Icon"
-                                        id="af2_checkboxhelpicon"
-                                        cssSelector=".cmp-adaptiveform-checkbox__questionmark"
-                                        longTitle="Checkbox Help Icon"
-                                        propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
-                                        secondarySelectors="af2_guideContainer:af2_helpicon">
-                                    <states jcr:primaryType="nt:unstructured">
-                                        <focus
-                                            jcr:primaryType="nt:unstructured"
-                                            jcr:title="Focus"
-                                            cssSelector=".cmp-adaptiveform-checkbox__questionmark:focus"/>
-                                        <hover
-                                            jcr:primaryType="nt:unstructured"
-                                            jcr:title="Hover"
-                                            cssSelector=".cmp-adaptiveform-checkbox__questionmark:hover"/>
-                                        <disabled
-                                            jcr:primaryType="nt:unstructured"
-                                            jcr:title="Disabled"
-                                            cssSelector=".cmp-adaptiveform-checkbox__questionmark:disabled"/>
-                                    </states>
-                                </checkBoxHelpIcon>
                             </items>
                             <states jcr:primaryType="nt:unstructured">
                                 <focus

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/checkboxgroup/v1/checkboxgroup/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/checkboxgroup/v1/checkboxgroup/_cq_styleConfig/.content.xml
@@ -30,25 +30,25 @@
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Label"
                                         id="af2_checkboxgrouplabel"
-                                        cssSelector=".cmp-adaptiveform-checkboxgroup__label"
+                                        cssSelector=".cmp-adaptiveform-checkboxgroup__label-container .cmp-adaptiveform-checkboxgroup__label"
                                         longTitle="Checkbox Group Label"
                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                                     <states jcr:primaryType="nt:unstructured">
                                         <hover
                                             jcr:primaryType="nt:unstructured"
                                             jcr:title="Hover"
-                                            cssSelector=".cmp-adaptiveform-checkboxgroup__label:hover"/>
+                                            cssSelector=".cmp-adaptiveform-checkboxgroup__label-container .cmp-adaptiveform-checkboxgroup__label:hover"/>
                                         <focus
                                             jcr:primaryType="nt:unstructured"
                                             jcr:title="Focus"
-                                            cssSelector=".cmp-adaptiveform-checkboxgroup__label:focus"/>
+                                            cssSelector=".cmp-adaptiveform-checkboxgroup__label-container .cmp-adaptiveform-checkboxgroup__label:focus"/>
                                     </states>
                                 </checkBoxGroupLabel>
                                 <checkBoxGroupHelpIcon
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Help Icon"
                                         id="af2_checkboxgrouphelpicon"
-                                        cssSelector=".cmp-adaptiveform-checkboxgroup__questionmark"
+                                        cssSelector=".cmp-adaptiveform-checkboxgroup__label-container .cmp-adaptiveform-checkboxgroup__questionmark"
                                         longTitle="Checkbox Group Help Icon"
                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
                                         secondarySelectors="af2_guideContainer:af2_helpicon">
@@ -56,15 +56,15 @@
                                         <focus
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Focus"
-                                                cssSelector=".cmp-adaptiveform-checkboxgroup__questionmark:focus"/>
+                                                cssSelector=".cmp-adaptiveform-checkboxgroup__label-container .cmp-adaptiveform-checkboxgroup__questionmark:focus"/>
                                         <hover
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Hover"
-                                                cssSelector=".cmp-adaptiveform-checkboxgroup__questionmark:hover"/>
+                                                cssSelector=".cmp-adaptiveform-checkboxgroup__label-container .cmp-adaptiveform-checkboxgroup__questionmark:hover"/>
                                         <disabled
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Disabled"
-                                                cssSelector=".cmp-adaptiveform-checkboxgroup__questionmark:disabled"/>
+                                                cssSelector=".cmp-adaptiveform-checkboxgroup__label-container .cmp-adaptiveform-checkboxgroup__questionmark:disabled"/>
                                     </states>
                                 </checkBoxGroupHelpIcon>
                             </items>
@@ -216,69 +216,69 @@
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Checkbox Item"
                                         id="af2_checkboxgroupitemhorizontal"
-                                        cssSelector=".cmp-adaptiveform-checkboxgroup-item"
-                                        longTitle="Checkbox Group Item"
+                                        cssSelector=".cmp-adaptiveform-checkboxgroup__widget.HORIZONTAL .cmp-adaptiveform-checkboxgroup-item"
+                                        longTitle="Checkbox Group Horizontal Layout Item"
                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                                     <items jcr:primaryType="nt:unstructured">
                                         <checkBoxGroupItemLabelContainerHorizontal
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Checkbox Item Label Container"
                                                 id="af2_checkboxgroupitemlabelcontainerhorizontal"
-                                                cssSelector=".cmp-adaptiveform-checkboxgroup__option-label"
-                                                longTitle="Checkbox Group Item Label Container"
+                                                cssSelector=".cmp-adaptiveform-checkboxgroup__widget.HORIZONTAL .cmp-adaptiveform-checkboxgroup__option-label"
+                                                longTitle="Checkbox Group Item Label Container (Horizontal)"
                                                 propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                                             <items jcr:primaryType="nt:unstructured">
                                                 <checkBoxGroupItemLabelHorizontal
                                                         jcr:primaryType="nt:unstructured"
                                                         jcr:title="Label"
                                                         id="af2_checkboxgroupitemlabelhorizontal"
-                                                        cssSelector=".cmp-adaptiveform-checkboxgroup__option-label span"
-                                                        longTitle="Checkbox Group Item Label"
+                                                        cssSelector=".cmp-adaptiveform-checkboxgroup__widget.HORIZONTAL .cmp-adaptiveform-checkboxgroup__option-label span"
+                                                        longTitle="Checkbox Group Item Label (Horizontal)"
                                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                                                     <states jcr:primaryType="nt:unstructured">
                                                         <hover
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Hover"
-                                                                cssSelector=".cmp-adaptiveform-checkboxgroup__option-label span:hover"/>
+                                                                cssSelector=".cmp-adaptiveform-checkboxgroup__widget.HORIZONTAL .cmp-adaptiveform-checkboxgroup__option-label span:hover"/>
                                                         <focus
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Focus"
-                                                                cssSelector=".cmp-adaptiveform-checkboxgroup__option-label span:focus"/>
+                                                                cssSelector=".cmp-adaptiveform-checkboxgroup__widget.HORIZONTAL .cmp-adaptiveform-checkboxgroup__option-label span:focus"/>
                                                         <checked
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Selected"
-                                                                cssSelector=".cmp-adaptiveform-checkboxgroup__option-label input[type='checkbox']:checked + span"/>
+                                                                cssSelector=".cmp-adaptiveform-checkboxgroup__widget.HORIZONTAL .cmp-adaptiveform-checkboxgroup__option-label input[type='checkbox']:checked + span"/>
                                                         <mandatory
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Mandatory"
-                                                                cssSelector=".cmp-adaptiveform-checkboxgroup[data-cmp-required='true'] .cmp-adaptiveform-checkboxgroup__option-label span"/>
+                                                                cssSelector=".cmp-adaptiveform-checkboxgroup[data-cmp-required='true'] .cmp-adaptiveform-checkboxgroup__widget.HORIZONTAL .cmp-adaptiveform-checkboxgroup__option-label span"/>
                                                     </states>
                                                 </checkBoxGroupItemLabelHorizontal>
                                                 <checkBoxWidgetAndTextHorizontal
                                                         jcr:primaryType="nt:unstructured"
                                                         jcr:title="Checkbox"
                                                         id="af2_checkboxgroupwidgetandtexthorizontal"
-                                                        cssSelector=".cmp-adaptiveform-checkboxgroup__option__widget"
-                                                        longTitle="Checkbox Group Item Widget"
+                                                        cssSelector=".cmp-adaptiveform-checkboxgroup__widget.HORIZONTAL .cmp-adaptiveform-checkboxgroup__option__widget"
+                                                        longTitle="Checkbox Group Item Widget (Horizontal)"
                                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
                                                         secondarySelectors="af2_guideContainer:af2_widgetAndText">
                                                     <states jcr:primaryType="nt:unstructured">
                                                         <focus
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Focus"
-                                                                cssSelector=".cmp-adaptiveform-checkboxgroup__option__widget:focus"/>
+                                                                cssSelector=".cmp-adaptiveform-checkboxgroup__widget.HORIZONTAL .cmp-adaptiveform-checkboxgroup__option__widget:focus"/>
                                                         <disabled
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Disabled"
-                                                                cssSelector=".cmp-adaptiveform-checkboxgroup__option__widget:disabled"/>
+                                                                cssSelector=".cmp-adaptiveform-checkboxgroup__widget.HORIZONTAL .cmp-adaptiveform-checkboxgroup__option__widget:disabled"/>
                                                         <hover
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Hover"
-                                                                cssSelector=".cmp-adaptiveform-checkboxgroup__option__widget:hover"/>
+                                                                cssSelector=".cmp-adaptiveform-checkboxgroup__widget.HORIZONTAL .cmp-adaptiveform-checkboxgroup__option__widget:hover"/>
                                                         <checked
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Selected"
-                                                                cssSelector=".cmp-adaptiveform-checkboxgroup__option__widget:checked"/>
+                                                                cssSelector=".cmp-adaptiveform-checkboxgroup__widget.HORIZONTAL .cmp-adaptiveform-checkboxgroup__option__widget:checked"/>
                                                     </states>
                                                 </checkBoxWidgetAndTextHorizontal>
                                             </items>
@@ -286,11 +286,11 @@
                                                 <hover
                                                         jcr:primaryType="nt:unstructured"
                                                         jcr:title="Hover"
-                                                        cssSelector=".cmp-adaptiveform-checkboxgroup__option-label:hover"/>
+                                                        cssSelector=".cmp-adaptiveform-checkboxgroup__widget.HORIZONTAL .cmp-adaptiveform-checkboxgroup__option-label:hover"/>
                                                 <focus
                                                         jcr:primaryType="nt:unstructured"
                                                         jcr:title="Focus"
-                                                        cssSelector=".cmp-adaptiveform-checkboxgroup__option-label:focus"/>
+                                                        cssSelector=".cmp-adaptiveform-checkboxgroup__widget.HORIZONTAL .cmp-adaptiveform-checkboxgroup__option-label:focus"/>
                                             </states>
                                         </checkBoxGroupItemLabelContainerHorizontal>
                                     </items>
@@ -298,19 +298,19 @@
                                         <disabled
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Disabled"
-                                                cssSelector=".cmp-adaptiveform-checkboxgroup-item .cmp-adaptiveform-checkboxgroup__option__widget:disabled"/>
+                                                cssSelector=".cmp-adaptiveform-checkboxgroup__widget.HORIZONTAL .cmp-adaptiveform-checkboxgroup-item .cmp-adaptiveform-checkboxgroup__option__widget:disabled"/>
                                         <hover
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Hover"
-                                                cssSelector=".cmp-adaptiveform-checkboxgroup-item:hover"/>
+                                                cssSelector=".cmp-adaptiveform-checkboxgroup__widget.HORIZONTAL .cmp-adaptiveform-checkboxgroup-item:hover"/>
                                         <checked
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Selected"
-                                                cssSelector=".cmp-adaptiveform-checkboxgroup-item .cmp-adaptiveform-checkboxgroup__option__widget:checked"/>
+                                                cssSelector=".cmp-adaptiveform-checkboxgroup__widget.HORIZONTAL .cmp-adaptiveform-checkboxgroup-item .cmp-adaptiveform-checkboxgroup__option__widget:checked"/>
                                         <focus
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Focus"
-                                                cssSelector=".cmp-adaptiveform-checkboxgroup-item:focus"/>
+                                                cssSelector=".cmp-adaptiveform-checkboxgroup__widget.HORIZONTAL .cmp-adaptiveform-checkboxgroup-item:focus"/>
                                     </states>
                                 </checkBoxGroupItemHorizontal>
                             </items>
@@ -337,69 +337,69 @@
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Checkbox Item"
                                         id="af2_checkboxgroupitemvertical"
-                                        cssSelector=".cmp-adaptiveform-checkboxgroup-item"
-                                        longTitle="Checkbox Group Item"
+                                        cssSelector=".cmp-adaptiveform-checkboxgroup__widget.VERTICAL .cmp-adaptiveform-checkboxgroup-item"
+                                        longTitle="Checkbox Group Vertical Layout Item"
                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                                     <items jcr:primaryType="nt:unstructured">
                                         <checkBoxGroupItemLabelContainerVertical
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Checkbox Item Label Container"
                                                 id="af2_checkboxgroupitemlabelcontainervertical"
-                                                cssSelector=".cmp-adaptiveform-checkboxgroup__option-label"
-                                                longTitle="Checkbox Group Item Label Container"
+                                                cssSelector=".cmp-adaptiveform-checkboxgroup__widget.VERTICAL .cmp-adaptiveform-checkboxgroup__option-label"
+                                                longTitle="Checkbox Group Item Label Container (Vertical)"
                                                 propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                                             <items jcr:primaryType="nt:unstructured">
                                                 <checkBoxGroupItemLabelVertical
                                                         jcr:primaryType="nt:unstructured"
                                                         jcr:title="Label"
                                                         id="af2_checkboxgroupitemlabelvertical"
-                                                        cssSelector=".cmp-adaptiveform-checkboxgroup__option-label span"
-                                                        longTitle="Checkbox Group Item Label"
+                                                        cssSelector=".cmp-adaptiveform-checkboxgroup__widget.VERTICAL .cmp-adaptiveform-checkboxgroup__option-label span"
+                                                        longTitle="Checkbox Group Item Label (Vertical)"
                                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                                                     <states jcr:primaryType="nt:unstructured">
                                                         <hover
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Hover"
-                                                                cssSelector=".cmp-adaptiveform-checkboxgroup__option-label span:hover"/>
+                                                                cssSelector=".cmp-adaptiveform-checkboxgroup__widget.VERTICAL .cmp-adaptiveform-checkboxgroup__option-label span:hover"/>
                                                         <focus
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Focus"
-                                                                cssSelector=".cmp-adaptiveform-checkboxgroup__option-label span:focus"/>
+                                                                cssSelector=".cmp-adaptiveform-checkboxgroup__widget.VERTICAL .cmp-adaptiveform-checkboxgroup__option-label span:focus"/>
                                                         <checked
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Selected"
-                                                                cssSelector=".cmp-adaptiveform-checkboxgroup__option-label input[type='checkbox']:checked + span"/>
+                                                                cssSelector=".cmp-adaptiveform-checkboxgroup__widget.VERTICAL .cmp-adaptiveform-checkboxgroup__option-label input[type='checkbox']:checked + span"/>
                                                         <mandatory
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Mandatory"
-                                                                cssSelector=".cmp-adaptiveform-checkboxgroup[data-cmp-required='true'] .cmp-adaptiveform-checkboxgroup__option-label span"/>
+                                                                cssSelector=".cmp-adaptiveform-checkboxgroup[data-cmp-required='true'] .cmp-adaptiveform-checkboxgroup__widget.VERTICAL .cmp-adaptiveform-checkboxgroup__option-label span"/>
                                                     </states>
                                                 </checkBoxGroupItemLabelVertical>
                                                 <checkBoxWidgetAndTextVertical
                                                         jcr:primaryType="nt:unstructured"
                                                         jcr:title="Checkbox"
                                                         id="af2_checkboxgroupwidgetandtextvertical"
-                                                        cssSelector=".cmp-adaptiveform-checkboxgroup__option__widget"
-                                                        longTitle="Checkbox Group Item Widget"
+                                                        cssSelector=".cmp-adaptiveform-checkboxgroup__widget.VERTICAL .cmp-adaptiveform-checkboxgroup__option__widget"
+                                                        longTitle="Checkbox Group Item Widget (Vertical)"
                                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
                                                         secondarySelectors="af2_guideContainer:af2_widgetAndText">
                                                     <states jcr:primaryType="nt:unstructured">
                                                         <focus
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Focus"
-                                                                cssSelector=".cmp-adaptiveform-checkboxgroup__option__widget:focus"/>
+                                                                cssSelector=".cmp-adaptiveform-checkboxgroup__widget.VERTICAL .cmp-adaptiveform-checkboxgroup__option__widget:focus"/>
                                                         <disabled
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Disabled"
-                                                                cssSelector=".cmp-adaptiveform-checkboxgroup__option__widget:disabled"/>
+                                                                cssSelector=".cmp-adaptiveform-checkboxgroup__widget.VERTICAL .cmp-adaptiveform-checkboxgroup__option__widget:disabled"/>
                                                         <hover
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Hover"
-                                                                cssSelector=".cmp-adaptiveform-checkboxgroup__option__widget:hover"/>
+                                                                cssSelector=".cmp-adaptiveform-checkboxgroup__widget.VERTICAL .cmp-adaptiveform-checkboxgroup__option__widget:hover"/>
                                                         <checked
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Selected"
-                                                                cssSelector=".cmp-adaptiveform-checkboxgroup__option__widget:checked"/>
+                                                                cssSelector=".cmp-adaptiveform-checkboxgroup__widget.VERTICAL .cmp-adaptiveform-checkboxgroup__option__widget:checked"/>
                                                     </states>
                                                 </checkBoxWidgetAndTextVertical>
                                             </items>
@@ -407,11 +407,11 @@
                                                 <hover
                                                         jcr:primaryType="nt:unstructured"
                                                         jcr:title="Hover"
-                                                        cssSelector=".cmp-adaptiveform-checkboxgroup__option-label:hover"/>
+                                                        cssSelector=".cmp-adaptiveform-checkboxgroup__widget.VERTICAL .cmp-adaptiveform-checkboxgroup__option-label:hover"/>
                                                 <focus
                                                         jcr:primaryType="nt:unstructured"
                                                         jcr:title="Focus"
-                                                        cssSelector=".cmp-adaptiveform-checkboxgroup__option-label:focus"/>
+                                                        cssSelector=".cmp-adaptiveform-checkboxgroup__widget.VERTICAL .cmp-adaptiveform-checkboxgroup__option-label:focus"/>
                                             </states>
                                         </checkBoxGroupItemLabelContainerVertical>
                                     </items>
@@ -419,19 +419,19 @@
                                         <disabled
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Disabled"
-                                                cssSelector=".cmp-adaptiveform-checkboxgroup-item .cmp-adaptiveform-checkboxgroup__option__widget:disabled"/>
+                                                cssSelector=".cmp-adaptiveform-checkboxgroup__widget.VERTICAL .cmp-adaptiveform-checkboxgroup-item .cmp-adaptiveform-checkboxgroup__option__widget:disabled"/>
                                         <hover
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Hover"
-                                                cssSelector=".cmp-adaptiveform-checkboxgroup-item:hover"/>
+                                                cssSelector=".cmp-adaptiveform-checkboxgroup__widget.VERTICAL .cmp-adaptiveform-checkboxgroup-item:hover"/>
                                         <checked
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Selected"
-                                                cssSelector=".cmp-adaptiveform-checkboxgroup-item .cmp-adaptiveform-checkboxgroup__option__widget:checked"/>
+                                                cssSelector=".cmp-adaptiveform-checkboxgroup__widget.VERTICAL .cmp-adaptiveform-checkboxgroup-item .cmp-adaptiveform-checkboxgroup__option__widget:checked"/>
                                         <focus
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Focus"
-                                                cssSelector=".cmp-adaptiveform-checkboxgroup-item:focus"/>
+                                                cssSelector=".cmp-adaptiveform-checkboxgroup__widget.VERTICAL .cmp-adaptiveform-checkboxgroup-item:focus"/>
                                     </states>
                                 </checkBoxGroupItemVertical>
                             </items>
@@ -461,6 +461,15 @@
                                 cssSelector=".cmp-adaptiveform-checkboxgroup__longdescription"
                                 longTitle="Checkbox Group Long Description"
                                 propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                    <items jcr:primaryType="nt:unstructured">
+                        <longDescriptionParagraph
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Long Description Paragraph"
+                                id="af2_checkboxgroupdescriptionlongparagraph"
+                                cssSelector=".cmp-adaptiveform-checkboxgroup__longdescription p"
+                                longTitle="Long Description Paragraph"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                    </items>
                             <states jcr:primaryType="nt:unstructured">
                                 <focus
                                         jcr:primaryType="nt:unstructured"

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v2/container/_cq_themeConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v2/container/_cq_themeConfig/.content.xml
@@ -85,6 +85,9 @@
                         <datePickerWidgetAndText
                             jcr:primaryType="nt:unstructured"
                             target="/mnt/override/libs/core/fd/components/form/datepicker/v1/datepicker/cq:styleConfig/items/field/items/widgetAndText"/>
+                        <dateTimeWidgetAndText
+                            jcr:primaryType="nt:unstructured"
+                            target="/mnt/override/libs/core/fd/components/form/datetime/v1/datetime/cq:styleConfig/items/field/items/widgetAndText"/>
                         <checkBoxWidgetAndText
                             jcr:primaryType="nt:unstructured"
                             target="/mnt/override/libs/core/fd/components/form/checkbox/v1/checkbox/cq:styleConfig/items/field/items/widgetAndText"/>
@@ -99,7 +102,10 @@
                             target="/mnt/override/libs/core/fd/components/form/switch/v1/switch/cq:styleConfig/items/field/items/widgetAndText"/>
                         <fileUploadButton
                             jcr:primaryType="nt:unstructured"
-                            target="/mnt/override/libs/core/fd/components/form/fileinput/v3/fileinput/cq:styleConfig/items/field/items/widgetAndText"/>
+                            target="/mnt/override/libs/core/fd/components/form/fileinput/v4/fileinput/cq:styleConfig/items/field/items/widgetAndText"/>
+                        <scribbleWidgetAndText
+                            jcr:primaryType="nt:unstructured"
+                            target="/mnt/override/libs/core/fd/components/form/scribble/v1/scribble/cq:styleConfig/items/field/items/widgetAndText"/>
                         <tncWidgetAndText
                             jcr:primaryType="nt:unstructured"
                             target="/mnt/override/libs/core/fd/components/form/termsandconditions/v1/termsandconditions/cq:styleConfig/items/field/items/widgetAndText"/>

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v2/container/_cq_themeConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v2/container/_cq_themeConfig/.content.xml
@@ -103,9 +103,6 @@
                         <fileUploadButton
                             jcr:primaryType="nt:unstructured"
                             target="/mnt/override/libs/core/fd/components/form/fileinput/v4/fileinput/cq:styleConfig/items/field/items/widgetAndText"/>
-                        <scribbleWidgetAndText
-                            jcr:primaryType="nt:unstructured"
-                            target="/mnt/override/libs/core/fd/components/form/scribble/v1/scribble/cq:styleConfig/items/field/items/widgetAndText"/>
                         <tncWidgetAndText
                             jcr:primaryType="nt:unstructured"
                             target="/mnt/override/libs/core/fd/components/form/termsandconditions/v1/termsandconditions/cq:styleConfig/items/field/items/widgetAndText"/>
@@ -137,9 +134,29 @@
                     target="/mnt/override/libs/core/fd/components/form/base/v1/base/cq:styleConfig/items/field/items/errorMessage"/>
             </items>
         </base>
+        <review
+            jcr:primaryType="nt:unstructured"
+            jcr:title="Review"
+            id="af2_review"
+            cssSelector=".cmp-adaptiveform-review"
+            longTitle="Review"
+            propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
+            target="/mnt/override/libs/core/fd/components/form/review/v1/review/cq:styleConfig/items/field/items/widgetAndText"/>
+        <scribble
+            jcr:primaryType="nt:unstructured"
+            jcr:title="Scribble"
+            id="af2_scribble"
+            cssSelector=".cmp-adaptiveform-scribble"
+            longTitle="Scribble"
+            propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
+            target="/mnt/override/libs/core/fd/components/form/scribble/v1/scribble/cq:styleConfig/items/field/items/widgetAndText"/>
         <button
             jcr:primaryType="nt:unstructured"
-            jcr:title="Button">
+            jcr:title="Button"
+            id="af2_button"
+            cssSelector=".cmp-adaptiveform-button"
+            longTitle="Button"
+            propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
             <items jcr:primaryType="nt:unstructured">
                 <allButton
                     jcr:primaryType="nt:unstructured"
@@ -154,7 +171,11 @@
         </button>
         <panel
             jcr:primaryType="nt:unstructured"
-            jcr:title="Panel">
+            jcr:title="Panel"
+            id="af2_panel"
+            cssSelector=".cmp-adaptiveform-panel"
+            longTitle="Panel"
+            propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
             <items jcr:primaryType="nt:unstructured">
                 <responsivePanel
                     jcr:primaryType="nt:unstructured"
@@ -175,12 +196,35 @@
         </panel>
         <Image
             jcr:primaryType="nt:unstructured"
-            target="/mnt/override/libs/core/fd/components/form/image/v1/image/cq:styleConfig/items/Image"/>
+            jcr:title="Image"
+            id="af2_image"
+            cssSelector=".cmp-adaptiveform-image"
+            longTitle="Image"
+            propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+            <items jcr:primaryType="nt:unstructured">
+                <imageRoot
+                    jcr:primaryType="nt:unstructured"
+                    target="/mnt/override/libs/core/fd/components/form/image/v1/image/cq:styleConfig/items/Image/items/imageRoot"/>
+                <image
+                    jcr:primaryType="nt:unstructured"
+                    target="/mnt/override/libs/core/fd/components/form/image/v1/image/cq:styleConfig/items/Image/items/image"/>
+            </items>
+        </Image>
         <hcaptcha
             jcr:primaryType="nt:unstructured"
+            jcr:title="HCaptcha"
+            id="af2_hcaptcha"
+            cssSelector=".cmp-adaptiveform-hcaptcha"
+            longTitle="HCaptcha"
+            propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
             target="/mnt/override/libs/core/fd/components/form/hcaptcha/v1/hcaptcha/cq:styleConfig/items/field/items/captcha"/>
         <recaptcha
-                jcr:primaryType="nt:unstructured"
-                target="/mnt/override/libs/core/fd/components/form/recaptcha/v1/recaptcha/cq:styleConfig/items/field/items/captcha"/>
+            jcr:primaryType="nt:unstructured"
+            jcr:title="reCaptcha"
+            id="af2_recaptcha"
+            cssSelector=".cmp-adaptiveform-recaptcha"
+            longTitle="reCaptcha"
+            propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
+            target="/mnt/override/libs/core/fd/components/form/recaptcha/v1/recaptcha/cq:styleConfig/items/field/items/captcha"/>
     </items>
 </jcr:root>

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/datepicker/v1/datepicker/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/datepicker/v1/datepicker/_cq_styleConfig/.content.xml
@@ -31,25 +31,25 @@
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Label"
                                         id="af2_datepickerlabel"
-                                        cssSelector=".cmp-adaptiveform-datepicker__label"
+                                        cssSelector=".cmp-adaptiveform-datepicker__label-container .cmp-adaptiveform-datepicker__label"
                                         longTitle="Datepicker Label"
                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                                     <states jcr:primaryType="nt:unstructured">
                                         <hover
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Hover"
-                                                cssSelector=".cmp-adaptiveform-datepicker__label:hover"/>
+                                                cssSelector=".cmp-adaptiveform-datepicker__label-container .cmp-adaptiveform-datepicker__label:hover"/>
                                         <focus
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Focus"
-                                                cssSelector=".cmp-adaptiveform-datepicker__label:focus"/>
+                                                cssSelector=".cmp-adaptiveform-datepicker__label-container .cmp-adaptiveform-datepicker__label:focus"/>
                                     </states>
                                 </datepickerLabel>
                                 <datepickerHelpIcon
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Help Icon"
                                         id="af2_datepickerhelpicon"
-                                        cssSelector=".cmp-adaptiveform-datepicker__questionmark"
+                                        cssSelector=".cmp-adaptiveform-datepicker__label-container .cmp-adaptiveform-datepicker__questionmark"
                                         longTitle="Datepicker Help Icon"
                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
                                         secondarySelectors="af2_guideContainer:af2_helpicon">
@@ -57,15 +57,15 @@
                                         <focus
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Focus"
-                                                cssSelector=".cmp-adaptiveform-datepicker__questionmark:focus"/>
+                                                cssSelector=".cmp-adaptiveform-datepicker__label-container .cmp-adaptiveform-datepicker__questionmark:focus"/>
                                         <hover
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Hover"
-                                                cssSelector=".cmp-adaptiveform-datepicker__questionmark:hover"/>
+                                                cssSelector=".cmp-adaptiveform-datepicker__label-container .cmp-adaptiveform-datepicker__questionmark:hover"/>
                                         <disabled
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Disabled"
-                                                cssSelector=".cmp-adaptiveform-datepicker__questionmark:disabled"/>
+                                                cssSelector=".cmp-adaptiveform-datepicker__label-container .cmp-adaptiveform-datepicker__questionmark:disabled"/>
                                     </states>
                                 </datepickerHelpIcon>
                             </items>
@@ -73,15 +73,15 @@
                                 <disabled
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Disabled"
-                                        cssSelector="cmp-adaptiveform-datepicker__label-container:disabled"/>
+                                        cssSelector=".cmp-adaptiveform-datepicker__label-container:disabled"/>
                                 <hover
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Hover"
-                                        cssSelector="cmp-adaptiveform-datepicker__label-container:hover"/>
+                                        cssSelector=".cmp-adaptiveform-datepicker__label-container:hover"/>
                                 <focus
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Focus"
-                                        cssSelector="cmp-adaptiveform-datepicker__label-container:focus"/>
+                                        cssSelector=".cmp-adaptiveform-datepicker__label-container:focus"/>
                             </states>
                         </datepickerLabelContainer>
                         <datepickerWidgetAndText
@@ -126,6 +126,15 @@
                                 cssSelector=".cmp-adaptiveform-datepicker__longdescription"
                                 longTitle="Datepicker Long Description"
                                 propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                    <items jcr:primaryType="nt:unstructured">
+                        <longDescriptionParagraph
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Long Description Paragraph"
+                                id="af2_datepickerdescriptionlongparagraph"
+                                cssSelector=".cmp-adaptiveform-datepicker__longdescription p"
+                                longTitle="Long Description Paragraph"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                    </items>
                             <states jcr:primaryType="nt:unstructured">
                                 <focus
                                         jcr:primaryType="nt:unstructured"

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/dropdown/v1/dropdown/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/dropdown/v1/dropdown/_cq_styleConfig/.content.xml
@@ -31,25 +31,25 @@
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Label"
                                         id="af2_dropdownlabel"
-                                        cssSelector=".cmp-adaptiveform-dropdown__label"
+                                        cssSelector=".cmp-adaptiveform-dropdown__label-container .cmp-adaptiveform-dropdown__label"
                                         longTitle="Dropdown Label"
                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                                     <states jcr:primaryType="nt:unstructured">
                                         <hover
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Hover"
-                                                cssSelector=".cmp-adaptiveform-dropdown__label:hover"/>
+                                                cssSelector=".cmp-adaptiveform-dropdown__label-container .cmp-adaptiveform-dropdown__label:hover"/>
                                         <focus
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Focus"
-                                                cssSelector=".cmp-adaptiveform-dropdown__label:focus"/>
+                                                cssSelector=".cmp-adaptiveform-dropdown__label-container .cmp-adaptiveform-dropdown__label:focus"/>
                                     </states>
                                 </dropdownLabel>
                                 <dropdownHelpIcon
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Help Icon"
                                         id="af2_dropdownhelpicon"
-                                        cssSelector=".cmp-adaptiveform-dropdown__questionmark"
+                                        cssSelector=".cmp-adaptiveform-dropdown__label-container .cmp-adaptiveform-dropdown__questionmark"
                                         longTitle="Dropdown Help Icon"
                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
                                         secondarySelectors="af2_guideContainer:af2_helpicon">
@@ -57,15 +57,15 @@
                                         <focus
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Focus"
-                                                cssSelector=".cmp-adaptiveform-dropdown__questionmark:focus"/>
+                                                cssSelector=".cmp-adaptiveform-dropdown__label-container .cmp-adaptiveform-dropdown__questionmark:focus"/>
                                         <hover
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Hover"
-                                                cssSelector=".cmp-adaptiveform-dropdown__questionmark:hover"/>
+                                                cssSelector=".cmp-adaptiveform-dropdown__label-container .cmp-adaptiveform-dropdown__questionmark:hover"/>
                                         <disabled
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Disabled"
-                                                cssSelector=".cmp-adaptiveform-dropdown__questionmark:disabled"/>
+                                                cssSelector=".cmp-adaptiveform-dropdown__label-container .cmp-adaptiveform-dropdown__questionmark:disabled"/>
                                     </states>
                                 </dropdownHelpIcon>
                             </items>
@@ -73,15 +73,15 @@
                                 <disabled
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Disabled"
-                                        cssSelector="cmp-adaptiveform-dropdown__label-container:disabled"/>
+                                        cssSelector=".cmp-adaptiveform-dropdown__label-container:disabled"/>
                                 <hover
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Hover"
-                                        cssSelector="cmp-adaptiveform-dropdown__label-container:hover"/>
+                                        cssSelector=".cmp-adaptiveform-dropdown__label-container:hover"/>
                                 <focus
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Focus"
-                                        cssSelector="cmp-adaptiveform-dropdown__label-container:focus"/>
+                                        cssSelector=".cmp-adaptiveform-dropdown__label-container:focus"/>
                             </states>
                         </dropdownLabelContainer>
                         <dropdownWidgetAndText
@@ -109,6 +109,10 @@
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Mandatory"
                                         cssSelector=".cmp-adaptiveform-dropdown__widget:required"/>
+                                <multiple
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Multiple"
+                                        cssSelector=".cmp-adaptiveform-dropdown__widget[multiple='multiple']"/>
                             </states>
                         </dropdownWidgetAndText>
                         <dropdownDescriptionShort
@@ -126,6 +130,15 @@
                                 cssSelector=".cmp-adaptiveform-dropdown__longdescription"
                                 longTitle="Dropdown Long Description"
                                 propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                    <items jcr:primaryType="nt:unstructured">
+                        <longDescriptionParagraph
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Long Description Paragraph"
+                                id="af2_dropdowndescriptionlongparagraph"
+                                cssSelector=".cmp-adaptiveform-dropdown__longdescription p"
+                                longTitle="Long Description Paragraph"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                    </items>
                             <states jcr:primaryType="nt:unstructured">
                                 <focus
                                         jcr:primaryType="nt:unstructured"

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/emailinput/v1/emailinput/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/emailinput/v1/emailinput/_cq_styleConfig/.content.xml
@@ -26,25 +26,25 @@
                                     jcr:primaryType="nt:unstructured"
                                     jcr:title="Label"
                                     id="af2_emaillabel"
-                                    cssSelector=".cmp-adaptiveform-emailinput__label"
+                                    cssSelector=".cmp-adaptiveform-emailinput__label-container .cmp-adaptiveform-emailinput__label"
                                     longTitle="Email Label"
                                     propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                                     <states jcr:primaryType="nt:unstructured">
                                         <hover
                                             jcr:primaryType="nt:unstructured"
                                             jcr:title="Hover"
-                                            cssSelector=".cmp-adaptiveform-emailinput__label:hover"/>
+                                            cssSelector=".cmp-adaptiveform-emailinput__label-container .cmp-adaptiveform-emailinput__label:hover"/>
                                         <focus
                                             jcr:primaryType="nt:unstructured"
                                             jcr:title="Focus"
-                                            cssSelector=".cmp-adaptiveform-emailinput__label:focus"/>
+                                            cssSelector=".cmp-adaptiveform-emailinput__label-container .cmp-adaptiveform-emailinput__label:focus"/>
                                     </states>
                                 </emailLabel>
                                 <emailHelpIcon
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Help Icon"
                                         id="af2_emailhelpicon"
-                                        cssSelector=".cmp-adaptiveform-emailinput__questionmark"
+                                        cssSelector=".cmp-adaptiveform-emailinput__label-container .cmp-adaptiveform-emailinput__questionmark"
                                         longTitle="Email Help Icon"
                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
                                         secondarySelectors="af2_guideContainer:af2_helpicon">
@@ -52,15 +52,15 @@
                                         <focus
                                             jcr:primaryType="nt:unstructured"
                                             jcr:title="Focus"
-                                            cssSelector=".cmp-adaptiveform-emailinput__questionmark:focus"/>
+                                            cssSelector=".cmp-adaptiveform-emailinput__label-container .cmp-adaptiveform-emailinput__questionmark:focus"/>
                                         <hover
                                             jcr:primaryType="nt:unstructured"
                                             jcr:title="Hover"
-                                            cssSelector=".cmp-adaptiveform-emailinput__questionmark:hover"/>
+                                            cssSelector=".cmp-adaptiveform-emailinput__label-container .cmp-adaptiveform-emailinput__questionmark:hover"/>
                                         <disabled
                                             jcr:primaryType="nt:unstructured"
                                             jcr:title="Disabled"
-                                            cssSelector=".cmp-adaptiveform-emailinput__questionmark:disabled"/>
+                                            cssSelector=".cmp-adaptiveform-emailinput__label-container .cmp-adaptiveform-emailinput__questionmark:disabled"/>
                                     </states>
                                 </emailHelpIcon>
                             </items>
@@ -121,6 +121,15 @@
                                 cssSelector=".cmp-adaptiveform-emailinput__longdescription"
                                 longTitle="Email Long Description"
                                 propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                    <items jcr:primaryType="nt:unstructured">
+                        <longDescriptionParagraph
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Long Description Paragraph"
+                                id="af2_emaildescriptionlongparagraph"
+                                cssSelector=".cmp-adaptiveform-emailinput__longdescription p"
+                                longTitle="Long Description Paragraph"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                    </items>
                             <states jcr:primaryType="nt:unstructured">
                                 <focus
                                     jcr:primaryType="nt:unstructured"

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/fileinput/v3/fileinput/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/fileinput/v3/fileinput/_cq_styleConfig/.content.xml
@@ -31,25 +31,25 @@
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Label"
                                         id="af2_fileinputlabel"
-                                        cssSelector=".cmp-adaptiveform-fileinput__label"
+                                        cssSelector=".cmp-adaptiveform-fileinput__label-container .cmp-adaptiveform-fileinput__label"
                                         longTitle="File Input Label"
                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                                     <states jcr:primaryType="nt:unstructured">
                                         <hover
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Hover"
-                                                cssSelector=".cmp-adaptiveform-fileinput__label:hover"/>
+                                                cssSelector=".cmp-adaptiveform-fileinput__label-container .cmp-adaptiveform-fileinput__label:hover"/>
                                         <focus
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Focus"
-                                                cssSelector=".cmp-adaptiveform-fileinput__label:focus"/>
+                                                cssSelector=".cmp-adaptiveform-fileinput__label-container .cmp-adaptiveform-fileinput__label:focus"/>
                                     </states>
                                 </fileinputLabel>
                                 <fileinputHelpIcon
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Help Icon"
                                         id="af2_fileinputhelpicon"
-                                        cssSelector=".cmp-adaptiveform-fileinput__questionmark"
+                                        cssSelector=".cmp-adaptiveform-fileinput__label-container .cmp-adaptiveform-fileinput__questionmark"
                                         longTitle="File Input Help Icon"
                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
                                         secondarySelectors="af2_guideContainer:af2_helpicon">
@@ -57,15 +57,15 @@
                                         <focus
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Focus"
-                                                cssSelector=".cmp-adaptiveform-fileinput__questionmark:focus"/>
+                                                cssSelector=".cmp-adaptiveform-fileinput__label-container .cmp-adaptiveform-fileinput__questionmark:focus"/>
                                         <hover
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Hover"
-                                                cssSelector=".cmp-adaptiveform-fileinput__questionmark:hover"/>
+                                                cssSelector=".cmp-adaptiveform-fileinput__label-container .cmp-adaptiveform-fileinput__questionmark:hover"/>
                                         <disabled
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Disabled"
-                                                cssSelector=".cmp-adaptiveform-fileinput__questionmark:disabled"/>
+                                                cssSelector=".cmp-adaptiveform-fileinput__label-container .cmp-adaptiveform-fileinput__questionmark:disabled"/>
                                     </states>
                                 </fileinputHelpIcon>
                             </items>
@@ -73,15 +73,15 @@
                                 <disabled
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Disabled"
-                                        cssSelector="cmp-adaptiveform-fileinput__label-container:disabled"/>
+                                        cssSelector=".cmp-adaptiveform-fileinput__label-container:disabled"/>
                                 <hover
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Hover"
-                                        cssSelector="cmp-adaptiveform-fileinput__label-container:hover"/>
+                                        cssSelector=".cmp-adaptiveform-fileinput__label-container:hover"/>
                                 <focus
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Focus"
-                                        cssSelector="cmp-adaptiveform-fileinput__label-container:focus"/>
+                                        cssSelector=".cmp-adaptiveform-fileinput__label-container:focus"/>
                             </states>
                         </fileinputLabelContainer>
                         <fileinputWidgetAndText
@@ -193,6 +193,24 @@
                                                 cssSelector=".cmp-adaptiveform-fileinput__widgetlabel:required"/>
                                     </states>
                                 </fileinputWidget>
+                                <fileinputNativeWidget
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Native File Input"
+                                        id="af2_fileinputnativewidget"
+                                        cssSelector=".cmp-adaptiveform-fileinput__widget"
+                                        longTitle="File Input Native Widget"
+                                        propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                                    <states jcr:primaryType="nt:unstructured">
+                                        <webkitUploadButton
+                                                jcr:primaryType="nt:unstructured"
+                                                jcr:title="WebKit Upload Button"
+                                                cssSelector=".cmp-adaptiveform-fileinput__widget::-webkit-file-upload-button"/>
+                                        <before
+                                                jcr:primaryType="nt:unstructured"
+                                                jcr:title="Before Pseudo"
+                                                cssSelector=".cmp-adaptiveform-fileinput__widget::before"/>
+                                    </states>
+                                </fileinputNativeWidget>
                             </items>
                             <states jcr:primaryType="nt:unstructured">
                                 <focus
@@ -213,6 +231,38 @@
                                         cssSelector=".cmp-adaptiveform-fileinput__container:required"/>
                             </states>
                         </fileinputWidgetAndText>
+                        <fileinputFileList
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="File List"
+                                id="af2_fileinputfilelist"
+                                cssSelector=".cmp-adaptiveform-fileinput__filelist"
+                                longTitle="File Input File List"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                            <items jcr:primaryType="nt:unstructured">
+                                <fileinputFileItem
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="File Item"
+                                        id="af2_fileinputfileitem"
+                                        cssSelector=".cmp-adaptiveform-fileinput__fileitem"
+                                        longTitle="File Input File Item"
+                                        propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                                </fileinputFileItem>
+                                <fileinputFileName
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="File Name"
+                                        id="af2_fileinputfilename"
+                                        cssSelector=".cmp-adaptiveform-fileinput__filename"
+                                        longTitle="File Input File Name"
+                                        propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                                <fileinputFileDelete
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="File Delete"
+                                        id="af2_fileinputfiledelete"
+                                        cssSelector=".cmp-adaptiveform-fileinput__filedelete"
+                                        longTitle="File Input File Delete"
+                                        propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                            </items>
+                        </fileinputFileList>
                         <fileinputDescriptionShort
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Short Description"
@@ -228,6 +278,15 @@
                                 cssSelector=".cmp-adaptiveform-fileinput__longdescription"
                                 longTitle="File Input Long Description"
                                 propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                    <items jcr:primaryType="nt:unstructured">
+                        <longDescriptionParagraph
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Long Description Paragraph"
+                                id="af2_fileinputdescriptionlongparagraph"
+                                cssSelector=".cmp-adaptiveform-fileinput__longdescription p"
+                                longTitle="Long Description Paragraph"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                    </items>
                             <states jcr:primaryType="nt:unstructured">
                                 <focus
                                     jcr:primaryType="nt:unstructured"

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/fileinput/v3/fileinput/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/fileinput/v3/fileinput/_cq_styleConfig/.content.xml
@@ -193,24 +193,6 @@
                                                 cssSelector=".cmp-adaptiveform-fileinput__widgetlabel:required"/>
                                     </states>
                                 </fileinputWidget>
-                                <fileinputNativeWidget
-                                        jcr:primaryType="nt:unstructured"
-                                        jcr:title="Native File Input"
-                                        id="af2_fileinputnativewidget"
-                                        cssSelector=".cmp-adaptiveform-fileinput__widget"
-                                        longTitle="File Input Native Widget"
-                                        propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
-                                    <states jcr:primaryType="nt:unstructured">
-                                        <webkitUploadButton
-                                                jcr:primaryType="nt:unstructured"
-                                                jcr:title="WebKit Upload Button"
-                                                cssSelector=".cmp-adaptiveform-fileinput__widget::-webkit-file-upload-button"/>
-                                        <before
-                                                jcr:primaryType="nt:unstructured"
-                                                jcr:title="Before Pseudo"
-                                                cssSelector=".cmp-adaptiveform-fileinput__widget::before"/>
-                                    </states>
-                                </fileinputNativeWidget>
                             </items>
                             <states jcr:primaryType="nt:unstructured">
                                 <focus

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/fileinput/v4/fileinput/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/fileinput/v4/fileinput/_cq_styleConfig/.content.xml
@@ -31,25 +31,25 @@
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Label"
                                         id="af2_fileinputlabel"
-                                        cssSelector=".cmp-adaptiveform-fileinput__label"
+                                        cssSelector=".cmp-adaptiveform-fileinput__label-container .cmp-adaptiveform-fileinput__label"
                                         longTitle="File Input Label"
                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                                     <states jcr:primaryType="nt:unstructured">
                                         <hover
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Hover"
-                                                cssSelector=".cmp-adaptiveform-fileinput__label:hover"/>
+                                                cssSelector=".cmp-adaptiveform-fileinput__label-container .cmp-adaptiveform-fileinput__label:hover"/>
                                         <focus
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Focus"
-                                                cssSelector=".cmp-adaptiveform-fileinput__label:focus"/>
+                                                cssSelector=".cmp-adaptiveform-fileinput__label-container .cmp-adaptiveform-fileinput__label:focus"/>
                                     </states>
                                 </fileinputLabel>
                                 <fileinputHelpIcon
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Help Icon"
                                         id="af2_fileinputhelpicon"
-                                        cssSelector=".cmp-adaptiveform-fileinput__questionmark"
+                                        cssSelector=".cmp-adaptiveform-fileinput__label-container .cmp-adaptiveform-fileinput__questionmark"
                                         longTitle="File Input Help Icon"
                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
                                         secondarySelectors="af2_guideContainer:af2_helpicon">
@@ -57,15 +57,15 @@
                                         <focus
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Focus"
-                                                cssSelector=".cmp-adaptiveform-fileinput__questionmark:focus"/>
+                                                cssSelector=".cmp-adaptiveform-fileinput__label-container .cmp-adaptiveform-fileinput__questionmark:focus"/>
                                         <hover
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Hover"
-                                                cssSelector=".cmp-adaptiveform-fileinput__questionmark:hover"/>
+                                                cssSelector=".cmp-adaptiveform-fileinput__label-container .cmp-adaptiveform-fileinput__questionmark:hover"/>
                                         <disabled
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Disabled"
-                                                cssSelector=".cmp-adaptiveform-fileinput__questionmark:disabled"/>
+                                                cssSelector=".cmp-adaptiveform-fileinput__label-container .cmp-adaptiveform-fileinput__questionmark:disabled"/>
                                     </states>
                                 </fileinputHelpIcon>
                             </items>
@@ -130,6 +130,24 @@
                                                 cssSelector=".cmp-adaptiveform-fileinput__widgetlabel:disabled"/>
                                     </states>
                                 </fileinputWidgetlabel>
+                                <fileinputNativeWidget
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Native File Input"
+                                        id="af2_fileinputnativewidget"
+                                        cssSelector=".cmp-adaptiveform-fileinput__widget"
+                                        longTitle="File Input Native Widget"
+                                        propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                                    <states jcr:primaryType="nt:unstructured">
+                                        <webkitUploadButton
+                                                jcr:primaryType="nt:unstructured"
+                                                jcr:title="WebKit Upload Button"
+                                                cssSelector=".cmp-adaptiveform-fileinput__widget::-webkit-file-upload-button"/>
+                                        <before
+                                                jcr:primaryType="nt:unstructured"
+                                                jcr:title="Before Pseudo"
+                                                cssSelector=".cmp-adaptiveform-fileinput__widget::before"/>
+                                    </states>
+                                </fileinputNativeWidget>
                                 <fileinputFilelist
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="File List"
@@ -137,6 +155,30 @@
                                         cssSelector=".cmp-adaptiveform-fileinput__filelist"
                                         longTitle="File Input File List"
                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                                    <items jcr:primaryType="nt:unstructured">
+                                        <fileinputFileItem
+                                                jcr:primaryType="nt:unstructured"
+                                                jcr:title="File Item"
+                                                id="af2_fileinputfileitem"
+                                                cssSelector=".cmp-adaptiveform-fileinput__fileitem"
+                                                longTitle="File Input File Item"
+                                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                                        </fileinputFileItem>
+                                        <fileinputFileName
+                                                jcr:primaryType="nt:unstructured"
+                                                jcr:title="File Name"
+                                                id="af2_fileinputfilename"
+                                                cssSelector=".cmp-adaptiveform-fileinput__filename"
+                                                longTitle="File Input File Name"
+                                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                                        <fileinputFileDelete
+                                                jcr:primaryType="nt:unstructured"
+                                                jcr:title="File Delete"
+                                                id="af2_fileinputfiledelete"
+                                                cssSelector=".cmp-adaptiveform-fileinput__filedelete"
+                                                longTitle="File Input File Delete"
+                                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                                    </items>
                                 </fileinputFilelist>
                             </items>
                         </fileinputContainer>
@@ -155,6 +197,15 @@
                                 cssSelector=".cmp-adaptiveform-fileinput__longdescription"
                                 longTitle="File Input Long Description"
                                 propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                    <items jcr:primaryType="nt:unstructured">
+                        <longDescriptionParagraph
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Long Description Paragraph"
+                                id="af2_fileinputdescriptionlongparagraph"
+                                cssSelector=".cmp-adaptiveform-fileinput__longdescription p"
+                                longTitle="Long Description Paragraph"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                    </items>
                             <states jcr:primaryType="nt:unstructured">
                                 <focus
                                         jcr:primaryType="nt:unstructured"

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/footer/v1/footer/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/footer/v1/footer/_cq_styleConfig/.content.xml
@@ -11,6 +11,13 @@
             cssSelector=".cmp-adaptiveform-footer"
             propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
             <items jcr:primaryType="nt:unstructured">
+                <footerTextPlain
+                    longTitle="Footer Text"
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="Footer Text (Plain)"
+                    id="af2_footertextplain"
+                    cssSelector=".cmp-adaptiveform-footer__text"
+                    propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
                 <footerText
                     longTitle="Footer Text"
                     jcr:primaryType="nt:unstructured"

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/image/v1/image/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/image/v1/image/_cq_styleConfig/.content.xml
@@ -3,6 +3,13 @@
     jcr:primaryType="nt:unstructured"
     jcr:title="image">
     <items jcr:primaryType="nt:unstructured">
+        <imageRoot
+            jcr:primaryType="nt:unstructured"
+            jcr:title="Image Container"
+            id="af2_imageroot"
+            cssSelector=".cmp-image"
+            longTitle="Image Container"
+            propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
         <Image
             jcr:primaryType="nt:unstructured"
             jcr:title="Image"

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/numberinput/v1/numberinput/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/numberinput/v1/numberinput/_cq_styleConfig/.content.xml
@@ -31,25 +31,25 @@
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Label"
                                         id="af2_numberinputlabel"
-                                        cssSelector=".cmp-adaptiveform-numberinput__label"
+                                        cssSelector=".cmp-adaptiveform-numberinput__label-container .cmp-adaptiveform-numberinput__label"
                                         longTitle="Number Input Label"
                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                                     <states jcr:primaryType="nt:unstructured">
                                         <hover
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Hover"
-                                                cssSelector=".cmp-adaptiveform-numberinput__label:hover"/>
+                                                cssSelector=".cmp-adaptiveform-numberinput__label-container .cmp-adaptiveform-numberinput__label:hover"/>
                                         <focus
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Focus"
-                                                cssSelector=".cmp-adaptiveform-numberinput__label:focus"/>
+                                                cssSelector=".cmp-adaptiveform-numberinput__label-container .cmp-adaptiveform-numberinput__label:focus"/>
                                     </states>
                                 </numberinputLabel>
                                 <numberinputHelpIcon
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Help Icon"
                                         id="af2_numberinputhelpicon"
-                                        cssSelector=".cmp-adaptiveform-numberinput__questionmark"
+                                        cssSelector=".cmp-adaptiveform-numberinput__label-container .cmp-adaptiveform-numberinput__questionmark"
                                         longTitle="Number Input Help Icon"
                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
                                         secondarySelectors="af2_guideContainer:af2_helpicon">
@@ -57,15 +57,15 @@
                                         <focus
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Focus"
-                                                cssSelector=".cmp-adaptiveform-numberinput__questionmark:focus"/>
+                                                cssSelector=".cmp-adaptiveform-numberinput__label-container .cmp-adaptiveform-numberinput__questionmark:focus"/>
                                         <hover
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Hover"
-                                                cssSelector=".cmp-adaptiveform-numberinput__questionmark:hover"/>
+                                                cssSelector=".cmp-adaptiveform-numberinput__label-container .cmp-adaptiveform-numberinput__questionmark:hover"/>
                                         <disabled
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Disabled"
-                                                cssSelector=".cmp-adaptiveform-numberinput__questionmark:disabled"/>
+                                                cssSelector=".cmp-adaptiveform-numberinput__label-container .cmp-adaptiveform-numberinput__questionmark:disabled"/>
                                     </states>
                                 </numberinputHelpIcon>
                             </items>
@@ -73,15 +73,15 @@
                                 <disabled
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Disabled"
-                                        cssSelector="cmp-adaptiveform-numberinput__label-container:disabled"/>
+                                        cssSelector=".cmp-adaptiveform-numberinput__label-container:disabled"/>
                                 <hover
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Hover"
-                                        cssSelector="cmp-adaptiveform-numberinput__label-container:hover"/>
+                                        cssSelector=".cmp-adaptiveform-numberinput__label-container:hover"/>
                                 <focus
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Focus"
-                                        cssSelector="cmp-adaptiveform-numberinput__label-container:focus"/>
+                                        cssSelector=".cmp-adaptiveform-numberinput__label-container:focus"/>
                             </states>
                         </numberinputLabelContainer>
                         <numberinputWidgetAndText
@@ -126,6 +126,15 @@
                                 cssSelector=".cmp-adaptiveform-numberinput__longdescription"
                                 longTitle="Number Input Long Description"
                                 propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                    <items jcr:primaryType="nt:unstructured">
+                        <longDescriptionParagraph
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Long Description Paragraph"
+                                id="af2_numberinputdescriptionlongparagraph"
+                                cssSelector=".cmp-adaptiveform-numberinput__longdescription p"
+                                longTitle="Long Description Paragraph"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                    </items>
                             <states jcr:primaryType="nt:unstructured">
                                 <focus
                                         jcr:primaryType="nt:unstructured"

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/panelcontainer/v1/panelcontainer/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/panelcontainer/v1/panelcontainer/_cq_styleConfig/.content.xml
@@ -23,25 +23,25 @@
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Label"
                                 id="af2_panellabel"
-                                cssSelector=".cmp-container__label"
+                                cssSelector=".cmp-container__label-container .cmp-container__label"
                                 longTitle="Panel Label"
                                 propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                             <states jcr:primaryType="nt:unstructured">
                                 <hover
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Hover"
-                                        cssSelector=".cmp-container__label:hover"/>
+                                        cssSelector=".cmp-container__label-container .cmp-container__label:hover"/>
                                 <focus
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Focus"
-                                        cssSelector=".cmp-container__label:focus"/>
+                                        cssSelector=".cmp-container__label-container .cmp-container__label:focus"/>
                             </states>
                         </panelLabel>
                         <panelHelpIcon
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Help Icon"
                                 id="af2_panelhelpicon"
-                                cssSelector=".cmp-container__questionmark"
+                                cssSelector=".cmp-container__label-container .cmp-container__questionmark"
                                 longTitle="Panel Help Icon"
                                 propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
                                 secondarySelectors="af2_guideContainer:af2_helpicon">
@@ -49,15 +49,15 @@
                                 <focus
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Focus"
-                                        cssSelector=".cmp-container__questionmark:focus"/>
+                                        cssSelector=".cmp-container__label-container .cmp-container__questionmark:focus"/>
                                 <hover
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Hover"
-                                        cssSelector=".cmp-container__questionmark:hover"/>
+                                        cssSelector=".cmp-container__label-container .cmp-container__questionmark:hover"/>
                                 <disabled
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Disabled"
-                                        cssSelector=".cmp-container__questionmark:disabled"/>
+                                        cssSelector=".cmp-container__label-container .cmp-container__questionmark:disabled"/>
                             </states>
                         </panelHelpIcon>
                     </items>
@@ -91,6 +91,15 @@
                         cssSelector=".cmp-container__longdescription"
                         longTitle="Panel Long Description"
                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                    <items jcr:primaryType="nt:unstructured">
+                        <longDescriptionParagraph
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Long Description Paragraph"
+                                id="af2_paneldescriptionlongparagraph"
+                                cssSelector=".cmp-container__longdescription p"
+                                longTitle="Long Description Paragraph"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                    </items>
                     <states jcr:primaryType="nt:unstructured">
                         <focus
                                 jcr:primaryType="nt:unstructured"

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/radiobutton/v1/radiobutton/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/radiobutton/v1/radiobutton/_cq_styleConfig/.content.xml
@@ -16,7 +16,8 @@
                     id="af2_radiobuttonwidgetandtext"
                     cssSelector=".cmp-adaptiveform-radiobutton"
                     longTitle="Radio Button Group Widget"
-                    propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                    propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
+                    secondarySelectors="af2_guideContainer:af2_widgetAndText">
                     <items jcr:primaryType="nt:unstructured">
                         <radioButtonLabelContainer
                                 jcr:primaryType="nt:unstructured"
@@ -30,25 +31,25 @@
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Label"
                                         id="af2_radiobuttonlabel"
-                                        cssSelector=".cmp-adaptiveform-radiobutton__label"
+                                        cssSelector=".cmp-adaptiveform-radiobutton__label-container .cmp-adaptiveform-radiobutton__label"
                                         longTitle="Radio Button Label"
                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                                     <states jcr:primaryType="nt:unstructured">
                                         <hover
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Hover"
-                                                cssSelector=".cmp-adaptiveform-radiobutton__label:hover"/>
+                                                cssSelector=".cmp-adaptiveform-radiobutton__label-container .cmp-adaptiveform-radiobutton__label:hover"/>
                                         <focus
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Focus"
-                                                cssSelector=".cmp-adaptiveform-radiobutton__label:focus"/>
+                                                cssSelector=".cmp-adaptiveform-radiobutton__label-container .cmp-adaptiveform-radiobutton__label:focus"/>
                                     </states>
                                 </radioButtonLabel>
                                 <radioButtonHelpIcon
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Help Icon"
                                         id="af2_radiobuttonhelpicon"
-                                        cssSelector=".cmp-adaptiveform-radiobutton__questionmark"
+                                        cssSelector=".cmp-adaptiveform-radiobutton__label-container .cmp-adaptiveform-radiobutton__questionmark"
                                         longTitle="Radio Button Help Icon"
                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
                                         secondarySelectors="af2_guideContainer:af2_helpicon">
@@ -56,15 +57,15 @@
                                         <focus
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Focus"
-                                                cssSelector=".cmp-adaptiveform-radiobutton__questionmark:focus"/>
+                                                cssSelector=".cmp-adaptiveform-radiobutton__label-container .cmp-adaptiveform-radiobutton__questionmark:focus"/>
                                         <hover
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Hover"
-                                                cssSelector=".cmp-adaptiveform-radiobutton__questionmark:hover"/>
+                                                cssSelector=".cmp-adaptiveform-radiobutton__label-container .cmp-adaptiveform-radiobutton__questionmark:hover"/>
                                         <disabled
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Disabled"
-                                                cssSelector=".cmp-adaptiveform-radiobutton__questionmark:disabled"/>
+                                                cssSelector=".cmp-adaptiveform-radiobutton__label-container .cmp-adaptiveform-radiobutton__questionmark:disabled"/>
                                     </states>
                                 </radioButtonHelpIcon>
                             </items>
@@ -220,73 +221,73 @@
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Radio Button Item"
                                         id="af2_radiobuttonitemhorizontal"
-                                        cssSelector=".cmp-adaptiveform-radiobutton__option"
-                                        longTitle="Radio Button Item"
+                                        cssSelector=".cmp-adaptiveform-radiobutton__widget.HORIZONTAL .cmp-adaptiveform-radiobutton__option"
+                                        longTitle="Radio Button Horizontal Layout Item"
                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                                     <items jcr:primaryType="nt:unstructured">
                                         <radioButtonItemLabelContainerHorizontal
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Radio Button Item Label Container"
                                                 id="af2_radiobuttonitemlabelcontainerhorizontal"
-                                                cssSelector=".cmp-adaptiveform-radiobutton__option-label"
-                                                longTitle="Radio Button Item Label Container"
+                                                cssSelector=".cmp-adaptiveform-radiobutton__widget.HORIZONTAL .cmp-adaptiveform-radiobutton__option-label"
+                                                longTitle="Radio Button Item Label Container (Horizontal)"
                                                 propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                                             <items jcr:primaryType="nt:unstructured">
                                                 <radioButtonLabelHorizontal
                                                         jcr:primaryType="nt:unstructured"
                                                         jcr:title="Label"
                                                         id="af2_radiobuttonitemlabelhorizontal"
-                                                        cssSelector=".cmp-adaptiveform-radiobutton__option-label span"
-                                                        longTitle="Radio Button Item Label"
+                                                        cssSelector=".cmp-adaptiveform-radiobutton__widget.HORIZONTAL .cmp-adaptiveform-radiobutton__option-label span"
+                                                        longTitle="Radio Button Item Label (Horizontal)"
                                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                                                     <states jcr:primaryType="nt:unstructured">
                                                         <disabled
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Disabled"
-                                                                cssSelector=".cmp-adaptiveform-radiobutton__option-label input[disabled] + span"/>
+                                                                cssSelector=".cmp-adaptiveform-radiobutton__widget.HORIZONTAL .cmp-adaptiveform-radiobutton__option-label input[disabled] + span"/>
                                                         <hover
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Hover"
-                                                                cssSelector=".cmp-adaptiveform-radiobutton__option-label:hover span"/>
+                                                                cssSelector=".cmp-adaptiveform-radiobutton__widget.HORIZONTAL .cmp-adaptiveform-radiobutton__option-label:hover span"/>
                                                         <checked
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Selected"
-                                                                cssSelector=".cmp-adaptiveform-radiobutton__option input[type='radio']:checked + span"/>
+                                                                cssSelector=".cmp-adaptiveform-radiobutton__widget.HORIZONTAL .cmp-adaptiveform-radiobutton__option-label input[type='radio']:checked + span"/>
                                                         <mandatory
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Mandatory"
-                                                                cssSelector=".cmp-adaptiveform-radiobutton[data-cmp-required='true'] .cmp-adaptiveform-radiobutton__option-label span"/>
+                                                                cssSelector=".cmp-adaptiveform-radiobutton[data-cmp-required='true'] .cmp-adaptiveform-radiobutton__widget.HORIZONTAL .cmp-adaptiveform-radiobutton__option-label span"/>
                                                     </states>
                                                 </radioButtonLabelHorizontal>
                                                 <radioButtonWidgetAndTextHorizontal
                                                         jcr:primaryType="nt:unstructured"
                                                         jcr:title="Radio Button"
                                                         id="af2_radiobuttonwidgethorizontal"
-                                                        cssSelector=".cmp-adaptiveform-radiobutton__option__widget"
-                                                        longTitle="Radio Button Item Widget"
+                                                        cssSelector=".cmp-adaptiveform-radiobutton__widget.HORIZONTAL .cmp-adaptiveform-radiobutton__option__widget"
+                                                        longTitle="Radio Button Item Widget (Horizontal)"
                                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
                                                         secondarySelectors="af2_guideContainer:af2_widgetAndText">
                                                     <states jcr:primaryType="nt:unstructured">
                                                         <focus
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Focus"
-                                                                cssSelector=".cmp-adaptiveform-radiobutton__option__widget:focus"/>
+                                                                cssSelector=".cmp-adaptiveform-radiobutton__widget.HORIZONTAL .cmp-adaptiveform-radiobutton__option__widget:focus"/>
                                                         <disabled
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Disabled"
-                                                                cssSelector=".cmp-adaptiveform-radiobutton__option__widget:disabled"/>
+                                                                cssSelector=".cmp-adaptiveform-radiobutton__widget.HORIZONTAL .cmp-adaptiveform-radiobutton__option__widget:disabled"/>
                                                         <hover
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Hover"
-                                                                cssSelector=".cmp-adaptiveform-radiobutton__option__widget:hover"/>
+                                                                cssSelector=".cmp-adaptiveform-radiobutton__widget.HORIZONTAL .cmp-adaptiveform-radiobutton__option__widget:hover"/>
                                                         <checked
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Selected"
-                                                                cssSelector=".cmp-adaptiveform-radiobutton__option__widget:checked"/>
+                                                                cssSelector=".cmp-adaptiveform-radiobutton__widget.HORIZONTAL .cmp-adaptiveform-radiobutton__option__widget:checked"/>
                                                         <mandatory
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Mandatory"
-                                                                cssSelector=".cmp-adaptiveform-radiobutton__option__widget:required"/>
+                                                                cssSelector=".cmp-adaptiveform-radiobutton__widget.HORIZONTAL .cmp-adaptiveform-radiobutton__option__widget:required"/>
                                                     </states>
                                                 </radioButtonWidgetAndTextHorizontal>
                                             </items>
@@ -294,11 +295,11 @@
                                                 <hover
                                                         jcr:primaryType="nt:unstructured"
                                                         jcr:title="Hover"
-                                                        cssSelector=".cmp-adaptiveform-radiobutton__option-label:hover"/>
+                                                        cssSelector=".cmp-adaptiveform-radiobutton__widget.HORIZONTAL .cmp-adaptiveform-radiobutton__option-label:hover"/>
                                                 <focus
                                                         jcr:primaryType="nt:unstructured"
                                                         jcr:title="Focus"
-                                                        cssSelector=".cmp-adaptiveform-radiobutton__option-label:focus"/>
+                                                        cssSelector=".cmp-adaptiveform-radiobutton__widget.HORIZONTAL .cmp-adaptiveform-radiobutton__option-label:focus"/>
                                             </states>
                                         </radioButtonItemLabelContainerHorizontal>
                                     </items>
@@ -306,19 +307,19 @@
                                         <disabled
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Disabled"
-                                                cssSelector=".cmp-adaptiveform-radiobutton__option input[disabled] + span"/>
+                                                cssSelector=".cmp-adaptiveform-radiobutton__widget.HORIZONTAL .cmp-adaptiveform-radiobutton__option input[disabled] + span"/>
                                         <hover
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Hover"
-                                                cssSelector=".cmp-adaptiveform-radiobutton__option:hover"/>
+                                                cssSelector=".cmp-adaptiveform-radiobutton__widget.HORIZONTAL .cmp-adaptiveform-radiobutton__option:hover"/>
                                         <focus
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Focus"
-                                                cssSelector=".cmp-adaptiveform-radiobutton__option:focus"/>
+                                                cssSelector=".cmp-adaptiveform-radiobutton__widget.HORIZONTAL .cmp-adaptiveform-radiobutton__option:focus"/>
                                         <mandatory
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Mandatory"
-                                                cssSelector=".cmp-adaptiveform-radiobutton[data-cmp-required='true'] .cmp-adaptiveform-radiobutton__option"/>
+                                                cssSelector=".cmp-adaptiveform-radiobutton[data-cmp-required='true'] .cmp-adaptiveform-radiobutton__widget.HORIZONTAL .cmp-adaptiveform-radiobutton__option"/>
                                     </states>
                                 </radioButtonItemHorizontal>
                             </items>
@@ -345,73 +346,73 @@
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Radio Button Item"
                                         id="af2_radiobuttonitemvertical"
-                                        cssSelector=".cmp-adaptiveform-radiobutton__option"
-                                        longTitle="Radio Button Item"
+                                        cssSelector=".cmp-adaptiveform-radiobutton__widget.VERTICAL .cmp-adaptiveform-radiobutton__option"
+                                        longTitle="Radio Button Vertical Layout Item"
                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                                     <items jcr:primaryType="nt:unstructured">
                                         <radioButtonItemLabelContainerVertical
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Radio Button Item Label Container"
                                                 id="af2_radiobuttonitemlabelcontainervertical"
-                                                cssSelector=".cmp-adaptiveform-radiobutton__option-label"
-                                                longTitle="Radio Button Item Label Container"
+                                                cssSelector=".cmp-adaptiveform-radiobutton__widget.VERTICAL .cmp-adaptiveform-radiobutton__option-label"
+                                                longTitle="Radio Button Item Label Container (Vertical)"
                                                 propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                                             <items jcr:primaryType="nt:unstructured">
                                                 <radioButtonLabelVertical
                                                         jcr:primaryType="nt:unstructured"
                                                         jcr:title="Label"
                                                         id="af2_radiobuttonitemlabelvertical"
-                                                        cssSelector=".cmp-adaptiveform-radiobutton__option-label span"
-                                                        longTitle="Radio Button Item Label"
+                                                        cssSelector=".cmp-adaptiveform-radiobutton__widget.VERTICAL .cmp-adaptiveform-radiobutton__option-label span"
+                                                        longTitle="Radio Button Item Label (Vertical)"
                                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                                                     <states jcr:primaryType="nt:unstructured">
                                                         <disabled
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Disabled"
-                                                                cssSelector=".cmp-adaptiveform-radiobutton__option-label input[disabled] + span"/>
+                                                                cssSelector=".cmp-adaptiveform-radiobutton__widget.VERTICAL .cmp-adaptiveform-radiobutton__option-label input[disabled] + span"/>
                                                         <hover
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Hover"
-                                                                cssSelector=".cmp-adaptiveform-radiobutton__option-label:hover span"/>
+                                                                cssSelector=".cmp-adaptiveform-radiobutton__widget.VERTICAL .cmp-adaptiveform-radiobutton__option-label:hover span"/>
                                                         <checked
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Selected"
-                                                                cssSelector=".cmp-adaptiveform-radiobutton__option input[type='radio']:checked + span"/>
+                                                                cssSelector=".cmp-adaptiveform-radiobutton__widget.VERTICAL .cmp-adaptiveform-radiobutton__option-label input[type='radio']:checked + span"/>
                                                         <mandatory
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Mandatory"
-                                                                cssSelector=".cmp-adaptiveform-radiobutton[data-cmp-required='true'] .cmp-adaptiveform-radiobutton__option-label span"/>
+                                                                cssSelector=".cmp-adaptiveform-radiobutton[data-cmp-required='true'] .cmp-adaptiveform-radiobutton__widget.VERTICAL .cmp-adaptiveform-radiobutton__option-label span"/>
                                                     </states>
                                                 </radioButtonLabelVertical>
                                                 <radioButtonWidgetAndTextVertical
                                                         jcr:primaryType="nt:unstructured"
                                                         jcr:title="Radio Button"
                                                         id="af2_radiobuttonwidgetvertical"
-                                                        cssSelector=".cmp-adaptiveform-radiobutton__option__widget"
-                                                        longTitle="Radio Button Item Widget"
+                                                        cssSelector=".cmp-adaptiveform-radiobutton__widget.VERTICAL .cmp-adaptiveform-radiobutton__option__widget"
+                                                        longTitle="Radio Button Item Widget (Vertical)"
                                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
                                                         secondarySelectors="af2_guideContainer:af2_widgetAndText">
                                                     <states jcr:primaryType="nt:unstructured">
                                                         <focus
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Focus"
-                                                                cssSelector=".cmp-adaptiveform-radiobutton__option__widget:focus"/>
+                                                                cssSelector=".cmp-adaptiveform-radiobutton__widget.VERTICAL .cmp-adaptiveform-radiobutton__option__widget:focus"/>
                                                         <disabled
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Disabled"
-                                                                cssSelector=".cmp-adaptiveform-radiobutton__option__widget:disabled"/>
+                                                                cssSelector=".cmp-adaptiveform-radiobutton__widget.VERTICAL .cmp-adaptiveform-radiobutton__option__widget:disabled"/>
                                                         <hover
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Hover"
-                                                                cssSelector=".cmp-adaptiveform-radiobutton__option__widget:hover"/>
+                                                                cssSelector=".cmp-adaptiveform-radiobutton__widget.VERTICAL .cmp-adaptiveform-radiobutton__option__widget:hover"/>
                                                         <checked
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Selected"
-                                                                cssSelector=".cmp-adaptiveform-radiobutton__option__widget:checked"/>
+                                                                cssSelector=".cmp-adaptiveform-radiobutton__widget.VERTICAL .cmp-adaptiveform-radiobutton__option__widget:checked"/>
                                                         <mandatory
                                                                 jcr:primaryType="nt:unstructured"
                                                                 jcr:title="Mandatory"
-                                                                cssSelector=".cmp-adaptiveform-radiobutton__option__widget:required"/>
+                                                                cssSelector=".cmp-adaptiveform-radiobutton__widget.VERTICAL .cmp-adaptiveform-radiobutton__option__widget:required"/>
                                                     </states>
                                                 </radioButtonWidgetAndTextVertical>
                                             </items>
@@ -419,11 +420,11 @@
                                                 <hover
                                                         jcr:primaryType="nt:unstructured"
                                                         jcr:title="Hover"
-                                                        cssSelector=".cmp-adaptiveform-radiobutton__option-label:hover"/>
+                                                        cssSelector=".cmp-adaptiveform-radiobutton__widget.VERTICAL .cmp-adaptiveform-radiobutton__option-label:hover"/>
                                                 <focus
                                                         jcr:primaryType="nt:unstructured"
                                                         jcr:title="Focus"
-                                                        cssSelector=".cmp-adaptiveform-radiobutton__option-label:focus"/>
+                                                        cssSelector=".cmp-adaptiveform-radiobutton__widget.VERTICAL .cmp-adaptiveform-radiobutton__option-label:focus"/>
                                             </states>
                                         </radioButtonItemLabelContainerVertical>
                                     </items>
@@ -431,19 +432,19 @@
                                         <disabled
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Disabled"
-                                                cssSelector=".cmp-adaptiveform-radiobutton__option input[disabled] + span"/>
+                                                cssSelector=".cmp-adaptiveform-radiobutton__widget.VERTICAL .cmp-adaptiveform-radiobutton__option input[disabled] + span"/>
                                         <hover
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Hover"
-                                                cssSelector=".cmp-adaptiveform-radiobutton__option:hover"/>
+                                                cssSelector=".cmp-adaptiveform-radiobutton__widget.VERTICAL .cmp-adaptiveform-radiobutton__option:hover"/>
                                         <focus
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Focus"
-                                                cssSelector=".cmp-adaptiveform-radiobutton__option:focus"/>
+                                                cssSelector=".cmp-adaptiveform-radiobutton__widget.VERTICAL .cmp-adaptiveform-radiobutton__option:focus"/>
                                         <mandatory
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Mandatory"
-                                                cssSelector=".cmp-adaptiveform-radiobutton[data-cmp-required='true'] .cmp-adaptiveform-radiobutton__option"/>
+                                                cssSelector=".cmp-adaptiveform-radiobutton[data-cmp-required='true'] .cmp-adaptiveform-radiobutton__widget.VERTICAL .cmp-adaptiveform-radiobutton__option"/>
                                     </states>
                                 </radioButtonItemVertical>
                             </items>
@@ -473,6 +474,15 @@
                                 cssSelector=".cmp-adaptiveform-radiobutton__longdescription"
                                 longTitle="Radio Button Long Description"
                                 propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                    <items jcr:primaryType="nt:unstructured">
+                        <longDescriptionParagraph
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Long Description Paragraph"
+                                id="af2_radiobuttondescriptionlongparagraph"
+                                cssSelector=".cmp-adaptiveform-radiobutton__longdescription p"
+                                longTitle="Long Description Paragraph"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                    </items>
                             <states jcr:primaryType="nt:unstructured">
                                 <focus
                                         jcr:primaryType="nt:unstructured"

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/review/v1/review/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/review/v1/review/_cq_styleConfig/.content.xml
@@ -87,6 +87,10 @@
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Disabled"
                                                 cssSelector=".cmp-adaptiveform-review__edit-button:disabled"/>
+                                        <htmlDisabled
+                                                jcr:primaryType="nt:unstructured"
+                                                jcr:title="Disabled (HTML)"
+                                                cssSelector=".cmp-adaptiveform-review__edit-button[disabled=&quot;true&quot;]"/>
                                     </states>
                                 </reviewEditButton>
                             </items>
@@ -113,6 +117,13 @@
                                         longTitle="Review Panel Label Container"
                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                                     <items jcr:primaryType="nt:unstructured">
+                                        <reviewPanelLabelInLabelContainer
+                                                jcr:primaryType="nt:unstructured"
+                                                jcr:title="Label"
+                                                id="af2_reviewpanellabel"
+                                                cssSelector=".cmp-adaptiveform-review__label-container .cmp-adaptiveform-review__label"
+                                                longTitle="Review Label"
+                                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
                                         <reviewPanelLabel
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Label"
@@ -151,6 +162,10 @@
                                                         jcr:primaryType="nt:unstructured"
                                                         jcr:title="Disabled"
                                                         cssSelector=".cmp-adaptiveform-review__panel .cmp-adaptiveform-review__edit-button:disabled"/>
+                                                <htmlDisabled
+                                                        jcr:primaryType="nt:unstructured"
+                                                        jcr:title="Disabled (HTML)"
+                                                        cssSelector=".cmp-adaptiveform-review__panel .cmp-adaptiveform-review__edit-button[disabled=&quot;true&quot;]"/>
                                             </states>
                                         </reviewPanelEditButton>
                                     </items>

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/review/v1/review/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/review/v1/review/_cq_styleConfig/.content.xml
@@ -90,7 +90,7 @@
                                         <htmlDisabled
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Disabled (HTML)"
-                                                cssSelector=".cmp-adaptiveform-review__edit-button[disabled=&quot;true&quot;]"/>
+                                                cssSelector=".cmp-adaptiveform-review__edit-button[disabled]"/>
                                     </states>
                                 </reviewEditButton>
                             </items>
@@ -165,7 +165,7 @@
                                                 <htmlDisabled
                                                         jcr:primaryType="nt:unstructured"
                                                         jcr:title="Disabled (HTML)"
-                                                        cssSelector=".cmp-adaptiveform-review__panel .cmp-adaptiveform-review__edit-button[disabled=&quot;true&quot;]"/>
+                                                        cssSelector=".cmp-adaptiveform-review__panel .cmp-adaptiveform-review__edit-button[disabled]"/>
                                             </states>
                                         </reviewPanelEditButton>
                                     </items>

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/switch/v1/switch/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/switch/v1/switch/_cq_styleConfig/.content.xml
@@ -31,25 +31,25 @@
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Label"
                                         id="af2_switchlabel"
-                                        cssSelector=".cmp-adaptiveform-switch__label"
+                                        cssSelector=".cmp-adaptiveform-switch__label-container .cmp-adaptiveform-switch__label"
                                         longTitle="Switch Label"
                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                                     <states jcr:primaryType="nt:unstructured">
                                         <hover
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Hover"
-                                                cssSelector=".cmp-adaptiveform-switch__label:hover"/>
+                                                cssSelector=".cmp-adaptiveform-switch__label-container .cmp-adaptiveform-switch__label:hover"/>
                                         <focus
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Focus"
-                                                cssSelector=".cmp-adaptiveform-switch__label:focus"/>
+                                                cssSelector=".cmp-adaptiveform-switch__label-container .cmp-adaptiveform-switch__label:focus"/>
                                     </states>
                                 </switchLabel>
                                 <switchHelpIcon
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Help Icon"
                                         id="af2_switchhelpicon"
-                                        cssSelector=".cmp-adaptiveform-switch__questionmark"
+                                        cssSelector=".cmp-adaptiveform-switch__label-container .cmp-adaptiveform-switch__questionmark"
                                         longTitle="Switch Help Icon"
                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
                                         secondarySelectors="af2_guideContainer:af2_helpicon">
@@ -57,15 +57,19 @@
                                         <focus
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Focus"
-                                                cssSelector=".cmp-adaptiveform-switch__questionmark:focus"/>
+                                                cssSelector=".cmp-adaptiveform-switch__label-container .cmp-adaptiveform-switch__questionmark:focus"/>
                                         <hover
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Hover"
-                                                cssSelector=".cmp-adaptiveform-switch__questionmark:hover"/>
+                                                cssSelector=".cmp-adaptiveform-switch__label-container .cmp-adaptiveform-switch__questionmark:hover"/>
                                         <disabled
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Disabled"
-                                                cssSelector=".cmp-adaptiveform-switch__questionmark:disabled"/>
+                                                cssSelector=".cmp-adaptiveform-switch__label-container .cmp-adaptiveform-switch__questionmark:disabled"/>
+                                        <rtl
+                                                jcr:primaryType="nt:unstructured"
+                                                jcr:title="RTL"
+                                                cssSelector="[dir=&quot;rtl&quot;] .cmp-adaptiveform-switch__label-container .cmp-adaptiveform-switch__questionmark"/>
                                     </states>
                                 </switchHelpIcon>
                             </items>
@@ -73,15 +77,15 @@
                                 <disabled
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Disabled"
-                                        cssSelector="cmp-adaptiveform-switch__label-container:disabled"/>
+                                        cssSelector=".cmp-adaptiveform-switch__label-container:disabled"/>
                                 <hover
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Hover"
-                                        cssSelector="cmp-adaptiveform-switch__label-container:hover"/>
+                                        cssSelector=".cmp-adaptiveform-switch__label-container:hover"/>
                                 <focus
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Focus"
-                                        cssSelector="cmp-adaptiveform-switch__label-container:focus"/>
+                                        cssSelector=".cmp-adaptiveform-switch__label-container:focus"/>
                             </states>
                         </switchLabelContainer>
                         <switchContainer
@@ -108,13 +112,47 @@
                                             jcr:primaryType="nt:unstructured"
                                             jcr:title="Focus"
                                             cssSelector=".cmp-adaptiveform-switch__option:focus"/>
+                                        <hideLabelsOn
+                                            jcr:primaryType="nt:unstructured"
+                                            jcr:title="Hide Labels (On)"
+                                            cssSelector=".cmp-adaptiveform-switch__hide-labels .cmp-adaptiveform-switch__option--on"/>
+                                        <hideLabelsOff
+                                            jcr:primaryType="nt:unstructured"
+                                            jcr:title="Hide Labels (Off)"
+                                            cssSelector=".cmp-adaptiveform-switch__hide-labels .cmp-adaptiveform-switch__option--off"/>
+                                        <unhideLabelsOn
+                                            jcr:primaryType="nt:unstructured"
+                                            jcr:title="Unhide Labels (On)"
+                                            cssSelector=".cmp-adaptiveform-switch__unhide-labels .cmp-adaptiveform-switch__option--on"/>
+                                        <unhideLabelsOff
+                                            jcr:primaryType="nt:unstructured"
+                                            jcr:title="Unhide Labels (Off)"
+                                            cssSelector=".cmp-adaptiveform-switch__unhide-labels .cmp-adaptiveform-switch__option--off"/>
                                     </states>
                                 </switchOption>
+                                <switchWidgetInput
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Widget Input"
+                                        id="af2_switchwidgetinput"
+                                        cssSelector=".cmp-adaptiveform-switch__widget"
+                                        longTitle="Switch Widget Input"
+                                        propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                                    <states jcr:primaryType="nt:unstructured">
+                                        <focus
+                                                jcr:primaryType="nt:unstructured"
+                                                jcr:title="Focus"
+                                                cssSelector="input:focus + .cmp-adaptiveform-switch__widget-slider"/>
+                                        <checked
+                                                jcr:primaryType="nt:unstructured"
+                                                jcr:title="Selected"
+                                                cssSelector="input:checked + .cmp-adaptiveform-switch__widget-slider"/>
+                                    </states>
+                                </switchWidgetInput>
                                 <switchWidget
                                         jcr:primaryType="nt:unstructured"
-                                        jcr:title="Widget"
+                                        jcr:title="Widget Label"
                                         id="af2_switchwidget"
-                                        cssSelector=".adaptiveform-switch__widget-label"
+                                        cssSelector=".cmp-adaptiveform-switch__widget-label"
                                         longTitle="Switch Widget"
                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                                     <states jcr:primaryType="nt:unstructured">
@@ -156,6 +194,14 @@
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Selected"
                                                 cssSelector=".cmp-adaptiveform-switch__widget:checked + .cmp-adaptiveform-switch__widget-slider .cmp-adaptiveform-switch__circle-indicator"/>
+                                        <filled
+                                                jcr:primaryType="nt:unstructured"
+                                                jcr:title="Filled"
+                                                cssSelector=".cmp-adaptiveform-switch--filled .cmp-adaptiveform-switch__circle-indicator"/>
+                                        <filledRtl
+                                                jcr:primaryType="nt:unstructured"
+                                                jcr:title="Filled RTL"
+                                                cssSelector="[dir=&quot;rtl&quot;] .cmp-adaptiveform-switch--filled .cmp-adaptiveform-switch__circle-indicator"/>
                                     </states>
                                 </switchHandle>
                                 <switchSlider
@@ -201,6 +247,15 @@
                                 cssSelector=".cmp-adaptiveform-switch__longdescription"
                                 longTitle="Switch Long Description"
                                 propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                    <items jcr:primaryType="nt:unstructured">
+                        <longDescriptionParagraph
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Long Description Paragraph"
+                                id="af2_switchdescriptionlongparagraph"
+                                cssSelector=".cmp-adaptiveform-switch__longdescription p"
+                                longTitle="Long Description Paragraph"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                    </items>
                             <states jcr:primaryType="nt:unstructured">
                                 <focus
                                         jcr:primaryType="nt:unstructured"

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/switch/v1/switch/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/switch/v1/switch/_cq_styleConfig/.content.xml
@@ -112,24 +112,36 @@
                                             jcr:primaryType="nt:unstructured"
                                             jcr:title="Focus"
                                             cssSelector=".cmp-adaptiveform-switch__option:focus"/>
-                                        <hideLabelsOn
-                                            jcr:primaryType="nt:unstructured"
-                                            jcr:title="Hide Labels (On)"
-                                            cssSelector=".cmp-adaptiveform-switch__hide-labels .cmp-adaptiveform-switch__option--on"/>
-                                        <hideLabelsOff
-                                            jcr:primaryType="nt:unstructured"
-                                            jcr:title="Hide Labels (Off)"
-                                            cssSelector=".cmp-adaptiveform-switch__hide-labels .cmp-adaptiveform-switch__option--off"/>
-                                        <unhideLabelsOn
-                                            jcr:primaryType="nt:unstructured"
-                                            jcr:title="Unhide Labels (On)"
-                                            cssSelector=".cmp-adaptiveform-switch__unhide-labels .cmp-adaptiveform-switch__option--on"/>
-                                        <unhideLabelsOff
-                                            jcr:primaryType="nt:unstructured"
-                                            jcr:title="Unhide Labels (Off)"
-                                            cssSelector=".cmp-adaptiveform-switch__unhide-labels .cmp-adaptiveform-switch__option--off"/>
                                     </states>
                                 </switchOption>
+                                <switchHideLabelsOn
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Hide Labels (On)"
+                                        id="af2_switchhidelabelson"
+                                        cssSelector=".cmp-adaptiveform-switch__hide-labels .cmp-adaptiveform-switch__option--on"
+                                        longTitle="Switch Hide Labels On Option"
+                                        propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                                <switchHideLabelsOff
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Hide Labels (Off)"
+                                        id="af2_switchhidelabelsoff"
+                                        cssSelector=".cmp-adaptiveform-switch__hide-labels .cmp-adaptiveform-switch__option--off"
+                                        longTitle="Switch Hide Labels Off Option"
+                                        propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                                <switchUnhideLabelsOn
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Unhide Labels (On)"
+                                        id="af2_switchunhidelabelson"
+                                        cssSelector=".cmp-adaptiveform-switch__unhide-labels .cmp-adaptiveform-switch__option--on"
+                                        longTitle="Switch Unhide Labels On Option"
+                                        propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                                <switchUnhideLabelsOff
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Unhide Labels (Off)"
+                                        id="af2_switchunhidelabelsoff"
+                                        cssSelector=".cmp-adaptiveform-switch__unhide-labels .cmp-adaptiveform-switch__option--off"
+                                        longTitle="Switch Unhide Labels Off Option"
+                                        propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
                                 <switchWidgetInput
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Widget Input"

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/tabsontop/v1/tabsontop/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/tabsontop/v1/tabsontop/_cq_styleConfig/.content.xml
@@ -23,25 +23,25 @@
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Label"
                                 id="af2_tabsOnToplabel"
-                                cssSelector=".cmp-tabs__label"
+                                cssSelector=".cmp-tabs__label-container .cmp-tabs__label"
                                 longTitle="Tabs On Top Label"
                                 propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                             <states jcr:primaryType="nt:unstructured">
                                 <hover
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Hover"
-                                        cssSelector=".cmp-tabs__label:hover"/>
+                                        cssSelector=".cmp-tabs__label-container .cmp-tabs__label:hover"/>
                                 <focus
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Focus"
-                                        cssSelector=".cmp-tabs__label:focus"/>
+                                        cssSelector=".cmp-tabs__label-container .cmp-tabs__label:focus"/>
                             </states>
                         </tabsOnTopLabel>
                         <tabsOnTopHelpIcon
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Help Icon"
                                 id="af2_tabsOnTophelpicon"
-                                cssSelector=".cmp-tabs__questionmark"
+                                cssSelector=".cmp-tabs__label-container .cmp-tabs__questionmark"
                                 longTitle="Tabs On Top Help Icon"
                                 propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
                                 secondarySelectors="af2_guideContainer:af2_helpicon">
@@ -49,15 +49,15 @@
                                 <focus
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Focus"
-                                        cssSelector=".cmp-tabs__questionmark:focus"/>
+                                        cssSelector=".cmp-tabs__label-container .cmp-tabs__questionmark:focus"/>
                                 <hover
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Hover"
-                                        cssSelector=".cmp-tabs__questionmark:hover"/>
+                                        cssSelector=".cmp-tabs__label-container .cmp-tabs__questionmark:hover"/>
                                 <disabled
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Disabled"
-                                        cssSelector=".cmp-tabs__questionmark:disabled"/>
+                                        cssSelector=".cmp-tabs__label-container .cmp-tabs__questionmark:disabled"/>
                             </states>
                         </tabsOnTopHelpIcon>
                     </items>
@@ -91,6 +91,15 @@
                         cssSelector=".cmp-tabs__longdescription"
                         longTitle="Tabs On Top Long Description"
                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                    <items jcr:primaryType="nt:unstructured">
+                        <longDescriptionParagraph
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Long Description Paragraph"
+                                id="af2_tabsOnTopdescriptionlongparagraph"
+                                cssSelector=".cmp-tabs__longdescription p"
+                                longTitle="Long Description Paragraph"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                    </items>
                     <states jcr:primaryType="nt:unstructured">
                         <focus
                                 jcr:primaryType="nt:unstructured"
@@ -122,6 +131,14 @@
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Active"
                                         cssSelector=".cmp-tabs__tab--active"/>
+                                <activeCompound
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Active (Compound)"
+                                        cssSelector=".cmp-tabs__tab.cmp-tabs__tab--active"/>
+                                <activeCompoundHover
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Active Hover (Compound)"
+                                        cssSelector=".cmp-tabs__tab.cmp-tabs__tab--active:hover"/>
                                 <hover
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Hover"
@@ -150,6 +167,30 @@
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Disabled"
                                 cssSelector=".cmp-tabs__tablist:disabled"/>
+                        <tablistMarkerDefault
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Tab List Marker"
+                                cssSelector=".cmp-tabs__tablist &gt; li::before"/>
+                        <tablistMarkerActive
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Tab List Marker (Active)"
+                                cssSelector=".cmp-tabs__tablist &gt; li.cmp-tabs__tab--active::before"/>
+                        <tablistMarkerStepped
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Tab List Marker (Stepped)"
+                                cssSelector=".cmp-tabs__tablist &gt; li.cmp-tabs__tab--stepped::before"/>
+                        <tablistMarkerActiveStepped
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Tab List Marker (Active Stepped)"
+                                cssSelector=".cmp-tabs__tablist &gt; li.cmp-tabs__tab--active.cmp-tabs__tab--stepped::before"/>
+                        <tablistItemStepped
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Tab List Item (Stepped)"
+                                cssSelector=".cmp-tabs__tablist &gt; li.cmp-tabs__tab--stepped"/>
+                        <tablistItem
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Tab List Item"
+                                cssSelector=".cmp-tabs__tablist &gt; li"/>
                     </states>
                 </tabsOnTopTabList>
             </items>

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/telephoneinput/v1/telephoneinput/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/telephoneinput/v1/telephoneinput/_cq_styleConfig/.content.xml
@@ -26,25 +26,25 @@
                                             jcr:primaryType="nt:unstructured"
                                             jcr:title="Label"
                                             id="af2_telephoneinputlabel"
-                                            cssSelector=".cmp-adaptiveform-telephoneinput__label"
+                                            cssSelector=".cmp-adaptiveform-telephoneinput__label-container .cmp-adaptiveform-telephoneinput__label"
                                             longTitle="Telephone Input Label"
                                             propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                                         <states jcr:primaryType="nt:unstructured">
                                             <hover
                                                     jcr:primaryType="nt:unstructured"
                                                     jcr:title="Hover"
-                                                    cssSelector=".cmp-adaptiveform-telephoneinput__label:hover"/>
+                                                    cssSelector=".cmp-adaptiveform-telephoneinput__label-container .cmp-adaptiveform-telephoneinput__label:hover"/>
                                             <focus
                                                     jcr:primaryType="nt:unstructured"
                                                     jcr:title="Focus"
-                                                    cssSelector=".cmp-adaptiveform-telephoneinput__label:focus"/>
+                                                    cssSelector=".cmp-adaptiveform-telephoneinput__label-container .cmp-adaptiveform-telephoneinput__label:focus"/>
                                         </states>
                                     </telephoneinputLabel>
                                     <telephoneinputHelpIcon
                                             jcr:primaryType="nt:unstructured"
                                             jcr:title="Help Icon"
                                             id="af2_telephoneinputhelpicon"
-                                            cssSelector=".cmp-adaptiveform-telephoneinput__questionmark"
+                                            cssSelector=".cmp-adaptiveform-telephoneinput__label-container .cmp-adaptiveform-telephoneinput__questionmark"
                                             longTitle="Telephone Input Help Icon"
                                             propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
                                             secondarySelectors="af2_guideContainer:af2_helpicon">
@@ -52,15 +52,15 @@
                                             <focus
                                                     jcr:primaryType="nt:unstructured"
                                                     jcr:title="Focus"
-                                                    cssSelector=".cmp-adaptiveform-telephoneinput__questionmark:focus"/>
+                                                    cssSelector=".cmp-adaptiveform-telephoneinput__label-container .cmp-adaptiveform-telephoneinput__questionmark:focus"/>
                                             <hover
                                                     jcr:primaryType="nt:unstructured"
                                                     jcr:title="Hover"
-                                                    cssSelector=".cmp-adaptiveform-telephoneinput__questionmark:hover"/>
+                                                    cssSelector=".cmp-adaptiveform-telephoneinput__label-container .cmp-adaptiveform-telephoneinput__questionmark:hover"/>
                                             <disabled
                                                     jcr:primaryType="nt:unstructured"
                                                     jcr:title="Disabled"
-                                                    cssSelector=".cmp-adaptiveform-telephoneinput__questionmark:disabled"/>
+                                                    cssSelector=".cmp-adaptiveform-telephoneinput__label-container .cmp-adaptiveform-telephoneinput__questionmark:disabled"/>
                                         </states>
                                     </telephoneinputHelpIcon>
                                 </items>
@@ -68,15 +68,15 @@
                                     <disabled
                                             jcr:primaryType="nt:unstructured"
                                             jcr:title="Disabled"
-                                            cssSelector="cmp-adaptiveform-telephoneinput__label-container:disabled"/>
+                                            cssSelector=".cmp-adaptiveform-telephoneinput__label-container:disabled"/>
                                     <hover
                                             jcr:primaryType="nt:unstructured"
                                             jcr:title="Hover"
-                                            cssSelector="cmp-adaptiveform-telephoneinput__label-container:hover"/>
+                                            cssSelector=".cmp-adaptiveform-telephoneinput__label-container:hover"/>
                                     <focus
                                             jcr:primaryType="nt:unstructured"
                                             jcr:title="Focus"
-                                            cssSelector="cmp-adaptiveform-telephoneinput__label-container:focus"/>
+                                            cssSelector=".cmp-adaptiveform-telephoneinput__label-container:focus"/>
                                 </states>
                             </telephoneinputLabelContainer>
                             <telephoneinputWidgetAndText
@@ -121,6 +121,15 @@
                                     cssSelector=".cmp-adaptiveform-telephoneinput__longdescription"
                                     longTitle="Telephone Input Long Description"
                                     propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                    <items jcr:primaryType="nt:unstructured">
+                        <longDescriptionParagraph
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Long Description Paragraph"
+                                id="af2_telephoneinputdescriptionlongparagraph"
+                                cssSelector=".cmp-adaptiveform-telephoneinput__longdescription p"
+                                longTitle="Long Description Paragraph"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                    </items>
                                 <states jcr:primaryType="nt:unstructured">
                                     <focus
                                             jcr:primaryType="nt:unstructured"

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/termsandconditions/v1/termsandconditions/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/termsandconditions/v1/termsandconditions/_cq_styleConfig/.content.xml
@@ -181,7 +181,7 @@
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Terms Text"
                                 id="af2_tncstandalonetext"
-                                cssSelector=".cmp-adaptiveform-termsandcondition__text"
+                                cssSelector=".cmp-adaptiveform-termsandcondition__content-container:not(.cmp-adaptiveform-termsandcondition__content-container--modal) .cmp-adaptiveform-termsandcondition__text"
                                 longTitle="Terms Text"
                                 propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
                         <tncLink

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/termsandconditions/v1/termsandconditions/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/termsandconditions/v1/termsandconditions/_cq_styleConfig/.content.xml
@@ -31,25 +31,25 @@
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Label"
                                         id="af2_tnclabel"
-                                        cssSelector=".cmp-adaptiveform-termsandcondition__label"
+                                        cssSelector=".cmp-adaptiveform-termsandcondition__label-container .cmp-adaptiveform-termsandcondition__label"
                                         longTitle="Terms and Conditions Label"
                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                                     <states jcr:primaryType="nt:unstructured">
                                         <hover
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Hover"
-                                                cssSelector=".cmp-adaptiveform-termsandcondition__label:hover"/>
+                                                cssSelector=".cmp-adaptiveform-termsandcondition__label-container .cmp-adaptiveform-termsandcondition__label:hover"/>
                                         <focus
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Focus"
-                                                cssSelector=".cmp-adaptiveform-termsandcondition__label:focus"/>
+                                                cssSelector=".cmp-adaptiveform-termsandcondition__label-container .cmp-adaptiveform-termsandcondition__label:focus"/>
                                     </states>
                                 </tncLabel>
                                 <tncHelpIcon
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Help Icon"
                                         id="af2_tnchelpicon"
-                                        cssSelector=".cmp-adaptiveform-termsandcondition__questionmark"
+                                        cssSelector=".cmp-adaptiveform-termsandcondition__label-container .cmp-adaptiveform-termsandcondition__questionmark"
                                         longTitle="Terms and Conditions Help Icon"
                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
                                         secondarySelectors="af2_guideContainer:af2_helpicon">
@@ -57,15 +57,15 @@
                                         <focus
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Focus"
-                                                cssSelector=".cmp-adaptiveform-termsandcondition__questionmark:focus"/>
+                                                cssSelector=".cmp-adaptiveform-termsandcondition__label-container .cmp-adaptiveform-termsandcondition__questionmark:focus"/>
                                         <hover
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Hover"
-                                                cssSelector=".cmp-adaptiveform-termsandcondition__questionmark:hover"/>
+                                                cssSelector=".cmp-adaptiveform-termsandcondition__label-container .cmp-adaptiveform-termsandcondition__questionmark:hover"/>
                                         <disabled
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Disabled"
-                                                cssSelector=".cmp-adaptiveform-termsandcondition__questionmark:disabled"/>
+                                                cssSelector=".cmp-adaptiveform-termsandcondition__label-container .cmp-adaptiveform-termsandcondition__questionmark:disabled"/>
                                     </states>
                                 </tncHelpIcon>
                             </items>
@@ -73,15 +73,15 @@
                                 <disabled
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Disabled"
-                                        cssSelector="cmp-adaptiveform-termsandcondition__label-container:disabled"/>
+                                        cssSelector=".cmp-adaptiveform-termsandcondition__label-container:disabled"/>
                                 <hover
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Hover"
-                                        cssSelector="cmp-adaptiveform-termsandcondition__label-container:hover"/>
+                                        cssSelector=".cmp-adaptiveform-termsandcondition__label-container:hover"/>
                                 <focus
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Focus"
-                                        cssSelector="cmp-adaptiveform-termsandcondition__label-container:focus"/>
+                                        cssSelector=".cmp-adaptiveform-termsandcondition__label-container:focus"/>
                             </states>
                         </tncLabelContainer>
                         <tncContentContainer
@@ -122,6 +122,95 @@
                                         cssSelector=".cmp-adaptiveform-termsandcondition__content-container:focus"/>
                             </states>
                         </tncContentContainer>
+                        <tncModalContentContainer
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Modal Content Container"
+                                id="af2_tncmodalcontainer"
+                                cssSelector=".cmp-adaptiveform-termsandcondition__content-container--modal"
+                                longTitle="Terms Modal Content Container"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                            <items jcr:primaryType="nt:unstructured">
+                                <tncModalText
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Modal Text"
+                                        id="af2_tncmodaltext"
+                                        cssSelector=".cmp-adaptiveform-termsandcondition__content-container--modal .cmp-adaptiveform-termsandcondition__text"
+                                        longTitle="Terms Modal Text"
+                                        propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                                <tncModalBody
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Modal Body"
+                                        id="af2_tncmodalbody"
+                                        cssSelector=".cmp-adaptiveform-termsandcondition__content-container--modal .cmp-adaptiveform-termsandcondition__body"
+                                        longTitle="Terms Modal Body"
+                                        propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                                <tncModalHeader
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Modal Header"
+                                        id="af2_tncmodalheader"
+                                        cssSelector=".cmp-adaptiveform-termsandcondition__content-container--modal .cmp-adaptiveform-termsandcondition__header"
+                                        longTitle="Terms Modal Header"
+                                        propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                                    <items jcr:primaryType="nt:unstructured">
+                                        <tncModalHeaderH3
+                                                jcr:primaryType="nt:unstructured"
+                                                jcr:title="Modal Header Title"
+                                                id="af2_tncmodalheaderh3"
+                                                cssSelector=".cmp-adaptiveform-termsandcondition__content-container--modal .cmp-adaptiveform-termsandcondition__header h3"
+                                                longTitle="Terms Modal Header Title"
+                                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                                    </items>
+                                </tncModalHeader>
+                                <tncModalCloseButton
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Modal Close Button"
+                                        id="af2_tncmodalclose"
+                                        cssSelector=".cmp-adaptiveform-termsandcondition__content-container--modal .cmp-adaptiveform-termsandcondition__close-button"
+                                        longTitle="Terms Modal Close Button"
+                                        propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                                <tncModalInnerContent
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Modal Inner Content"
+                                        id="af2_tncmodalinnercontent"
+                                        cssSelector=".cmp-adaptiveform-termsandcondition__content-container--modal .cmp-adaptiveform-termsandcondition__content"
+                                        longTitle="Terms Modal Inner Content"
+                                        propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                            </items>
+                        </tncModalContentContainer>
+                        <tncStandaloneText
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Terms Text"
+                                id="af2_tncstandalonetext"
+                                cssSelector=".cmp-adaptiveform-termsandcondition__text"
+                                longTitle="Terms Text"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                        <tncLink
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Terms Link"
+                                id="af2_tnclink"
+                                cssSelector=".cmp-adaptiveform-termsandcondition__link"
+                                longTitle="Terms Link"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                            <items jcr:primaryType="nt:unstructured">
+                                <tncLinkCheckboxGroupValid
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Link with Valid Checkbox Group"
+                                        id="af2_tnclinkcbvalid"
+                                        cssSelector=".cmp-adaptiveform-termsandcondition__link .cmp-adaptiveform-checkboxgroup[data-cmp-valid='true']"
+                                        longTitle="Terms Link Checkbox Group Valid"
+                                        propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                            </items>
+                            <states jcr:primaryType="nt:unstructured">
+                                <link
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Link"
+                                        cssSelector=".cmp-adaptiveform-termsandcondition__link a:link"/>
+                                <visited
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Visited"
+                                        cssSelector=".cmp-adaptiveform-termsandcondition__link a:visited"/>
+                            </states>
+                        </tncLink>
                         <tncConsentArea
                             jcr:primaryType="nt:unstructured"
                             jcr:title="Consent Area"
@@ -206,6 +295,15 @@
                                 cssSelector=".cmp-adaptiveform-termsandcondition__longdescription"
                                 longTitle="Terms And Conditions Long Description"
                                 propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                    <items jcr:primaryType="nt:unstructured">
+                        <longDescriptionParagraph
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Long Description Paragraph"
+                                id="af2_tncdescriptionlongparagraph"
+                                cssSelector=".cmp-adaptiveform-termsandcondition__longdescription p"
+                                longTitle="Long Description Paragraph"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                    </items>
                             <states jcr:primaryType="nt:unstructured">
                                 <focus
                                         jcr:primaryType="nt:unstructured"

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/textinput/v1/textinput/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/textinput/v1/textinput/_cq_styleConfig/.content.xml
@@ -31,25 +31,25 @@
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Label"
                                         id="af2_textinputlabel"
-                                        cssSelector=".cmp-adaptiveform-textinput__label"
+                                        cssSelector=".cmp-adaptiveform-textinput__label-container .cmp-adaptiveform-textinput__label"
                                         longTitle="Text Input Label"
                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                                     <states jcr:primaryType="nt:unstructured">
                                         <hover
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Hover"
-                                                cssSelector=".cmp-adaptiveform-textinput__label:hover"/>
+                                                cssSelector=".cmp-adaptiveform-textinput__label-container .cmp-adaptiveform-textinput__label:hover"/>
                                         <focus
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Focus"
-                                                cssSelector=".cmp-adaptiveform-textinput__label:focus"/>
+                                                cssSelector=".cmp-adaptiveform-textinput__label-container .cmp-adaptiveform-textinput__label:focus"/>
                                     </states>
                                 </textinputLabel>
                                 <textinputHelpIcon
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Help Icon"
                                         id="af2_textinputhelpicon"
-                                        cssSelector=".cmp-adaptiveform-textinput__questionmark"
+                                        cssSelector=".cmp-adaptiveform-textinput__label-container .cmp-adaptiveform-textinput__questionmark"
                                         longTitle="Text Input Help Icon"
                                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
                                         secondarySelectors="af2_guideContainer:af2_helpicon">
@@ -57,15 +57,15 @@
                                         <focus
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Focus"
-                                                cssSelector=".cmp-adaptiveform-textinput__questionmark:focus"/>
+                                                cssSelector=".cmp-adaptiveform-textinput__label-container .cmp-adaptiveform-textinput__questionmark:focus"/>
                                         <hover
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Hover"
-                                                cssSelector=".cmp-adaptiveform-textinput__questionmark:hover"/>
+                                                cssSelector=".cmp-adaptiveform-textinput__label-container .cmp-adaptiveform-textinput__questionmark:hover"/>
                                         <disabled
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Disabled"
-                                                cssSelector=".cmp-adaptiveform-textinput__questionmark:disabled"/>
+                                                cssSelector=".cmp-adaptiveform-textinput__label-container .cmp-adaptiveform-textinput__questionmark:disabled"/>
                                     </states>
                                 </textinputHelpIcon>
                             </items>
@@ -73,15 +73,15 @@
                                 <disabled
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Disabled"
-                                        cssSelector="cmp-adaptiveform-textinput__label-container:disabled"/>
+                                        cssSelector=".cmp-adaptiveform-textinput__label-container:disabled"/>
                                 <hover
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Hover"
-                                        cssSelector="cmp-adaptiveform-textinput__label-container:hover"/>
+                                        cssSelector=".cmp-adaptiveform-textinput__label-container:hover"/>
                                 <focus
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Focus"
-                                        cssSelector="cmp-adaptiveform-textinput__label-container:focus"/>
+                                        cssSelector=".cmp-adaptiveform-textinput__label-container:focus"/>
                             </states>
                         </textinputLabelContainer>
                         <textinputWidgetAndText
@@ -126,6 +126,15 @@
                                 cssSelector=".cmp-adaptiveform-textinput__longdescription"
                                 longTitle="Text Input Long Description"
                                 propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                    <items jcr:primaryType="nt:unstructured">
+                        <longDescriptionParagraph
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Long Description Paragraph"
+                                id="af2_textinputdescriptionlongparagraph"
+                                cssSelector=".cmp-adaptiveform-textinput__longdescription p"
+                                longTitle="Long Description Paragraph"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                    </items>
                             <states jcr:primaryType="nt:unstructured">
                                 <focus
                                         jcr:primaryType="nt:unstructured"

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/title/v2/title/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/title/v2/title/_cq_styleConfig/.content.xml
@@ -3,6 +3,13 @@
     jcr:primaryType="nt:unstructured"
     jcr:title="FormTitle">
     <items jcr:primaryType="nt:unstructured">
+        <formTitleText
+            jcr:primaryType="nt:unstructured"
+            jcr:title="Title Text"
+            id="af2_formtitletext"
+            cssSelector=".cmp-title__text"
+            longTitle="Form Title Text"
+            propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
         <formTitle
             jcr:primaryType="nt:unstructured"
             jcr:title="Title"

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/verticaltabs/v1/verticaltabs/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/verticaltabs/v1/verticaltabs/_cq_styleConfig/.content.xml
@@ -23,25 +23,25 @@
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Label"
                                 id="af2_verticalTabslabel"
-                                cssSelector=".cmp-verticaltabs__label"
+                                cssSelector=".cmp-verticaltabs__label-container .cmp-verticaltabs__label"
                                 longTitle="Vertical Tabs Label"
                                 propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                             <states jcr:primaryType="nt:unstructured">
                                 <hover
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Hover"
-                                        cssSelector=".cmp-verticaltabs__label:hover"/>
+                                        cssSelector=".cmp-verticaltabs__label-container .cmp-verticaltabs__label:hover"/>
                                 <focus
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Focus"
-                                        cssSelector=".cmp-verticaltabs__label:focus"/>
+                                        cssSelector=".cmp-verticaltabs__label-container .cmp-verticaltabs__label:focus"/>
                             </states>
                         </verticalTabsLabel>
                         <verticalTabsHelpIcon
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Help Icon"
                                 id="af2_verticalTabshelpicon"
-                                cssSelector=".cmp-verticaltabs__questionmark"
+                                cssSelector=".cmp-verticaltabs__label-container .cmp-verticaltabs__questionmark"
                                 longTitle="Vertical Tabs Help Icon"
                                 propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
                                 secondarySelectors="af2_guideContainer:af2_helpicon">
@@ -49,15 +49,15 @@
                                 <focus
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Focus"
-                                        cssSelector=".cmp-verticaltabs__questionmark:focus"/>
+                                        cssSelector=".cmp-verticaltabs__label-container .cmp-verticaltabs__questionmark:focus"/>
                                 <hover
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Hover"
-                                        cssSelector=".cmp-verticaltabs__questionmark:hover"/>
+                                        cssSelector=".cmp-verticaltabs__label-container .cmp-verticaltabs__questionmark:hover"/>
                                 <disabled
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Disabled"
-                                        cssSelector=".cmp-verticaltabs__questionmark:disabled"/>
+                                        cssSelector=".cmp-verticaltabs__label-container .cmp-verticaltabs__questionmark:disabled"/>
                             </states>
                         </verticalTabsHelpIcon>
                     </items>
@@ -91,6 +91,15 @@
                         cssSelector=".cmp-verticaltabs__longdescription"
                         longTitle="Vertical Tabs Long Description"
                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                    <items jcr:primaryType="nt:unstructured">
+                        <longDescriptionParagraph
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Long Description Paragraph"
+                                id="af2_verticalTabsdescriptionlongparagraph"
+                                cssSelector=".cmp-verticaltabs__longdescription p"
+                                longTitle="Long Description Paragraph"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                    </items>
                     <states jcr:primaryType="nt:unstructured">
                         <focus
                                 jcr:primaryType="nt:unstructured"
@@ -102,6 +111,20 @@
                                 cssSelector=".cmp-verticaltabs__longdescription:hover"/>
                     </states>
                 </verticalTabsDescriptionLong>
+                <verticalTabsTabPanel
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Tab Panel"
+                        id="af2_verticalTabstabpanel"
+                        cssSelector=".cmp-verticaltabs__tabpanel"
+                        longTitle="Vertical Tabs Tab Panel"
+                        propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                    <states jcr:primaryType="nt:unstructured">
+                        <active
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Active"
+                                cssSelector=".cmp-verticaltabs__tabpanel--active"/>
+                    </states>
+                </verticalTabsTabPanel>
                 <verticalTabsTabContainer
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Tab Container"
@@ -130,6 +153,10 @@
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Active"
                                                 cssSelector=".cmp-verticaltabs__tab--active"/>
+                                        <activeCompound
+                                                jcr:primaryType="nt:unstructured"
+                                                jcr:title="Active (Compound)"
+                                                cssSelector=".cmp-verticaltabs__tab.cmp-verticaltabs__tab--active"/>
                                         <hover
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Hover"
@@ -158,6 +185,30 @@
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Disabled"
                                         cssSelector=".cmp-verticaltabs__tablist:disabled"/>
+                                <tablistMarkerDefault
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Tab List Marker"
+                                        cssSelector=".cmp-verticaltabs__tablist &gt; li::before"/>
+                                <tablistMarkerActive
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Tab List Marker (Active)"
+                                        cssSelector=".cmp-verticaltabs__tablist &gt; li.cmp-verticaltabs__tab--active::before"/>
+                                <tablistMarkerStepped
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Tab List Marker (Stepped)"
+                                        cssSelector=".cmp-verticaltabs__tablist &gt; li.cmp-verticaltabs__tab--stepped::before"/>
+                                <tablistMarkerActiveStepped
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Tab List Marker (Active Stepped)"
+                                        cssSelector=".cmp-verticaltabs__tablist &gt; li.cmp-verticaltabs__tab--active.cmp-verticaltabs__tab--stepped::before"/>
+                                <tablistItemStepped
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Tab List Item (Stepped)"
+                                        cssSelector=".cmp-verticaltabs__tablist &gt; li.cmp-verticaltabs__tab--stepped"/>
+                                <tablistItem
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Tab List Item"
+                                        cssSelector=".cmp-verticaltabs__tablist &gt; li"/>
                             </states>
                         </verticalTabsTabList>
                     </items>

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/wizard/v2/wizard/_cq_styleConfig/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/wizard/v2/wizard/_cq_styleConfig/.content.xml
@@ -11,6 +11,13 @@
             longTitle="Wizard Panel Container"
             propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
             <items jcr:primaryType="nt:unstructured">
+                <wizardRoot
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Wizard Root"
+                        id="af2_wizardroot"
+                        cssSelector=".cmp-adaptiveform-wizard"
+                        longTitle="Wizard Root"
+                        propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
                 <wizardLabelContainer
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Label Container"
@@ -23,25 +30,25 @@
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Label"
                                 id="af2_wizardlabel"
-                                cssSelector=".cmp-adaptiveform-wizard__label"
+                                cssSelector=".cmp-adaptiveform-wizard__label-container .cmp-adaptiveform-wizard__label"
                                 longTitle="Wizard Label"
                                 propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                             <states jcr:primaryType="nt:unstructured">
                                 <hover
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Hover"
-                                        cssSelector=".cmp-adaptiveform-wizard__label:hover"/>
+                                        cssSelector=".cmp-adaptiveform-wizard__label-container .cmp-adaptiveform-wizard__label:hover"/>
                                 <focus
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Focus"
-                                        cssSelector=".cmp-adaptiveform-wizard__label:focus"/>
+                                        cssSelector=".cmp-adaptiveform-wizard__label-container .cmp-adaptiveform-wizard__label:focus"/>
                             </states>
                         </wizardLabel>
                         <wizardHelpIcon
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Help Icon"
                                 id="af2_wizardhelpicon"
-                                cssSelector=".cmp-adaptiveform-wizard__questionmark"
+                                cssSelector=".cmp-adaptiveform-wizard__label-container .cmp-adaptiveform-wizard__questionmark"
                                 longTitle="Wizard Help Icon"
                                 propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"
                                 secondarySelectors="af2_guideContainer:af2_helpicon">
@@ -49,15 +56,15 @@
                                 <focus
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Focus"
-                                        cssSelector=".cmp-adaptiveform-wizard__questionmark:focus"/>
+                                        cssSelector=".cmp-adaptiveform-wizard__label-container .cmp-adaptiveform-wizard__questionmark:focus"/>
                                 <hover
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Hover"
-                                        cssSelector=".cmp-adaptiveform-wizard__questionmark:hover"/>
+                                        cssSelector=".cmp-adaptiveform-wizard__label-container .cmp-adaptiveform-wizard__questionmark:hover"/>
                                 <disabled
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Disabled"
-                                        cssSelector=".cmp-adaptiveform-wizard__questionmark:disabled"/>
+                                        cssSelector=".cmp-adaptiveform-wizard__label-container .cmp-adaptiveform-wizard__questionmark:disabled"/>
                             </states>
                         </wizardHelpIcon>
                     </items>
@@ -91,6 +98,15 @@
                         cssSelector=".cmp-adaptiveform-wizard__longdescription"
                         longTitle="Wizard Long Description"
                         propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                    <items jcr:primaryType="nt:unstructured">
+                        <longDescriptionParagraph
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Long Description Paragraph"
+                                id="af2_wizarddescriptionlongparagraph"
+                                cssSelector=".cmp-adaptiveform-wizard__longdescription p"
+                                longTitle="Long Description Paragraph"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                    </items>
                     <states jcr:primaryType="nt:unstructured">
                         <focus
                                 jcr:primaryType="nt:unstructured"
@@ -110,6 +126,61 @@
                     longTitle="Wizard Widget"
                     propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
                     <items jcr:primaryType="nt:unstructured">
+                        <wizardWidgetV2Compound
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Widget (V2 Compound)"
+                                id="af2_wizardwidgetv2compound"
+                                cssSelector=".cmp-adaptiveform-wizard__widget--v2.cmp-adaptiveform-wizard__widget"
+                                longTitle="Wizard Widget V2 Compound"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common"/>
+                        <wizardWizardPanel
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Wizard Panel"
+                                id="af2_wizardwizardpanel"
+                                cssSelector=".cmp-adaptiveform-wizard__wizardpanel"
+                                longTitle="Wizard Content Panel"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                            <states jcr:primaryType="nt:unstructured">
+                                <v2Compound
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="V2 Compound"
+                                        cssSelector=".cmp-adaptiveform-wizard__wizardpanel--v2.cmp-adaptiveform-wizard__wizardpanel"/>
+                            </states>
+                        </wizardWizardPanel>
+                        <wizardTabList
+                                jcr:primaryType="nt:unstructured"
+                                jcr:title="Tab List"
+                                id="af2_wizardtablist"
+                                cssSelector=".cmp-adaptiveform-wizard__tabList"
+                                longTitle="Wizard Tab List"
+                                propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                            <states jcr:primaryType="nt:unstructured">
+                                <tablistMarkerDefault
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Tab List Marker"
+                                        cssSelector=".cmp-adaptiveform-wizard__tabList &gt; li::before"/>
+                                <tablistMarkerActive
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Tab List Marker (Active)"
+                                        cssSelector=".cmp-adaptiveform-wizard__tabList &gt; li.cmp-adaptiveform-wizard__tab--active::before"/>
+                                <tablistMarkerStepped
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Tab List Marker (Stepped)"
+                                        cssSelector=".cmp-adaptiveform-wizard__tabList &gt; li.cmp-adaptiveform-wizard__tab--stepped::before"/>
+                                <tablistMarkerActiveStepped
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Tab List Marker (Active Stepped)"
+                                        cssSelector=".cmp-adaptiveform-wizard__tabList &gt; li.cmp-adaptiveform-wizard__tab--active.cmp-adaptiveform-wizard__tab--stepped::before"/>
+                                <tablistItemStepped
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Tab List Item (Stepped)"
+                                        cssSelector=".cmp-adaptiveform-wizard__tabList &gt; li.cmp-adaptiveform-wizard__tab--stepped"/>
+                                <tablistItem
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Tab List Item"
+                                        cssSelector=".cmp-adaptiveform-wizard__tabList &gt; li"/>
+                            </states>
+                        </wizardTabList>
                         <wizardPanelNavigationGroup
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Wizard Navigation Group"
@@ -130,10 +201,26 @@
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Active"
                                                 cssSelector=".cmp-adaptiveform-wizard__tab:active"/>
+                                        <activeBem
+                                                jcr:primaryType="nt:unstructured"
+                                                jcr:title="Active (BEM)"
+                                                cssSelector=".cmp-adaptiveform-wizard__tab--active"/>
+                                        <scopedTab
+                                                jcr:primaryType="nt:unstructured"
+                                                jcr:title="Tab (Scoped)"
+                                                cssSelector=".cmp-adaptiveform-wizard .cmp-adaptiveform-wizard__tab"/>
+                                        <scopedActive
+                                                jcr:primaryType="nt:unstructured"
+                                                jcr:title="Active Tab (Scoped)"
+                                                cssSelector=".cmp-adaptiveform-wizard .cmp-adaptiveform-wizard__tab--active"/>
                                         <stepped
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Visited"
                                                 cssSelector=".cmp-adaptiveform-wizard__tab.stepped"/>
+                                        <steppedBem
+                                                jcr:primaryType="nt:unstructured"
+                                                jcr:title="Visited (BEM)"
+                                                cssSelector=".cmp-adaptiveform-wizard__tab--stepped"/>
                                         <hover
                                                 jcr:primaryType="nt:unstructured"
                                                 jcr:title="Hover"
@@ -168,6 +255,14 @@
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Hover"
                                         cssSelector=".cmp-adaptiveform-wizard__nav--next:hover"/>
+                                    <rtl
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="RTL"
+                                        cssSelector="[dir=&quot;rtl&quot;] .cmp-adaptiveform-wizard__nav--next"/>
+                                    <rtlHover
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="RTL Hover"
+                                        cssSelector="[dir=&quot;rtl&quot;] .cmp-adaptiveform-wizard__nav--next:hover"/>
                                 </states>
                                 </panelNextScroll>
                                 <panelPreviousScroll
@@ -182,8 +277,30 @@
                                             jcr:primaryType="nt:unstructured"
                                             jcr:title="Hover"
                                             cssSelector=".cmp-adaptiveform-wizard__nav--previous:hover"/>
+                                        <rtl
+                                            jcr:primaryType="nt:unstructured"
+                                            jcr:title="RTL"
+                                            cssSelector="[dir=&quot;rtl&quot;] .cmp-adaptiveform-wizard__nav--previous"/>
+                                        <rtlHover
+                                            jcr:primaryType="nt:unstructured"
+                                            jcr:title="RTL Hover"
+                                            cssSelector="[dir=&quot;rtl&quot;] .cmp-adaptiveform-wizard__nav--previous:hover"/>
                                     </states>
                                 </panelPreviousScroll>
+                                <wizardNav
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Navigation"
+                                        id="af2_wizardnav"
+                                        cssSelector=".cmp-adaptiveform-wizard__nav"
+                                        longTitle="Wizard Navigation"
+                                        propertySheet="/mnt/overlay/fd/af/components/stylePropertySheet/common">
+                                    <states jcr:primaryType="nt:unstructured">
+                                        <rtl
+                                            jcr:primaryType="nt:unstructured"
+                                            jcr:title="RTL"
+                                            cssSelector="[dir=&quot;rtl&quot;] .cmp-adaptiveform-wizard__nav"/>
+                                    </states>
+                                </wizardNav>
                             </items>
                         </wizardPanelScrollers>
                     </items>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This commit aligns Adaptive Form _cq_styleConfig selectors with authored markup and canvas theme expectations: scoped label/help, long-description paragraphs, richer tabs/wizard/list markers, file-input and T&C surfaces, v2 wizard/nav/RTL, removal of duplicate submit/reset/button help entries, optional disabled widget styling, and theme config updates so datetime, scribble, and file upload v4 participate in the form theme editor.
<!--- Describe your changes in detail -->

## Related Issue

<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
