### PR TITLE
feat(dialog): add fieldType hidden field to container component dialogs

### DIFF
--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/accordion/v1/accordion/_cq_dialog/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/accordion/v1/accordion/_cq_dialog/.content.xml
@@ -104,6 +104,19 @@
                                                     jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="granite/ui/components/coral/foundation/include"
                                                     path="core/fd/components/form/base/v1/base/cq:dialog/content/items/tabs/items/basic/items/columns/items/column/items/readonly-typehint"/>
+                                            <fieldType
+                                                    jcr:primaryType="nt:unstructured"
+                                                    sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                                    name="./fieldType"
+                                                    required="{Boolean}true"
+                                                    granite:hidden="true">
+                                                <items jcr:primaryType="nt:unstructured">
+                                                    <item jcr:primaryType="nt:unstructured"
+                                                          text="Panel"
+                                                          value="panel"
+                                                          selected="{Boolean}true"/>
+                                                </items>
+                                            </fieldType>
                                         </items>
                                     </column>
                                 </items>

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/fragment/v1/fragment/_cq_dialog/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/fragment/v1/fragment/_cq_dialog/.content.xml
@@ -54,6 +54,19 @@
                                             <unboundFormElement
                                                     jcr:primaryType="nt:unstructured"
                                                     sling:hideResource="{Boolean}true"/>
+                                            <fieldType
+                                                    jcr:primaryType="nt:unstructured"
+                                                    sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                                    name="./fieldType"
+                                                    required="{Boolean}true"
+                                                    granite:hidden="true">
+                                                <items jcr:primaryType="nt:unstructured">
+                                                    <item jcr:primaryType="nt:unstructured"
+                                                          text="Panel"
+                                                          value="panel"
+                                                          selected="{Boolean}true"/>
+                                                </items>
+                                            </fieldType>
                                         </items>
                                     </column>
                                 </items>

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/panelcontainer/v1/panelcontainer/_cq_dialog/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/panelcontainer/v1/panelcontainer/_cq_dialog/.content.xml
@@ -152,6 +152,19 @@
                                                     jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="granite/ui/components/coral/foundation/include"
                                                     path="core/fd/components/form/base/v1/base/cq:dialog/content/items/tabs/items/basic/items/columns/items/column/items/readonly-typehint"/>
+                                            <fieldType
+                                                    jcr:primaryType="nt:unstructured"
+                                                    sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                                    name="./fieldType"
+                                                    required="{Boolean}true"
+                                                    granite:hidden="true">
+                                                <items jcr:primaryType="nt:unstructured">
+                                                    <item jcr:primaryType="nt:unstructured"
+                                                          text="Panel"
+                                                          value="panel"
+                                                          selected="{Boolean}true"/>
+                                                </items>
+                                            </fieldType>
                                         </items>
                                     </column>
                                 </items>

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/tabsontop/v1/tabsontop/_cq_dialog/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/tabsontop/v1/tabsontop/_cq_dialog/.content.xml
@@ -104,6 +104,19 @@
                                                     jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="granite/ui/components/coral/foundation/include"
                                                     path="core/fd/components/form/base/v1/base/cq:dialog/content/items/tabs/items/basic/items/columns/items/column/items/readonly-typehint"/>
+                                            <fieldType
+                                                    jcr:primaryType="nt:unstructured"
+                                                    sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                                    name="./fieldType"
+                                                    required="{Boolean}true"
+                                                    granite:hidden="true">
+                                                <items jcr:primaryType="nt:unstructured">
+                                                    <item jcr:primaryType="nt:unstructured"
+                                                          text="Panel"
+                                                          value="panel"
+                                                          selected="{Boolean}true"/>
+                                                </items>
+                                            </fieldType>
                                         </items>
                                     </column>
                                 </items>

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/wizard/v1/wizard/_cq_dialog/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/wizard/v1/wizard/_cq_dialog/.content.xml
@@ -99,6 +99,19 @@
                                                     jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="granite/ui/components/coral/foundation/include"
                                                     path="core/fd/components/form/base/v1/base/cq:dialog/content/items/tabs/items/basic/items/columns/items/column/items/readonly-typehint"/>
+                                            <fieldType
+                                                    jcr:primaryType="nt:unstructured"
+                                                    sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                                    name="./fieldType"
+                                                    required="{Boolean}true"
+                                                    granite:hidden="true">
+                                                <items jcr:primaryType="nt:unstructured">
+                                                    <item jcr:primaryType="nt:unstructured"
+                                                          text="Panel"
+                                                          value="panel"
+                                                          selected="{Boolean}true"/>
+                                                </items>
+                                            </fieldType>
                                         </items>
                                     </column>
                                 </items>


### PR DESCRIPTION
Adds a hidden select field for fieldType with value 'panel' to the _cq_dialog of panelcontainer, accordion, wizard, tabsontop, and fragment.

These containers inherit from wcm/foundation/components/responsivegrid rather than the AF2 base component, so ./fieldType was never included in their dialogs. As a result the Sites Content MCP componentDefinitions endpoint returned an empty requiredKeys for all containers, causing content authoring agents to omit fieldType from authored nodes.

Consistent with the pattern applied to container v2 in #1843.

Fixes: FORMS-25246

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
