### PR TITLE
FORMS-25355: Make checkedValue required in Checkbox dialog

### DIFF
--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/checkbox/v1/checkbox/_cq_dialog/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/checkbox/v1/checkbox/_cq_dialog/.content.xml
@@ -75,6 +75,7 @@
                                                   sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                   fieldLabel="When Checked, return value"
                                                   fieldDescription="Value submitted when the checkbox is checked. Enter the value as text. For boolean fields, use true. For numeric intent, enter values such as 1 as text."
+                                                  required="{Boolean}true"
                                                   name="./checkedValue"/>
                                                 <enableUncheckedValue
                                                   jcr:primaryType="nt:unstructured"


### PR DESCRIPTION
## Summary

- Marks `checkedValue` as `required="{Boolean}true"` in the Checkbox v1 authoring dialog (`_cq_dialog/.content.xml`)
- Prevents authors from saving the dialog without specifying a checked value, eliminating the silent fallback to the HTML default `"on"`
- The `_cq_template.xml` already provides `checkedValue="on"` and `uncheckedValue="off"` as defaults for newly created checkbox instances, so the required field is pre-populated on first open

Fixes #1874 | [FORMS-25355](https://jira.corp.adobe.com/browse/FORMS-25355)

## Test plan

- [ ] Drag a new Checkbox component onto a form — dialog should open with `checkedValue` pre-filled as `"on"`
- [ ] Clear the `checkedValue` field and try to save — dialog should block save with a validation error
- [ ] Enter a custom value (e.g. `"true"`) and save — component should work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)