### PR TITLE
feat(af-core): FORMS-25463 expose cq:annotations parallel to fd:dor

### DIFF
--- a/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/internal/form/ReservedProperties.java
+++ b/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/internal/form/ReservedProperties.java
@@ -176,6 +176,8 @@ public final class ReservedProperties {
 
     public static final String FD_DRAFT_ID = "fd:draftId";
 
+    public static final String PN_CQ_ANNOTATIONS = "cq:annotations";
+
     // Begin: Form submission related properties
     public static final String FD_SUBMIT_PROPERTIES = "fd:submit";
     public static final String PN_SUBMIT_ACTION_TYPE = "actionType";

--- a/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImpl.java
+++ b/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImpl.java
@@ -314,10 +314,6 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
 
     public static final String CUSTOM_RULE_PROPERTY_WRAPPER = "fd:rules";
 
-    /**
-     * Key under which reviewer annotations (cq:annotations) are exposed in the component's serialized properties map,
-     * parallel to fd:dor / fd:path.
-     */
     public static final String CUSTOM_ANNOTATIONS_PROPERTY_WRAPPER = "cq:annotations";
 
     /**
@@ -752,33 +748,13 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
     }
 
     /**
-     * Returns the reviewer annotations for this component, read from the {@code cq:annotations} child resource on the
-     * component node (a sibling of {@code fd:dorContainer}). Each annotation node's properties are serialized into a
-     * per-annotation map keyed by node name; the result is placed parallel to {@code fd:dor} under the component's
-     * properties.
-     *
-     * <p>
-     * Scoped to authoring/review IC print forms only; runtime/publish requests must not depend on this authoring
-     * payload. Same print-channel gate as {@link #getDorContainer()}, plus an explicit publish-view denylist via
-     * {@link FormConstants#REQ_ATTR_PUBLISH_VIEW} so the runtime publish path never receives this data.
-     *
-     * @return ordered map keyed by annotation node name with the annotation's properties (text, x, y, state,
-     *         reviewedBy, reviewedAt, resolvedBy, resolvedAt, ...); or null when the channel is not print, the
-     *         resource is missing, the request is in publish view, or no cq:annotations child exists. Returning
-     *         null lets callers omit the property and keeps the output non-breaking for forms without annotations.
+     * Returns the reviewer annotations stored under the component's {@code cq:annotations} child resource,
+     * keyed by annotation node name. Scoped to the print channel; returns null when no annotations exist
+     * so callers can omit the property.
      */
     @JsonIgnore
     public Map<String, Object> getCqAnnotations() {
-        // Gate matches getDorContainer() (print channel + resource present) plus an explicit
-        // publish-view denylist. The previous isAuthorMode(request) check relied on WCMMode,
-        // but the IC REST GET (CommunicationReadProcessor → FormModelReader) resolves the Sling
-        // Model with a wrapped request that doesn't carry WCMMode, so the gate always failed
-        // and cq:annotations never reached the response. See the pre-existing TODO above about
-        // sling-model-wrapper requests having incorrect WCMMode for the same reason.
         if (!FormConstants.CHANNEL_PRINT.equals(this.channel) || resource == null) {
-            return null;
-        }
-        if (request != null && Boolean.TRUE.equals(request.getAttribute(FormConstants.REQ_ATTR_PUBLISH_VIEW))) {
             return null;
         }
         Resource annotationsResource = resource.getChild("cq:annotations");

--- a/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImpl.java
+++ b/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImpl.java
@@ -653,6 +653,7 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
             .stream()
             .filter(entry -> isAllowedType(entry.getValue())
                 && !reservedProperties.contains(entry.getKey())
+                && !CUSTOM_ANNOTATIONS_PROPERTY_WRAPPER.equals(entry.getKey())
                 && excludedPrefixes.stream().noneMatch(prefix -> entry.getKey().startsWith(prefix)))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         nodeBasedCustomProperties.forEach(customProperties::putIfAbsent);

--- a/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImpl.java
+++ b/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImpl.java
@@ -340,7 +340,7 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
             properties.put(CUSTOM_DOR_PROPERTY_WRAPPER, getDorProperties());
         }
         Map<String, Object> annotations = getCqAnnotations();
-        if (annotations != null && !annotations.isEmpty()) {
+        if (annotations != null) {
             properties.put(CUSTOM_ANNOTATIONS_PROPERTY_WRAPPER, annotations);
         }
         properties.put(CUSTOM_JCR_PATH_PROPERTY_WRAPPER, getPath());
@@ -649,7 +649,6 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
             .stream()
             .filter(entry -> isAllowedType(entry.getValue())
                 && !reservedProperties.contains(entry.getKey())
-                && !CUSTOM_ANNOTATIONS_PROPERTY_WRAPPER.equals(entry.getKey())
                 && excludedPrefixes.stream().noneMatch(prefix -> entry.getKey().startsWith(prefix)))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         nodeBasedCustomProperties.forEach(customProperties::putIfAbsent);
@@ -753,11 +752,11 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
      * so callers can omit the property.
      */
     @JsonIgnore
-    public Map<String, Object> getCqAnnotations() {
+    private Map<String, Object> getCqAnnotations() {
         if (!FormConstants.CHANNEL_PRINT.equals(this.channel) || resource == null) {
             return null;
         }
-        Resource annotationsResource = resource.getChild("cq:annotations");
+        Resource annotationsResource = resource.getChild(CUSTOM_ANNOTATIONS_PROPERTY_WRAPPER);
         if (annotationsResource == null) {
             return null;
         }
@@ -765,7 +764,9 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
         for (Resource child : annotationsResource.getChildren()) {
             ValueMap vm = child.getValueMap();
             Map<String, Object> ann = vm.entrySet().stream()
-                .filter(e -> isAllowedType(e.getValue()))
+                .filter(e -> isAllowedType(e.getValue())
+                    && !e.getKey().startsWith("jcr:")
+                    && !e.getKey().startsWith("sling:"))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (a, b) -> a, LinkedHashMap::new));
             if (!ann.isEmpty()) {
                 result.put(child.getName(), ann);

--- a/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImpl.java
+++ b/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImpl.java
@@ -137,7 +137,6 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
      * Returns dorBindRef of the form field
      *
      * @return dorBindRef of the field
-     * 
      * @since com.adobe.cq.forms.core.components.util 4.0.0
      */
     @JsonIgnore
@@ -227,7 +226,6 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
      * Returns the name of the form field
      *
      * @return name of the form field
-     * 
      * @since com.adobe.cq.forms.core.components.models.form 0.0.1
      */
     @Override
@@ -247,7 +245,6 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
      * Returns the view type
      *
      * @return the view type
-     * 
      * @since com.adobe.cq.forms.core.components.models.form 0.0.1
      */
     @Override
@@ -266,7 +263,6 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
      * Returns {@code true} if form field should be visible, otherwise {@code false}.
      *
      * @return {@code true} if form field should be visible, otherwise {@code false}
-     * 
      * @since com.adobe.cq.forms.core.components.models.form 0.0.1
      */
     @Override
@@ -298,8 +294,7 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
             // TODO: for some reason sling model wrapper request (through model.json) is giving incorrect wcmmode
             // we anyways dont need to rely on wcmmode while fetching form definition.
             if (!matches) {
-                editMode = WCMMode.fromRequest(request) == WCMMode.EDIT
-                        || WCMMode.fromRequest(request) == WCMMode.DESIGN;
+                editMode = WCMMode.fromRequest(request) == WCMMode.EDIT || WCMMode.fromRequest(request) == WCMMode.DESIGN;
             }
         }
         return editMode;
@@ -326,12 +321,14 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
     public static final String CUSTOM_ANNOTATIONS_PROPERTY_WRAPPER = "cq:annotations";
 
     /**
-     * Predicate to check if a map entry is non empty return true if and only if 1) the value is not of type string and
-     * non empty or 2) the value is of type string[] and has more than 1 elements
+     * Predicate to check if a map entry is non empty
+     * return true if and only if
+     * 1) the value is not of type string and non empty or
+     * 2) the value is of type string[] and has more than 1 elements
      */
-    private final Predicate<Map.Entry<String, Object>> isEntryNonEmpty = obj -> (obj.getValue() instanceof String
-            && ((String) obj.getValue()).length() > 0)
-            || (obj.getValue() instanceof String[] && ((String[]) obj.getValue()).length > 0);
+    private final Predicate<Map.Entry<String, Object>> isEntryNonEmpty = obj -> (obj.getValue() instanceof String && ((String) obj
+        .getValue()).length() > 0)
+        || (obj.getValue() instanceof String[] && ((String[]) obj.getValue()).length > 0);
 
     @Override
     public @NotNull Map<String, Object> getProperties() {
@@ -375,21 +372,20 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
     }
 
     /**
-     * Returns rules (visible, required, etc.) for the given resource. Used when exporting fragment components so that
-     * rules configured on the referenced fragment are included in the stitched output as root-level "rules" (parallel
-     * to "events").
+     * Returns rules (visible, required, etc.) for the given resource. Used when exporting
+     * fragment components so that rules configured on the referenced fragment are
+     * included in the stitched output as root-level "rules" (parallel to "events").
      *
-     * @param resource
-     *            the resource that may have an fd:rules child
-     * 
+     * @param resource the resource that may have an fd:rules child
      * @return map of rule name to expression, never null
      */
     protected final Map<String, String> getRulesForResource(Resource resource) {
-        String[] VALID_RULES = new String[] { "description", "enabled", "enum", "enumNames", "exclusiveMaximum",
-                "exclusiveMinimum", "label", "maximum", "minimum", "readOnly", "required", "value", "visible" };
+        String[] VALID_RULES = new String[] { "description", "enabled", "enum", "enumNames",
+            "exclusiveMaximum", "exclusiveMinimum", "label", "maximum", "minimum",
+            "readOnly", "required", "value", "visible" };
 
-        Predicate<Map.Entry<String, Object>> isRuleNameValid = obj -> Arrays.stream(VALID_RULES)
-                .anyMatch(validKey -> validKey.equals(obj.getKey()));
+        Predicate<Map.Entry<String, Object>> isRuleNameValid = obj -> Arrays.stream(VALID_RULES).anyMatch(validKey -> validKey.equals(obj
+            .getKey()));
 
         Predicate<Map.Entry<String, Object>> isRuleValid = isEntryNonEmpty.and(isRuleNameValid);
 
@@ -399,9 +395,11 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
         Resource ruleNode = resource.getChild("fd:rules");
         if (ruleNode != null) {
             ValueMap ruleNodeProps = ruleNode.getValueMap();
-            return ruleNodeProps.entrySet().stream().filter(isRuleValid)
-                    .map(entry -> new AbstractMap.SimpleEntry<>(entry.getKey(), (String) entry.getValue()))
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            return ruleNodeProps.entrySet()
+                .stream()
+                .filter(isRuleValid)
+                .map(entry -> new AbstractMap.SimpleEntry<>(entry.getKey(), (String) entry.getValue()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         }
         return Collections.emptyMap();
     }
@@ -412,12 +410,11 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
     }
 
     /**
-     * Returns rules properties (fd:rules) for the given resource. Used when exporting fragment components so that rules
-     * configured on the referenced fragment are included in the stitched output.
+     * Returns rules properties (fd:rules) for the given resource. Used when exporting
+     * fragment components so that rules configured on the referenced fragment are
+     * included in the stitched output.
      *
-     * @param resource
-     *            the resource that may have an fd:rules child
-     * 
+     * @param resource the resource that may have an fd:rules child
      * @return map of rules properties, never null
      */
     protected final Map<String, Object> getRulesPropertiesForResource(Resource resource) {
@@ -444,10 +441,8 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
         }
     }
 
-    private void populateAdditionalRulesProperties(@NotNull Resource ruleNode,
-            Map<String, Object> customRulesProperties) {
-        String[] RULES = { "fd:formReady", "fd:layoutReady", "fd:docReady", "fd:calc", "fd:init", "fd:validate",
-                "fd:indexChange" };
+    private void populateAdditionalRulesProperties(@NotNull Resource ruleNode, Map<String, Object> customRulesProperties) {
+        String[] RULES = { "fd:formReady", "fd:layoutReady", "fd:docReady", "fd:calc", "fd:init", "fd:validate", "fd:indexChange" };
         ValueMap props = ruleNode.adaptTo(ValueMap.class);
         if (props != null) {
             Arrays.stream(RULES).forEach(rule -> addRuleProperty(props, customRulesProperties, rule));
@@ -463,7 +458,6 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
      * If atleast one rule is invalid then status of rule for component is considered as invalid
      *
      * @param rulesResource
-     * 
      * @return
      */
     private String getRulesStatus(Resource rulesResource) {
@@ -484,21 +478,20 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
     }
 
     /**
-     * Sanitizes the event entry by * removing invalid event names, * removing events where the handler is not of type
-     * string or string[] * converts all the event handlers into string[] for easy consumption * updates custom event
-     * key (as we cannot save custom:eventName in JCR)
+     * Sanitizes the event entry by
+     * * removing invalid event names,
+     * * removing events where the handler is not of type string or string[]
+     * * converts all the event handlers into string[] for easy consumption
+     * * updates custom event key (as we cannot save custom:eventName in JCR)
      *
-     * @param entry
-     *            the event entry to manipulate
-     * 
+     * @param entry the event entry to manipulate
      * @return the updated event entry
      */
     private Stream<Map.Entry<String, String[]>> sanitizeEvent(Map.Entry<String, Object> entry) {
-        String[] VALID_EVENTS = new String[] { "click", "submit", "initialize", "load", "change", "submitSuccess",
-                "submitError" };
+        String[] VALID_EVENTS = new String[] { "click", "submit", "initialize", "load", "change", "submitSuccess", "submitError" };
 
-        Predicate<Map.Entry<String, Object>> isEventNameValid = obj -> obj.getKey().startsWith("custom_")
-                || Arrays.stream(VALID_EVENTS).anyMatch(validKey -> validKey.equals(obj.getKey()));
+        Predicate<Map.Entry<String, Object>> isEventNameValid = obj -> obj.getKey().startsWith("custom_") ||
+            Arrays.stream(VALID_EVENTS).anyMatch(validKey -> validKey.equals(obj.getKey()));
         Predicate<Map.Entry<String, Object>> isEventValid = isEntryNonEmpty.and(isEventNameValid);
 
         Stream<Map.Entry<String, String[]>> updatedEntry;
@@ -534,12 +527,11 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
     }
 
     /**
-     * Returns events (fd:events) for the given resource. Used when exporting fragment components so that events
-     * configured on the referenced fragment are included in the stitched output.
+     * Returns events (fd:events) for the given resource. Used when exporting
+     * fragment components so that events configured on the referenced fragment are
+     * included in the stitched output.
      *
-     * @param resource
-     *            the resource that may have an fd:events child
-     * 
+     * @param resource the resource that may have an fd:events child
      * @return map of event name to handler expressions, never null
      */
     protected final Map<String, String[]> getEventsForResource(Resource resource) {
@@ -551,15 +543,15 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
                 eventSet.addAll(eventNodeProps.entrySet());
             }
         }
-        return eventSet.stream().flatMap(this::sanitizeEvent)
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        return eventSet.stream()
+            .flatMap(this::sanitizeEvent)
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     /**
      * Returns the reference to the data model
      *
      * @return reference to the data model
-     * 
      * @since com.adobe.cq.forms.core.components.models.form 0.0.1
      */
     @Override
@@ -574,7 +566,6 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
      * Returns getPath of the form field
      *
      * @return getPath of the field
-     * 
      * @since com.adobe.cq.forms.core.components.util 3.1.0
      */
     @Override
@@ -609,10 +600,9 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
         if (componentData == null) {
             if (this.dataLayerEnabled == null) {
                 if (this.getCurrentPage() != null) {
-                    // Check at page level to allow components embedded via containers in editable templates to inherit
-                    // the setting
-                    this.dataLayerEnabled = com.adobe.cq.wcm.core.components.util.ComponentUtils
-                            .isDataLayerEnabled(this.getCurrentPage().getContentResource());
+                    // Check at page level to allow components embedded via containers in editable templates to inherit the setting
+                    this.dataLayerEnabled = com.adobe.cq.wcm.core.components.util.ComponentUtils.isDataLayerEnabled(this.getCurrentPage()
+                        .getContentResource());
                 } else {
                     this.dataLayerEnabled = ComponentUtils.isDataLayerEnabled(this.resource);
                 }
@@ -626,8 +616,8 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
 
     private static class DataRefSerializer extends JsonSerializer<String> {
         @Override
-        public void serialize(String s, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
-                throws IOException {
+        public void serialize(String s, JsonGenerator jsonGenerator,
+            SerializerProvider serializerProvider) throws IOException {
             if (NULL_DATA_REF.equals(s)) {
                 jsonGenerator.writeString((String) null);
             } else {
@@ -642,15 +632,13 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
     }
 
     private boolean isAllowedType(Object value) {
-        return value instanceof String || value instanceof String[] || value instanceof Boolean
-                || value instanceof Boolean[] || value instanceof Calendar || value instanceof Calendar[]
-                || value instanceof BigDecimal || value instanceof BigDecimal[] || value instanceof Long
-                || value instanceof Long[];
+        return value instanceof String || value instanceof String[] || value instanceof Boolean || value instanceof Boolean[]
+            || value instanceof Calendar || value instanceof Calendar[] || value instanceof BigDecimal
+            || value instanceof BigDecimal[] || value instanceof Long || value instanceof Long[];
     }
 
     /**
-     * Fetches all the custom properties associated with a given component's instance (including additional custom
-     * properties)
+     * Fetches all the custom properties associated with a given component's instance (including additional custom properties)
      *
      * @return {@code Map<String, String>} returns all custom property key value pairs associated with the resource
      */
@@ -661,15 +649,18 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
         Set<String> reservedProperties = ReservedProperties.getReservedProperties();
 
         ValueMap resourceMap = resource.getValueMap();
-        Map<String, Object> nodeBasedCustomProperties = resourceMap.entrySet().stream()
-                .filter(entry -> isAllowedType(entry.getValue()) && !reservedProperties.contains(entry.getKey())
-                        && !CUSTOM_ANNOTATIONS_PROPERTY_WRAPPER.equals(entry.getKey())
-                        && excludedPrefixes.stream().noneMatch(prefix -> entry.getKey().startsWith(prefix)))
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        Map<String, Object> nodeBasedCustomProperties = resourceMap.entrySet()
+            .stream()
+            .filter(entry -> isAllowedType(entry.getValue())
+                && !reservedProperties.contains(entry.getKey())
+                && !CUSTOM_ANNOTATIONS_PROPERTY_WRAPPER.equals(entry.getKey())
+                && excludedPrefixes.stream().noneMatch(prefix -> entry.getKey().startsWith(prefix)))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         nodeBasedCustomProperties.forEach(customProperties::putIfAbsent);
         try {
             templateBasedCustomProperties = Optional.ofNullable(this.resource.adaptTo(CustomPropertyInfo.class))
-                    .map(CustomPropertyInfo::getProperties).orElse(Collections.emptyMap());
+                .map(CustomPropertyInfo::getProperties)
+                .orElse(Collections.emptyMap());
         } catch (NoClassDefFoundError e) {
             logger.info("CustomPropertyInfo class not found. This feature is available in the latest Forms addon.");
             templateBasedCustomProperties = Collections.emptyMap();
@@ -685,12 +676,10 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
             Resource associatePropertiesResource = resource.getChild(CUSTOM_ASSOCIATE_PROPERTY_WRAPPER);
             if (associatePropertiesResource != null) {
                 try {
-                    AssociateProperties associateProperties = associatePropertiesResource
-                            .adaptTo(AssociateProperties.class);
+                    AssociateProperties associateProperties = associatePropertiesResource.adaptTo(AssociateProperties.class);
                     ObjectMapper objectMapper = new ObjectMapper();
                     if (associateProperties != null) {
-                        return objectMapper.convertValue(associateProperties, new TypeReference<Map<String, Object>>() {
-                        });
+                        return objectMapper.convertValue(associateProperties, new TypeReference<Map<String, Object>>() {});
                     }
                 } catch (Exception e) {
                     logger.warn("Unable to adapt associate properties", e);
@@ -755,8 +744,7 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
                 DorContainer dorContainer = dorContainerResource.adaptTo(DorContainer.class);
                 ObjectMapper objectMapper = new ObjectMapper();
                 if (dorContainer != null) {
-                    return objectMapper.convertValue(dorContainer, new TypeReference<Map<String, Object>>() {
-                    });
+                    return objectMapper.convertValue(dorContainer, new TypeReference<Map<String, Object>>() {});
                 }
             }
         }
@@ -788,15 +776,16 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
             return null;
         }
         // Structural-only JCR properties that carry no annotation data.
-        Set<String> excluded = new java.util.HashSet<>(Arrays.asList("jcr:primaryType", "jcr:mixinTypes"));
+        Set<String> excluded = new HashSet<>(Arrays.asList("jcr:primaryType", "jcr:mixinTypes"));
         Map<String, Object> result = new LinkedHashMap<>();
         for (Resource child : annotationsResource.getChildren()) {
             ValueMap vm = child.getValueMap();
             Map<String, Object> ann = vm.entrySet().stream()
-                    .filter(e -> !excluded.contains(e.getKey()) && isAllowedType(e.getValue()))
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue,
-                            (a, b) -> a, LinkedHashMap::new));
-            if (!ann.isEmpty()) result.put(child.getName(), ann);
+                .filter(e -> !excluded.contains(e.getKey()) && isAllowedType(e.getValue()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (a, b) -> a, LinkedHashMap::new));
+            if (!ann.isEmpty()) {
+                result.put(child.getName(), ann);
+            }
         }
         return result.isEmpty() ? null : result;
     }

--- a/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImpl.java
+++ b/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImpl.java
@@ -758,20 +758,20 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
      * serialized into a per-annotation map keyed by node name; the result is
      * placed parallel to {@code fd:dor} under the component's properties.
      *
-     * <p>Scoped to IC print forms only (same channel gate as
-     * {@link #getDorContainer()}); returns null for v2 Adaptive Forms and
-     * the IC web channel.
+     * <p>Scoped to authoring/review IC print forms only; runtime/publish
+     * requests must not depend on this authoring payload. Same print-channel
+     * gate as {@link #getDorContainer()}, plus author mode check.
      *
      * @return ordered map keyed by annotation node name with color, text, x,
      *     y, optional state/resolvedBy/resolvedAt and JCR audit fields; or
-     *     null when the channel is not print, the resource is missing, or no
-     *     cq:annotations child exists. Returning null lets callers omit the
-     *     property and keeps the output non-breaking for forms without
-     *     annotations.
+     *     null when not in author mode, the channel is not print, the resource
+     *     is missing, or no cq:annotations child exists. Returning null lets
+     *     callers omit the property and keeps the output non-breaking for
+     *     forms without annotations.
      */
     @JsonIgnore
     public Map<String, Object> getCqAnnotations() {
-        if (!FormConstants.CHANNEL_PRINT.equals(this.channel) || resource == null) {
+        if (!FormConstants.CHANNEL_PRINT.equals(this.channel) || !isAuthorMode(request) || resource == null) {
             return null;
         }
         Resource annotationsResource = resource.getChild("cq:annotations");

--- a/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImpl.java
+++ b/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImpl.java
@@ -137,6 +137,7 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
      * Returns dorBindRef of the form field
      *
      * @return dorBindRef of the field
+     * 
      * @since com.adobe.cq.forms.core.components.util 4.0.0
      */
     @JsonIgnore
@@ -226,6 +227,7 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
      * Returns the name of the form field
      *
      * @return name of the form field
+     * 
      * @since com.adobe.cq.forms.core.components.models.form 0.0.1
      */
     @Override
@@ -245,6 +247,7 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
      * Returns the view type
      *
      * @return the view type
+     * 
      * @since com.adobe.cq.forms.core.components.models.form 0.0.1
      */
     @Override
@@ -263,6 +266,7 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
      * Returns {@code true} if form field should be visible, otherwise {@code false}.
      *
      * @return {@code true} if form field should be visible, otherwise {@code false}
+     * 
      * @since com.adobe.cq.forms.core.components.models.form 0.0.1
      */
     @Override
@@ -294,7 +298,8 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
             // TODO: for some reason sling model wrapper request (through model.json) is giving incorrect wcmmode
             // we anyways dont need to rely on wcmmode while fetching form definition.
             if (!matches) {
-                editMode = WCMMode.fromRequest(request) == WCMMode.EDIT || WCMMode.fromRequest(request) == WCMMode.DESIGN;
+                editMode = WCMMode.fromRequest(request) == WCMMode.EDIT
+                        || WCMMode.fromRequest(request) == WCMMode.DESIGN;
             }
         }
         return editMode;
@@ -315,20 +320,18 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
     public static final String CUSTOM_RULE_PROPERTY_WRAPPER = "fd:rules";
 
     /**
-     * Key under which reviewer annotations (cq:annotations) are exposed in the
-     * component's serialized properties map, parallel to fd:dor / fd:path.
+     * Key under which reviewer annotations (cq:annotations) are exposed in the component's serialized properties map,
+     * parallel to fd:dor / fd:path.
      */
     public static final String CUSTOM_ANNOTATIONS_PROPERTY_WRAPPER = "cq:annotations";
 
     /**
-     * Predicate to check if a map entry is non empty
-     * return true if and only if
-     * 1) the value is not of type string and non empty or
-     * 2) the value is of type string[] and has more than 1 elements
+     * Predicate to check if a map entry is non empty return true if and only if 1) the value is not of type string and
+     * non empty or 2) the value is of type string[] and has more than 1 elements
      */
-    private final Predicate<Map.Entry<String, Object>> isEntryNonEmpty = obj -> (obj.getValue() instanceof String && ((String) obj
-        .getValue()).length() > 0)
-        || (obj.getValue() instanceof String[] && ((String[]) obj.getValue()).length > 0);
+    private final Predicate<Map.Entry<String, Object>> isEntryNonEmpty = obj -> (obj.getValue() instanceof String
+            && ((String) obj.getValue()).length() > 0)
+            || (obj.getValue() instanceof String[] && ((String[]) obj.getValue()).length > 0);
 
     @Override
     public @NotNull Map<String, Object> getProperties() {
@@ -372,20 +375,21 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
     }
 
     /**
-     * Returns rules (visible, required, etc.) for the given resource. Used when exporting
-     * fragment components so that rules configured on the referenced fragment are
-     * included in the stitched output as root-level "rules" (parallel to "events").
+     * Returns rules (visible, required, etc.) for the given resource. Used when exporting fragment components so that
+     * rules configured on the referenced fragment are included in the stitched output as root-level "rules" (parallel
+     * to "events").
      *
-     * @param resource the resource that may have an fd:rules child
+     * @param resource
+     *            the resource that may have an fd:rules child
+     * 
      * @return map of rule name to expression, never null
      */
     protected final Map<String, String> getRulesForResource(Resource resource) {
-        String[] VALID_RULES = new String[] { "description", "enabled", "enum", "enumNames",
-            "exclusiveMaximum", "exclusiveMinimum", "label", "maximum", "minimum",
-            "readOnly", "required", "value", "visible" };
+        String[] VALID_RULES = new String[] { "description", "enabled", "enum", "enumNames", "exclusiveMaximum",
+                "exclusiveMinimum", "label", "maximum", "minimum", "readOnly", "required", "value", "visible" };
 
-        Predicate<Map.Entry<String, Object>> isRuleNameValid = obj -> Arrays.stream(VALID_RULES).anyMatch(validKey -> validKey.equals(obj
-            .getKey()));
+        Predicate<Map.Entry<String, Object>> isRuleNameValid = obj -> Arrays.stream(VALID_RULES)
+                .anyMatch(validKey -> validKey.equals(obj.getKey()));
 
         Predicate<Map.Entry<String, Object>> isRuleValid = isEntryNonEmpty.and(isRuleNameValid);
 
@@ -395,11 +399,9 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
         Resource ruleNode = resource.getChild("fd:rules");
         if (ruleNode != null) {
             ValueMap ruleNodeProps = ruleNode.getValueMap();
-            return ruleNodeProps.entrySet()
-                .stream()
-                .filter(isRuleValid)
-                .map(entry -> new AbstractMap.SimpleEntry<>(entry.getKey(), (String) entry.getValue()))
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            return ruleNodeProps.entrySet().stream().filter(isRuleValid)
+                    .map(entry -> new AbstractMap.SimpleEntry<>(entry.getKey(), (String) entry.getValue()))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         }
         return Collections.emptyMap();
     }
@@ -410,11 +412,12 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
     }
 
     /**
-     * Returns rules properties (fd:rules) for the given resource. Used when exporting
-     * fragment components so that rules configured on the referenced fragment are
-     * included in the stitched output.
+     * Returns rules properties (fd:rules) for the given resource. Used when exporting fragment components so that rules
+     * configured on the referenced fragment are included in the stitched output.
      *
-     * @param resource the resource that may have an fd:rules child
+     * @param resource
+     *            the resource that may have an fd:rules child
+     * 
      * @return map of rules properties, never null
      */
     protected final Map<String, Object> getRulesPropertiesForResource(Resource resource) {
@@ -441,8 +444,10 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
         }
     }
 
-    private void populateAdditionalRulesProperties(@NotNull Resource ruleNode, Map<String, Object> customRulesProperties) {
-        String[] RULES = { "fd:formReady", "fd:layoutReady", "fd:docReady", "fd:calc", "fd:init", "fd:validate", "fd:indexChange" };
+    private void populateAdditionalRulesProperties(@NotNull Resource ruleNode,
+            Map<String, Object> customRulesProperties) {
+        String[] RULES = { "fd:formReady", "fd:layoutReady", "fd:docReady", "fd:calc", "fd:init", "fd:validate",
+                "fd:indexChange" };
         ValueMap props = ruleNode.adaptTo(ValueMap.class);
         if (props != null) {
             Arrays.stream(RULES).forEach(rule -> addRuleProperty(props, customRulesProperties, rule));
@@ -458,6 +463,7 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
      * If atleast one rule is invalid then status of rule for component is considered as invalid
      *
      * @param rulesResource
+     * 
      * @return
      */
     private String getRulesStatus(Resource rulesResource) {
@@ -478,20 +484,21 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
     }
 
     /**
-     * Sanitizes the event entry by
-     * * removing invalid event names,
-     * * removing events where the handler is not of type string or string[]
-     * * converts all the event handlers into string[] for easy consumption
-     * * updates custom event key (as we cannot save custom:eventName in JCR)
+     * Sanitizes the event entry by * removing invalid event names, * removing events where the handler is not of type
+     * string or string[] * converts all the event handlers into string[] for easy consumption * updates custom event
+     * key (as we cannot save custom:eventName in JCR)
      *
-     * @param entry the event entry to manipulate
+     * @param entry
+     *            the event entry to manipulate
+     * 
      * @return the updated event entry
      */
     private Stream<Map.Entry<String, String[]>> sanitizeEvent(Map.Entry<String, Object> entry) {
-        String[] VALID_EVENTS = new String[] { "click", "submit", "initialize", "load", "change", "submitSuccess", "submitError" };
+        String[] VALID_EVENTS = new String[] { "click", "submit", "initialize", "load", "change", "submitSuccess",
+                "submitError" };
 
-        Predicate<Map.Entry<String, Object>> isEventNameValid = obj -> obj.getKey().startsWith("custom_") ||
-            Arrays.stream(VALID_EVENTS).anyMatch(validKey -> validKey.equals(obj.getKey()));
+        Predicate<Map.Entry<String, Object>> isEventNameValid = obj -> obj.getKey().startsWith("custom_")
+                || Arrays.stream(VALID_EVENTS).anyMatch(validKey -> validKey.equals(obj.getKey()));
         Predicate<Map.Entry<String, Object>> isEventValid = isEntryNonEmpty.and(isEventNameValid);
 
         Stream<Map.Entry<String, String[]>> updatedEntry;
@@ -527,11 +534,12 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
     }
 
     /**
-     * Returns events (fd:events) for the given resource. Used when exporting
-     * fragment components so that events configured on the referenced fragment are
-     * included in the stitched output.
+     * Returns events (fd:events) for the given resource. Used when exporting fragment components so that events
+     * configured on the referenced fragment are included in the stitched output.
      *
-     * @param resource the resource that may have an fd:events child
+     * @param resource
+     *            the resource that may have an fd:events child
+     * 
      * @return map of event name to handler expressions, never null
      */
     protected final Map<String, String[]> getEventsForResource(Resource resource) {
@@ -543,15 +551,15 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
                 eventSet.addAll(eventNodeProps.entrySet());
             }
         }
-        return eventSet.stream()
-            .flatMap(this::sanitizeEvent)
-            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        return eventSet.stream().flatMap(this::sanitizeEvent)
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     /**
      * Returns the reference to the data model
      *
      * @return reference to the data model
+     * 
      * @since com.adobe.cq.forms.core.components.models.form 0.0.1
      */
     @Override
@@ -566,6 +574,7 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
      * Returns getPath of the form field
      *
      * @return getPath of the field
+     * 
      * @since com.adobe.cq.forms.core.components.util 3.1.0
      */
     @Override
@@ -600,9 +609,10 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
         if (componentData == null) {
             if (this.dataLayerEnabled == null) {
                 if (this.getCurrentPage() != null) {
-                    // Check at page level to allow components embedded via containers in editable templates to inherit the setting
-                    this.dataLayerEnabled = com.adobe.cq.wcm.core.components.util.ComponentUtils.isDataLayerEnabled(this.getCurrentPage()
-                        .getContentResource());
+                    // Check at page level to allow components embedded via containers in editable templates to inherit
+                    // the setting
+                    this.dataLayerEnabled = com.adobe.cq.wcm.core.components.util.ComponentUtils
+                            .isDataLayerEnabled(this.getCurrentPage().getContentResource());
                 } else {
                     this.dataLayerEnabled = ComponentUtils.isDataLayerEnabled(this.resource);
                 }
@@ -616,8 +626,8 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
 
     private static class DataRefSerializer extends JsonSerializer<String> {
         @Override
-        public void serialize(String s, JsonGenerator jsonGenerator,
-            SerializerProvider serializerProvider) throws IOException {
+        public void serialize(String s, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+                throws IOException {
             if (NULL_DATA_REF.equals(s)) {
                 jsonGenerator.writeString((String) null);
             } else {
@@ -632,13 +642,15 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
     }
 
     private boolean isAllowedType(Object value) {
-        return value instanceof String || value instanceof String[] || value instanceof Boolean || value instanceof Boolean[]
-            || value instanceof Calendar || value instanceof Calendar[] || value instanceof BigDecimal
-            || value instanceof BigDecimal[] || value instanceof Long || value instanceof Long[];
+        return value instanceof String || value instanceof String[] || value instanceof Boolean
+                || value instanceof Boolean[] || value instanceof Calendar || value instanceof Calendar[]
+                || value instanceof BigDecimal || value instanceof BigDecimal[] || value instanceof Long
+                || value instanceof Long[];
     }
 
     /**
-     * Fetches all the custom properties associated with a given component's instance (including additional custom properties)
+     * Fetches all the custom properties associated with a given component's instance (including additional custom
+     * properties)
      *
      * @return {@code Map<String, String>} returns all custom property key value pairs associated with the resource
      */
@@ -649,18 +661,15 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
         Set<String> reservedProperties = ReservedProperties.getReservedProperties();
 
         ValueMap resourceMap = resource.getValueMap();
-        Map<String, Object> nodeBasedCustomProperties = resourceMap.entrySet()
-            .stream()
-            .filter(entry -> isAllowedType(entry.getValue())
-                && !reservedProperties.contains(entry.getKey())
-                && !CUSTOM_ANNOTATIONS_PROPERTY_WRAPPER.equals(entry.getKey())
-                && excludedPrefixes.stream().noneMatch(prefix -> entry.getKey().startsWith(prefix)))
-            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        Map<String, Object> nodeBasedCustomProperties = resourceMap.entrySet().stream()
+                .filter(entry -> isAllowedType(entry.getValue()) && !reservedProperties.contains(entry.getKey())
+                        && !CUSTOM_ANNOTATIONS_PROPERTY_WRAPPER.equals(entry.getKey())
+                        && excludedPrefixes.stream().noneMatch(prefix -> entry.getKey().startsWith(prefix)))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         nodeBasedCustomProperties.forEach(customProperties::putIfAbsent);
         try {
             templateBasedCustomProperties = Optional.ofNullable(this.resource.adaptTo(CustomPropertyInfo.class))
-                .map(CustomPropertyInfo::getProperties)
-                .orElse(Collections.emptyMap());
+                    .map(CustomPropertyInfo::getProperties).orElse(Collections.emptyMap());
         } catch (NoClassDefFoundError e) {
             logger.info("CustomPropertyInfo class not found. This feature is available in the latest Forms addon.");
             templateBasedCustomProperties = Collections.emptyMap();
@@ -676,10 +685,12 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
             Resource associatePropertiesResource = resource.getChild(CUSTOM_ASSOCIATE_PROPERTY_WRAPPER);
             if (associatePropertiesResource != null) {
                 try {
-                    AssociateProperties associateProperties = associatePropertiesResource.adaptTo(AssociateProperties.class);
+                    AssociateProperties associateProperties = associatePropertiesResource
+                            .adaptTo(AssociateProperties.class);
                     ObjectMapper objectMapper = new ObjectMapper();
                     if (associateProperties != null) {
-                        return objectMapper.convertValue(associateProperties, new TypeReference<Map<String, Object>>() {});
+                        return objectMapper.convertValue(associateProperties, new TypeReference<Map<String, Object>>() {
+                        });
                     }
                 } catch (Exception e) {
                     logger.warn("Unable to adapt associate properties", e);
@@ -744,7 +755,8 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
                 DorContainer dorContainer = dorContainerResource.adaptTo(DorContainer.class);
                 ObjectMapper objectMapper = new ObjectMapper();
                 if (dorContainer != null) {
-                    return objectMapper.convertValue(dorContainer, new TypeReference<Map<String, Object>>() {});
+                    return objectMapper.convertValue(dorContainer, new TypeReference<Map<String, Object>>() {
+                    });
                 }
             }
         }
@@ -752,22 +764,19 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
     }
 
     /**
-     * Returns the reviewer annotations for this component, read from the
-     * {@code cq:annotations} child resource on the component node (a sibling
-     * of {@code fd:dorContainer}). Each annotation node's properties are
-     * serialized into a per-annotation map keyed by node name; the result is
-     * placed parallel to {@code fd:dor} under the component's properties.
+     * Returns the reviewer annotations for this component, read from the {@code cq:annotations} child resource on the
+     * component node (a sibling of {@code fd:dorContainer}). Each annotation node's properties are serialized into a
+     * per-annotation map keyed by node name; the result is placed parallel to {@code fd:dor} under the component's
+     * properties.
      *
-     * <p>Scoped to authoring/review IC print forms only; runtime/publish
-     * requests must not depend on this authoring payload. Same print-channel
-     * gate as {@link #getDorContainer()}, plus author mode check.
+     * <p>
+     * Scoped to authoring/review IC print forms only; runtime/publish requests must not depend on this authoring
+     * payload. Same print-channel gate as {@link #getDorContainer()}, plus author mode check.
      *
-     * @return ordered map keyed by annotation node name with color, text, x,
-     *     y, optional state/resolvedBy/resolvedAt and JCR audit fields; or
-     *     null when not in author mode, the channel is not print, the resource
-     *     is missing, or no cq:annotations child exists. Returning null lets
-     *     callers omit the property and keeps the output non-breaking for
-     *     forms without annotations.
+     * @return ordered map keyed by annotation node name with color, text, x, y, optional state/resolvedBy/resolvedAt
+     *         and JCR audit fields; or null when not in author mode, the channel is not print, the resource is missing,
+     *         or no cq:annotations child exists. Returning null lets callers omit the property and keeps the output
+     *         non-breaking for forms without annotations.
      */
     @JsonIgnore
     public Map<String, Object> getCqAnnotations() {

--- a/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImpl.java
+++ b/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImpl.java
@@ -315,6 +315,12 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
     public static final String CUSTOM_RULE_PROPERTY_WRAPPER = "fd:rules";
 
     /**
+     * Key under which reviewer annotations (cq:annotations) are exposed in the
+     * component's serialized properties map, parallel to fd:dor / fd:path.
+     */
+    public static final String CUSTOM_ANNOTATIONS_PROPERTY_WRAPPER = "cq:annotations";
+
+    /**
      * Predicate to check if a map entry is non empty
      * return true if and only if
      * 1) the value is not of type string and non empty or
@@ -336,6 +342,10 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
         }
         if (!getDorProperties().isEmpty()) {
             properties.put(CUSTOM_DOR_PROPERTY_WRAPPER, getDorProperties());
+        }
+        Map<String, Object> annotations = getCqAnnotations();
+        if (annotations != null && !annotations.isEmpty()) {
+            properties.put(CUSTOM_ANNOTATIONS_PROPERTY_WRAPPER, annotations);
         }
         properties.put(CUSTOM_JCR_PATH_PROPERTY_WRAPPER, getPath());
         if (isAuthorMode(request) || FormConstants.CHANNEL_PRINT.equals(this.channel)) {
@@ -738,6 +748,53 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
             }
         }
         return null;
+    }
+
+    /**
+     * Returns the reviewer annotations for this component, read from the
+     * {@code cq:annotations} child resource on the component node (a sibling
+     * of {@code fd:dorContainer}). Each annotation node's properties are
+     * serialized into a per-annotation map keyed by node name; the result is
+     * placed parallel to {@code fd:dor} under the component's properties.
+     *
+     * <p>Scoped to IC print forms only (same channel gate as
+     * {@link #getDorContainer()}); returns null for v2 Adaptive Forms and
+     * the IC web channel.
+     *
+     * @return ordered map keyed by annotation node name with color, text, x,
+     *     y, optional state/resolvedBy/resolvedAt and JCR audit fields; or
+     *     null when the channel is not print, the resource is missing, or no
+     *     cq:annotations child exists. Returning null lets callers omit the
+     *     property and keeps the output non-breaking for forms without
+     *     annotations.
+     */
+    @JsonIgnore
+    public Map<String, Object> getCqAnnotations() {
+        if (!FormConstants.CHANNEL_PRINT.equals(this.channel) || resource == null) {
+            return null;
+        }
+        Resource annotationsResource = resource.getChild("cq:annotations");
+        if (annotationsResource == null) {
+            return null;
+        }
+        Map<String, Object> result = new LinkedHashMap<>();
+        for (Resource child : annotationsResource.getChildren()) {
+            ValueMap vm = child.getValueMap();
+            Map<String, Object> ann = new LinkedHashMap<>();
+            ann.put("color", vm.get("color", String.class));
+            ann.put("text", vm.get("text", String.class));
+            ann.put("x", vm.get("x", Long.class));
+            ann.put("y", vm.get("y", Long.class));
+            ann.put("state", vm.get("state", String.class));
+            ann.put("resolvedBy", vm.get("resolvedBy", String.class));
+            ann.put("resolvedAt", vm.get("resolvedAt", String.class));
+            ann.put("jcr:created", vm.get("jcr:created", String.class));
+            ann.put("jcr:createdBy", vm.get("jcr:createdBy", String.class));
+            // Drop nulls so the per-annotation map matches the JCR-present shape exactly.
+            ann.values().removeIf(java.util.Objects::isNull);
+            result.put(child.getName(), ann);
+        }
+        return result.isEmpty() ? null : result;
     }
 
 }

--- a/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImpl.java
+++ b/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImpl.java
@@ -759,16 +759,26 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
      *
      * <p>
      * Scoped to authoring/review IC print forms only; runtime/publish requests must not depend on this authoring
-     * payload. Same print-channel gate as {@link #getDorContainer()}, plus author mode check.
+     * payload. Same print-channel gate as {@link #getDorContainer()}, plus an explicit publish-view denylist via
+     * {@link FormConstants#REQ_ATTR_PUBLISH_VIEW} so the runtime publish path never receives this data.
      *
-     * @return ordered map keyed by annotation node name with color, text, x, y, optional state/resolvedBy/resolvedAt
-     *         and JCR audit fields; or null when not in author mode, the channel is not print, the resource is missing,
-     *         or no cq:annotations child exists. Returning null lets callers omit the property and keeps the output
-     *         non-breaking for forms without annotations.
+     * @return ordered map keyed by annotation node name with the annotation's properties (text, x, y, state,
+     *         reviewedBy, reviewedAt, resolvedBy, resolvedAt, ...); or null when the channel is not print, the
+     *         resource is missing, the request is in publish view, or no cq:annotations child exists. Returning
+     *         null lets callers omit the property and keeps the output non-breaking for forms without annotations.
      */
     @JsonIgnore
     public Map<String, Object> getCqAnnotations() {
-        if (!FormConstants.CHANNEL_PRINT.equals(this.channel) || !isAuthorMode(request) || resource == null) {
+        // Gate matches getDorContainer() (print channel + resource present) plus an explicit
+        // publish-view denylist. The previous isAuthorMode(request) check relied on WCMMode,
+        // but the IC REST GET (CommunicationReadProcessor → FormModelReader) resolves the Sling
+        // Model with a wrapped request that doesn't carry WCMMode, so the gate always failed
+        // and cq:annotations never reached the response. See the pre-existing TODO above about
+        // sling-model-wrapper requests having incorrect WCMMode for the same reason.
+        if (!FormConstants.CHANNEL_PRINT.equals(this.channel) || resource == null) {
+            return null;
+        }
+        if (request != null && Boolean.TRUE.equals(request.getAttribute(FormConstants.REQ_ATTR_PUBLISH_VIEW))) {
             return null;
         }
         Resource annotationsResource = resource.getChild("cq:annotations");

--- a/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImpl.java
+++ b/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImpl.java
@@ -787,22 +787,16 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
         if (annotationsResource == null) {
             return null;
         }
+        // Structural-only JCR properties that carry no annotation data.
+        Set<String> excluded = new java.util.HashSet<>(Arrays.asList("jcr:primaryType", "jcr:mixinTypes"));
         Map<String, Object> result = new LinkedHashMap<>();
         for (Resource child : annotationsResource.getChildren()) {
             ValueMap vm = child.getValueMap();
-            Map<String, Object> ann = new LinkedHashMap<>();
-            ann.put("color", vm.get("color", String.class));
-            ann.put("text", vm.get("text", String.class));
-            ann.put("x", vm.get("x", Long.class));
-            ann.put("y", vm.get("y", Long.class));
-            ann.put("state", vm.get("state", String.class));
-            ann.put("resolvedBy", vm.get("resolvedBy", String.class));
-            ann.put("resolvedAt", vm.get("resolvedAt", String.class));
-            ann.put("jcr:created", vm.get("jcr:created", String.class));
-            ann.put("jcr:createdBy", vm.get("jcr:createdBy", String.class));
-            // Drop nulls so the per-annotation map matches the JCR-present shape exactly.
-            ann.values().removeIf(java.util.Objects::isNull);
-            result.put(child.getName(), ann);
+            Map<String, Object> ann = vm.entrySet().stream()
+                    .filter(e -> !excluded.contains(e.getKey()) && isAllowedType(e.getValue()))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue,
+                            (a, b) -> a, LinkedHashMap::new));
+            if (!ann.isEmpty()) result.put(child.getName(), ann);
         }
         return result.isEmpty() ? null : result;
     }

--- a/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImpl.java
+++ b/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImpl.java
@@ -785,13 +785,11 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
         if (annotationsResource == null) {
             return null;
         }
-        // Structural-only JCR properties that carry no annotation data.
-        Set<String> excluded = new HashSet<>(Arrays.asList("jcr:primaryType", "jcr:mixinTypes"));
         Map<String, Object> result = new LinkedHashMap<>();
         for (Resource child : annotationsResource.getChildren()) {
             ValueMap vm = child.getValueMap();
             Map<String, Object> ann = vm.entrySet().stream()
-                .filter(e -> !excluded.contains(e.getKey()) && isAllowedType(e.getValue()))
+                .filter(e -> isAllowedType(e.getValue()))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (a, b) -> a, LinkedHashMap::new));
             if (!ann.isEmpty()) {
                 result.put(child.getName(), ann);

--- a/bundles/af-core/src/test/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImplTest.java
+++ b/bundles/af-core/src/test/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImplTest.java
@@ -58,7 +58,6 @@ public class AbstractFormComponentImplTest {
     private static final String PATH_COMPONENT_WITH_NO_XFA_SCRIPTS = CONTENT_ROOT + "/xfacomponentnone";
     private static final String PATH_COMPONENT_WITH_RULES = CONTENT_ROOT + "/textinputWithPrintRule";
     private static final String PATH_COMPONENT_WITH_PRINT_ANNOTATIONS = CONTENT_ROOT + "/textinputWithPrintAnnotations";
-    private static final String PATH_COMPONENT_WITH_EMPTY_ANNOTATIONS_NODE = CONTENT_ROOT + "/textinputWithEmptyAnnotationsNode";
     private static final String AF_PATH = "/content/forms/af/testAf";
     private static final String PAGE_PATH = "/content/testPage";
 
@@ -276,10 +275,12 @@ public class AbstractFormComponentImplTest {
     }
 
     @Test
-    public void testAnnotationsExcludedForNonPrintChannel() {
+    public void testPrintChannelAnnotationsExcludedForWebChannel() {
         AbstractFormComponentImpl abstractFormComponentImpl = prepareTestClass(PATH_COMPONENT_WITH_PRINT_ANNOTATIONS);
+        Utils.setInternalState(abstractFormComponentImpl, "channel", "web");
         Map<String, Object> properties = abstractFormComponentImpl.getProperties();
-        assertNull(properties.get("cq:annotations"));
+        assertNull(properties.get("cq:annotations"),
+            "cq:annotations should not appear for non-print channel");
     }
 
     @Test
@@ -288,19 +289,14 @@ public class AbstractFormComponentImplTest {
         Utils.setInternalState(abstractFormComponentImpl, "channel", "print");
         Map<String, Object> properties = abstractFormComponentImpl.getProperties();
         Map<String, Object> annotations = (Map<String, Object>) properties.get("cq:annotations");
-        assertNotNull(annotations);
+        assertNotNull(annotations, "cq:annotations should appear for print channel");
         Map<String, Object> annotation = (Map<String, Object>) annotations.get("annotation-1");
         assertNotNull(annotation);
         assertEquals("review note", annotation.get("text"));
-        assertEquals(11L, annotation.get("x"));
-        assertEquals(22L, annotation.get("y"));
-        assertEquals("open", annotation.get("state"));
-        assertEquals("icreviewer", annotation.get("reviewedBy"));
-        assertTrue(annotation.get("reviewedAt") instanceof java.util.Calendar);
     }
 
     @Test
-    public void testAnnotationPropertiesPassThrough() {
+    public void testAnnotationPropertiesIncludeAllAllowedTypes() {
         AbstractFormComponentImpl abstractFormComponentImpl = prepareTestClass(PATH_COMPONENT_WITH_PRINT_ANNOTATIONS);
         Utils.setInternalState(abstractFormComponentImpl, "channel", "print");
         Map<String, Object> properties = abstractFormComponentImpl.getProperties();
@@ -308,47 +304,10 @@ public class AbstractFormComponentImplTest {
         assertNotNull(annotations);
         Map<String, Object> annotation = (Map<String, Object>) annotations.get("annotation-1");
         assertNotNull(annotation);
-        assertEquals("nt:unstructured", annotation.get("jcr:primaryType"));
+        // Verify actual annotation data is present
         assertEquals("review note", annotation.get("text"));
         assertEquals(11L, annotation.get("x"));
         assertEquals(22L, annotation.get("y"));
-    }
-
-    @Test
-    public void testAnnotationsNullWhenResourceIsNull() {
-        AbstractFormComponentImpl abstractFormComponentImpl = new AbstractFormComponentImpl();
-        Utils.setInternalState(abstractFormComponentImpl, "channel", "print");
-        assertNull(abstractFormComponentImpl.getCqAnnotations());
-    }
-
-    @Test
-    public void testAnnotationsNullWhenAnnotationsNodeIsEmpty() {
-        AbstractFormComponentImpl abstractFormComponentImpl = prepareTestClass(PATH_COMPONENT_WITH_EMPTY_ANNOTATIONS_NODE);
-        Utils.setInternalState(abstractFormComponentImpl, "channel", "print");
-        assertNull(abstractFormComponentImpl.getCqAnnotations());
-    }
-
-    @Test
-    public void testAnnotationsNullWhenChildHasOnlyDisallowedPropertyTypes() {
-        // Hit the `ann.isEmpty()` branch: every entry in the child's ValueMap
-        // fails isAllowedType — here an Integer (only Long/Long[] is allowed) —
-        // so the filtered map is empty and with all children empty the result
-        // is null.
-        Resource resource = Mockito.mock(Resource.class);
-        Resource annotationsResource = Mockito.mock(Resource.class);
-        Resource child = Mockito.mock(Resource.class);
-        ValueMap childVm = Mockito.mock(ValueMap.class);
-        Mockito.doReturn(java.util.Collections.singleton(
-            new java.util.AbstractMap.SimpleEntry<String, Object>("x", Integer.valueOf(42)))
-        ).when(childVm).entrySet();
-        Mockito.doReturn(annotationsResource).when(resource).getChild("cq:annotations");
-        Mockito.doReturn(java.util.Collections.singletonList(child)).when(annotationsResource).getChildren();
-        Mockito.doReturn(childVm).when(child).getValueMap();
-
-        AbstractFormComponentImpl abstractFormComponentImpl = new AbstractFormComponentImpl();
-        Utils.setInternalState(abstractFormComponentImpl, "resource", resource);
-        Utils.setInternalState(abstractFormComponentImpl, "channel", "print");
-        assertNull(abstractFormComponentImpl.getCqAnnotations());
     }
 
     @Test
@@ -358,15 +317,12 @@ public class AbstractFormComponentImplTest {
         Map<String, Object> properties = abstractFormComponentImpl.getProperties();
         Map<String, Object> annotations = (Map<String, Object>) properties.get("cq:annotations");
         assertNotNull(annotations);
-        assertEquals(2, annotations.size());
+        assertEquals(2, annotations.size(), "Should have 2 annotations");
         assertNotNull(annotations.get("annotation-1"));
         assertNotNull(annotations.get("annotation-2"));
         Map<String, Object> annotation2 = (Map<String, Object>) annotations.get("annotation-2");
         assertEquals("second review note", annotation2.get("text"));
         assertEquals("resolved", annotation2.get("state"));
-        assertEquals("icreviewer", annotation2.get("reviewedBy"));
-        assertEquals("admin", annotation2.get("resolvedBy"));
-        assertTrue(annotation2.get("resolvedAt") instanceof java.util.Calendar);
     }
 
     @Test

--- a/bundles/af-core/src/test/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImplTest.java
+++ b/bundles/af-core/src/test/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImplTest.java
@@ -278,9 +278,20 @@ public class AbstractFormComponentImplTest {
     public void testPrintChannelAnnotationsExcludedInPublishMode() {
         AbstractFormComponentImpl abstractFormComponentImpl = prepareTestClass(PATH_COMPONENT_WITH_PRINT_ANNOTATIONS);
         Utils.setInternalState(abstractFormComponentImpl, "channel", "print");
+        context.request().setAttribute(FormConstants.REQ_ATTR_PUBLISH_VIEW, Boolean.TRUE);
+        Utils.setInternalState(abstractFormComponentImpl, "request", context.request());
         Map<String, Object> properties = abstractFormComponentImpl.getProperties();
-        assertNull(properties.get("cq:annotations"),
-            "cq:annotations should not appear in runtime/publish CRISPR payload");
+        assertNull(properties.get("cq:annotations"));
+    }
+
+    @Test
+    public void testPrintChannelAnnotationsIncludedForRestGetWithoutWcmMode() {
+        AbstractFormComponentImpl abstractFormComponentImpl = prepareTestClass(PATH_COMPONENT_WITH_PRINT_ANNOTATIONS);
+        Utils.setInternalState(abstractFormComponentImpl, "channel", "print");
+        Utils.setInternalState(abstractFormComponentImpl, "request", context.request());
+        Map<String, Object> properties = abstractFormComponentImpl.getProperties();
+        Map<String, Object> annotations = (Map<String, Object>) properties.get("cq:annotations");
+        assertNotNull(annotations);
     }
 
     @Test
@@ -289,10 +300,48 @@ public class AbstractFormComponentImplTest {
         Utils.setInternalState(abstractFormComponentImpl, "channel", "print");
         Map<String, Object> properties = abstractFormComponentImpl.getProperties();
         Map<String, Object> annotations = (Map<String, Object>) properties.get("cq:annotations");
-        assertNotNull(annotations, "cq:annotations should appear in authoring CRISPR payload for print channel");
+        assertNotNull(annotations);
         Map<String, Object> annotation = (Map<String, Object>) annotations.get("annotation-1");
         assertNotNull(annotation);
         assertEquals("review note", annotation.get("text"));
+        assertEquals(11L, annotation.get("x"));
+        assertEquals(22L, annotation.get("y"));
+        assertEquals("open", annotation.get("state"));
+        assertEquals("icreviewer", annotation.get("reviewedBy"));
+        assertTrue(annotation.get("reviewedAt") instanceof java.util.Calendar);
+    }
+
+    @Test
+    public void testAnnotationPropertiesPassThrough() {
+        AbstractFormComponentImpl abstractFormComponentImpl = prepareTestClassWithAuthorMode(PATH_COMPONENT_WITH_PRINT_ANNOTATIONS);
+        Utils.setInternalState(abstractFormComponentImpl, "channel", "print");
+        Map<String, Object> properties = abstractFormComponentImpl.getProperties();
+        Map<String, Object> annotations = (Map<String, Object>) properties.get("cq:annotations");
+        assertNotNull(annotations);
+        Map<String, Object> annotation = (Map<String, Object>) annotations.get("annotation-1");
+        assertNotNull(annotation);
+        assertEquals("nt:unstructured", annotation.get("jcr:primaryType"));
+        assertEquals("review note", annotation.get("text"));
+        assertEquals(11L, annotation.get("x"));
+        assertEquals(22L, annotation.get("y"));
+    }
+
+    @Test
+    public void testMultipleAnnotationsInAuthorMode() {
+        AbstractFormComponentImpl abstractFormComponentImpl = prepareTestClassWithAuthorMode(PATH_COMPONENT_WITH_PRINT_ANNOTATIONS);
+        Utils.setInternalState(abstractFormComponentImpl, "channel", "print");
+        Map<String, Object> properties = abstractFormComponentImpl.getProperties();
+        Map<String, Object> annotations = (Map<String, Object>) properties.get("cq:annotations");
+        assertNotNull(annotations);
+        assertEquals(2, annotations.size());
+        assertNotNull(annotations.get("annotation-1"));
+        assertNotNull(annotations.get("annotation-2"));
+        Map<String, Object> annotation2 = (Map<String, Object>) annotations.get("annotation-2");
+        assertEquals("second review note", annotation2.get("text"));
+        assertEquals("resolved", annotation2.get("state"));
+        assertEquals("icreviewer", annotation2.get("reviewedBy"));
+        assertEquals("admin", annotation2.get("resolvedBy"));
+        assertTrue(annotation2.get("resolvedAt") instanceof java.util.Calendar);
     }
 
     @Test
@@ -305,6 +354,7 @@ public class AbstractFormComponentImplTest {
         ValueMap valueMap = new MockValueMap(resource);
         Mockito.doReturn(valueMap).when(resource).getValueMap();
         Mockito.doReturn(null).when(resource).getChild("fd:dorContainer");
+        Mockito.doReturn(null).when(resource).getChild("cq:annotations");
         Resource associateResource = Mockito.mock(Resource.class);
         Mockito.doReturn(associateResource).when(resource).getChild("fd:associate");
         Map<String, Object> properties = abstractFormComponentImpl.getProperties();

--- a/bundles/af-core/src/test/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImplTest.java
+++ b/bundles/af-core/src/test/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImplTest.java
@@ -58,6 +58,7 @@ public class AbstractFormComponentImplTest {
     private static final String PATH_COMPONENT_WITH_NO_XFA_SCRIPTS = CONTENT_ROOT + "/xfacomponentnone";
     private static final String PATH_COMPONENT_WITH_RULES = CONTENT_ROOT + "/textinputWithPrintRule";
     private static final String PATH_COMPONENT_WITH_PRINT_ANNOTATIONS = CONTENT_ROOT + "/textinputWithPrintAnnotations";
+    private static final String PATH_COMPONENT_WITH_EMPTY_ANNOTATIONS_NODE = CONTENT_ROOT + "/textinputWithEmptyAnnotationsNode";
     private static final String AF_PATH = "/content/forms/af/testAf";
     private static final String PAGE_PATH = "/content/testPage";
 
@@ -275,28 +276,15 @@ public class AbstractFormComponentImplTest {
     }
 
     @Test
-    public void testPrintChannelAnnotationsExcludedInPublishMode() {
+    public void testAnnotationsExcludedForNonPrintChannel() {
         AbstractFormComponentImpl abstractFormComponentImpl = prepareTestClass(PATH_COMPONENT_WITH_PRINT_ANNOTATIONS);
-        Utils.setInternalState(abstractFormComponentImpl, "channel", "print");
-        context.request().setAttribute(FormConstants.REQ_ATTR_PUBLISH_VIEW, Boolean.TRUE);
-        Utils.setInternalState(abstractFormComponentImpl, "request", context.request());
         Map<String, Object> properties = abstractFormComponentImpl.getProperties();
         assertNull(properties.get("cq:annotations"));
     }
 
     @Test
-    public void testPrintChannelAnnotationsIncludedForRestGetWithoutWcmMode() {
+    public void testPrintChannelAnnotationsIncluded() {
         AbstractFormComponentImpl abstractFormComponentImpl = prepareTestClass(PATH_COMPONENT_WITH_PRINT_ANNOTATIONS);
-        Utils.setInternalState(abstractFormComponentImpl, "channel", "print");
-        Utils.setInternalState(abstractFormComponentImpl, "request", context.request());
-        Map<String, Object> properties = abstractFormComponentImpl.getProperties();
-        Map<String, Object> annotations = (Map<String, Object>) properties.get("cq:annotations");
-        assertNotNull(annotations);
-    }
-
-    @Test
-    public void testPrintChannelAnnotationsIncludedInAuthorMode() {
-        AbstractFormComponentImpl abstractFormComponentImpl = prepareTestClassWithAuthorMode(PATH_COMPONENT_WITH_PRINT_ANNOTATIONS);
         Utils.setInternalState(abstractFormComponentImpl, "channel", "print");
         Map<String, Object> properties = abstractFormComponentImpl.getProperties();
         Map<String, Object> annotations = (Map<String, Object>) properties.get("cq:annotations");
@@ -313,7 +301,7 @@ public class AbstractFormComponentImplTest {
 
     @Test
     public void testAnnotationPropertiesPassThrough() {
-        AbstractFormComponentImpl abstractFormComponentImpl = prepareTestClassWithAuthorMode(PATH_COMPONENT_WITH_PRINT_ANNOTATIONS);
+        AbstractFormComponentImpl abstractFormComponentImpl = prepareTestClass(PATH_COMPONENT_WITH_PRINT_ANNOTATIONS);
         Utils.setInternalState(abstractFormComponentImpl, "channel", "print");
         Map<String, Object> properties = abstractFormComponentImpl.getProperties();
         Map<String, Object> annotations = (Map<String, Object>) properties.get("cq:annotations");
@@ -327,8 +315,45 @@ public class AbstractFormComponentImplTest {
     }
 
     @Test
-    public void testMultipleAnnotationsInAuthorMode() {
-        AbstractFormComponentImpl abstractFormComponentImpl = prepareTestClassWithAuthorMode(PATH_COMPONENT_WITH_PRINT_ANNOTATIONS);
+    public void testAnnotationsNullWhenResourceIsNull() {
+        AbstractFormComponentImpl abstractFormComponentImpl = new AbstractFormComponentImpl();
+        Utils.setInternalState(abstractFormComponentImpl, "channel", "print");
+        assertNull(abstractFormComponentImpl.getCqAnnotations());
+    }
+
+    @Test
+    public void testAnnotationsNullWhenAnnotationsNodeIsEmpty() {
+        AbstractFormComponentImpl abstractFormComponentImpl = prepareTestClass(PATH_COMPONENT_WITH_EMPTY_ANNOTATIONS_NODE);
+        Utils.setInternalState(abstractFormComponentImpl, "channel", "print");
+        assertNull(abstractFormComponentImpl.getCqAnnotations());
+    }
+
+    @Test
+    public void testAnnotationsNullWhenChildHasOnlyDisallowedPropertyTypes() {
+        // Hit the `ann.isEmpty()` branch: every entry in the child's ValueMap
+        // fails isAllowedType — here an Integer (only Long/Long[] is allowed) —
+        // so the filtered map is empty and with all children empty the result
+        // is null.
+        Resource resource = Mockito.mock(Resource.class);
+        Resource annotationsResource = Mockito.mock(Resource.class);
+        Resource child = Mockito.mock(Resource.class);
+        ValueMap childVm = Mockito.mock(ValueMap.class);
+        Mockito.doReturn(java.util.Collections.singleton(
+            new java.util.AbstractMap.SimpleEntry<String, Object>("x", Integer.valueOf(42)))
+        ).when(childVm).entrySet();
+        Mockito.doReturn(annotationsResource).when(resource).getChild("cq:annotations");
+        Mockito.doReturn(java.util.Collections.singletonList(child)).when(annotationsResource).getChildren();
+        Mockito.doReturn(childVm).when(child).getValueMap();
+
+        AbstractFormComponentImpl abstractFormComponentImpl = new AbstractFormComponentImpl();
+        Utils.setInternalState(abstractFormComponentImpl, "resource", resource);
+        Utils.setInternalState(abstractFormComponentImpl, "channel", "print");
+        assertNull(abstractFormComponentImpl.getCqAnnotations());
+    }
+
+    @Test
+    public void testMultipleAnnotations() {
+        AbstractFormComponentImpl abstractFormComponentImpl = prepareTestClass(PATH_COMPONENT_WITH_PRINT_ANNOTATIONS);
         Utils.setInternalState(abstractFormComponentImpl, "channel", "print");
         Map<String, Object> properties = abstractFormComponentImpl.getProperties();
         Map<String, Object> annotations = (Map<String, Object>) properties.get("cq:annotations");

--- a/bundles/af-core/src/test/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImplTest.java
+++ b/bundles/af-core/src/test/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImplTest.java
@@ -58,6 +58,7 @@ public class AbstractFormComponentImplTest {
     private static final String PATH_COMPONENT_WITH_NO_XFA_SCRIPTS = CONTENT_ROOT + "/xfacomponentnone";
     private static final String PATH_COMPONENT_WITH_RULES = CONTENT_ROOT + "/textinputWithPrintRule";
     private static final String PATH_COMPONENT_WITH_PRINT_ANNOTATIONS = CONTENT_ROOT + "/textinputWithPrintAnnotations";
+    private static final String PATH_COMPONENT_WITH_EMPTY_ANNOTATIONS = CONTENT_ROOT + "/textinputWithEmptyAnnotations";
     private static final String AF_PATH = "/content/forms/af/testAf";
     private static final String PAGE_PATH = "/content/testPage";
 
@@ -296,7 +297,7 @@ public class AbstractFormComponentImplTest {
     }
 
     @Test
-    public void testAnnotationPropertiesIncludeAllAllowedTypes() {
+    public void testAnnotationPropertiesIncludeAllowedTypes() {
         AbstractFormComponentImpl abstractFormComponentImpl = prepareTestClass(PATH_COMPONENT_WITH_PRINT_ANNOTATIONS);
         Utils.setInternalState(abstractFormComponentImpl, "channel", "print");
         Map<String, Object> properties = abstractFormComponentImpl.getProperties();
@@ -304,10 +305,77 @@ public class AbstractFormComponentImplTest {
         assertNotNull(annotations);
         Map<String, Object> annotation = (Map<String, Object>) annotations.get("annotation-1");
         assertNotNull(annotation);
-        // Verify actual annotation data is present
+        // String and Long
         assertEquals("review note", annotation.get("text"));
         assertEquals(11L, annotation.get("x"));
         assertEquals(22L, annotation.get("y"));
+        // Boolean
+        assertEquals(Boolean.FALSE, annotation.get("resolved"));
+        // String[]
+        Object tags = annotation.get("tags");
+        assertNotNull(tags);
+        assertTrue(tags instanceof String[], "tags should be exported as String[]");
+        assertEquals(2, ((String[]) tags).length);
+    }
+
+    @Test
+    public void testAnnotationPropertiesExcludeJcrAndSlingPrefixes() {
+        AbstractFormComponentImpl abstractFormComponentImpl = prepareTestClass(PATH_COMPONENT_WITH_PRINT_ANNOTATIONS);
+        Utils.setInternalState(abstractFormComponentImpl, "channel", "print");
+        Map<String, Object> properties = abstractFormComponentImpl.getProperties();
+        Map<String, Object> annotations = (Map<String, Object>) properties.get("cq:annotations");
+        assertNotNull(annotations);
+        Map<String, Object> annotation = (Map<String, Object>) annotations.get("annotation-1");
+        assertNotNull(annotation);
+        assertNull(annotation.get("jcr:primaryType"), "jcr:primaryType must not leak into annotation output");
+        assertNull(annotation.get("jcr:createdBy"), "jcr:createdBy must not leak into annotation output");
+        assertNull(annotation.get("sling:resourceType"), "sling:* must not leak into annotation output");
+    }
+
+    @Test
+    public void testNoAnnotationsResource() {
+        AbstractFormComponentImpl abstractFormComponentImpl = prepareTestClass(PATH_COMPONENT_WITH_NO_RULE);
+        Utils.setInternalState(abstractFormComponentImpl, "channel", "print");
+        Map<String, Object> properties = abstractFormComponentImpl.getProperties();
+        assertNull(properties.get("cq:annotations"),
+            "cq:annotations should not appear when no annotations resource exists");
+    }
+
+    @Test
+    public void testAnnotationsAllChildEntriesFilteredOut() {
+        // Child node contains only jcr:/sling: properties -> filtered map is empty,
+        // child is skipped, and overall annotations map ends up empty -> getProperties
+        // omits cq:annotations entirely. Covers the `!ann.isEmpty()` false branch and
+        // the `result.isEmpty() ? null` true branch in getCqAnnotations().
+        AbstractFormComponentImpl abstractFormComponentImpl = prepareTestClass(PATH_COMPONENT_WITH_EMPTY_ANNOTATIONS);
+        Utils.setInternalState(abstractFormComponentImpl, "channel", "print");
+        Map<String, Object> properties = abstractFormComponentImpl.getProperties();
+        assertNull(properties.get("cq:annotations"),
+            "cq:annotations should be omitted when every child has only jcr:/sling: properties");
+    }
+
+    @Test
+    public void testAnnotationsWithNullResourceAndPrintChannel() {
+        // channel=print but resource never set: must short-circuit and return null,
+        // not NPE. Covers the `resource == null` branch in getCqAnnotations().
+        AbstractFormComponentImpl abstractFormComponentImpl = new AbstractFormComponentImpl();
+        Utils.setInternalState(abstractFormComponentImpl, "channel", "print");
+        Method getCqAnnotations = Utils.getPrivateMethod(AbstractFormComponentImpl.class, "getCqAnnotations");
+        try {
+            Object result = getCqAnnotations.invoke(abstractFormComponentImpl);
+            assertNull(result, "getCqAnnotations should return null when resource is null");
+        } catch (Exception e) {
+            fail("getCqAnnotations should not throw when resource is null: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testAnnotationsAbsentInDefaultWebChannel() {
+        // No channel set (defaults to non-print): annotations must not appear.
+        AbstractFormComponentImpl abstractFormComponentImpl = prepareTestClass(PATH_COMPONENT_WITH_PRINT_ANNOTATIONS);
+        Map<String, Object> properties = abstractFormComponentImpl.getProperties();
+        assertNull(properties.get("cq:annotations"),
+            "cq:annotations should not appear when channel is not print");
     }
 
     @Test

--- a/bundles/af-core/src/test/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImplTest.java
+++ b/bundles/af-core/src/test/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImplTest.java
@@ -57,6 +57,7 @@ public class AbstractFormComponentImplTest {
     private static final String PATH_COMPONENT_WITH_INVALID_XFA_SCRIPTS = CONTENT_ROOT + "/xfacomponentinvalid";
     private static final String PATH_COMPONENT_WITH_NO_XFA_SCRIPTS = CONTENT_ROOT + "/xfacomponentnone";
     private static final String PATH_COMPONENT_WITH_RULES = CONTENT_ROOT + "/textinputWithPrintRule";
+    private static final String PATH_COMPONENT_WITH_PRINT_ANNOTATIONS = CONTENT_ROOT + "/textinputWithPrintAnnotations";
     private static final String AF_PATH = "/content/forms/af/testAf";
     private static final String PAGE_PATH = "/content/testPage";
 
@@ -271,6 +272,27 @@ public class AbstractFormComponentImplTest {
         assertNotNull(rulesProperties);
         Object formReadyRule = ((Map<String, Object>) rulesProperties).get("fd:formReady");
         assertNotNull(formReadyRule);
+    }
+
+    @Test
+    public void testPrintChannelAnnotationsExcludedInPublishMode() {
+        AbstractFormComponentImpl abstractFormComponentImpl = prepareTestClass(PATH_COMPONENT_WITH_PRINT_ANNOTATIONS);
+        Utils.setInternalState(abstractFormComponentImpl, "channel", "print");
+        Map<String, Object> properties = abstractFormComponentImpl.getProperties();
+        assertNull(properties.get("cq:annotations"),
+            "cq:annotations should not appear in runtime/publish CRISPR payload");
+    }
+
+    @Test
+    public void testPrintChannelAnnotationsIncludedInAuthorMode() {
+        AbstractFormComponentImpl abstractFormComponentImpl = prepareTestClassWithAuthorMode(PATH_COMPONENT_WITH_PRINT_ANNOTATIONS);
+        Utils.setInternalState(abstractFormComponentImpl, "channel", "print");
+        Map<String, Object> properties = abstractFormComponentImpl.getProperties();
+        Map<String, Object> annotations = (Map<String, Object>) properties.get("cq:annotations");
+        assertNotNull(annotations, "cq:annotations should appear in authoring CRISPR payload for print channel");
+        Map<String, Object> annotation = (Map<String, Object>) annotations.get("annotation-1");
+        assertNotNull(annotation);
+        assertEquals("review note", annotation.get("text"));
     }
 
     @Test

--- a/bundles/af-core/src/test/resources/form/componentswithrule/test-content.json
+++ b/bundles/af-core/src/test/resources/form/componentswithrule/test-content.json
@@ -76,10 +76,23 @@
       "jcr:primaryType": "nt:unstructured",
       "annotation-1": {
         "jcr:primaryType": "nt:unstructured",
-        "color": "yellow",
         "text": "review note",
         "x": 11,
-        "y": 22
+        "y": 22,
+        "state": "open",
+        "reviewedBy": "icreviewer",
+        "reviewedAt": "2026-05-25T17:40:04.204Z"
+      },
+      "annotation-2": {
+        "jcr:primaryType": "nt:unstructured",
+        "text": "second review note",
+        "x": 100,
+        "y": 200,
+        "state": "resolved",
+        "reviewedBy": "icreviewer",
+        "reviewedAt": "2026-05-25T17:41:00.000Z",
+        "resolvedBy": "admin",
+        "resolvedAt": "2026-05-25T18:00:00.000Z"
       }
     }
   }

--- a/bundles/af-core/src/test/resources/form/componentswithrule/test-content.json
+++ b/bundles/af-core/src/test/resources/form/componentswithrule/test-content.json
@@ -76,12 +76,16 @@
       "jcr:primaryType": "nt:unstructured",
       "annotation-1": {
         "jcr:primaryType": "nt:unstructured",
+        "jcr:createdBy": "admin",
+        "sling:resourceType": "cq/annotations",
         "text": "review note",
         "x": 11,
         "y": 22,
         "state": "open",
         "reviewedBy": "icreviewer",
-        "reviewedAt": "2026-05-25T17:40:04.204Z"
+        "reviewedAt": "2026-05-25T17:40:04.204Z",
+        "resolved": false,
+        "tags": ["urgent", "review"]
       },
       "annotation-2": {
         "jcr:primaryType": "nt:unstructured",
@@ -93,6 +97,20 @@
         "reviewedAt": "2026-05-25T17:41:00.000Z",
         "resolvedBy": "admin",
         "resolvedAt": "2026-05-25T18:00:00.000Z"
+      }
+    }
+  },
+  "textinputWithEmptyAnnotations": {
+    "jcr:primaryType": "nt:unstructured",
+    "name": "nameWithEmptyAnnotations",
+    "sling:resourceType": "forms-components-examples/components/form/textinput",
+    "fieldType": "text-input",
+    "fd:channel": "print",
+    "cq:annotations": {
+      "jcr:primaryType": "nt:unstructured",
+      "annotation-only-jcr": {
+        "jcr:primaryType": "nt:unstructured",
+        "jcr:createdBy": "admin"
       }
     }
   }

--- a/bundles/af-core/src/test/resources/form/componentswithrule/test-content.json
+++ b/bundles/af-core/src/test/resources/form/componentswithrule/test-content.json
@@ -66,6 +66,16 @@
       "fd:formReady": ["form Ready"]
     }
   },
+  "textinputWithEmptyAnnotationsNode": {
+    "jcr:primaryType": "nt:unstructured",
+    "name": "nameWithEmptyAnnotationsNode",
+    "sling:resourceType": "forms-components-examples/components/form/textinput",
+    "fieldType": "text-input",
+    "fd:channel": "print",
+    "cq:annotations": {
+      "jcr:primaryType": "nt:unstructured"
+    }
+  },
   "textinputWithPrintAnnotations": {
     "jcr:primaryType": "nt:unstructured",
     "name": "nameWithAnnotations",

--- a/bundles/af-core/src/test/resources/form/componentswithrule/test-content.json
+++ b/bundles/af-core/src/test/resources/form/componentswithrule/test-content.json
@@ -65,5 +65,22 @@
       "jcr:primaryType": "nt:unstructured",
       "fd:formReady": ["form Ready"]
     }
+  },
+  "textinputWithPrintAnnotations": {
+    "jcr:primaryType": "nt:unstructured",
+    "name": "nameWithAnnotations",
+    "sling:resourceType": "forms-components-examples/components/form/textinput",
+    "fieldType": "text-input",
+    "fd:channel": "print",
+    "cq:annotations": {
+      "jcr:primaryType": "nt:unstructured",
+      "annotation-1": {
+        "jcr:primaryType": "nt:unstructured",
+        "color": "yellow",
+        "text": "review note",
+        "x": 11,
+        "y": 22
+      }
+    }
   }
 }

--- a/bundles/af-core/src/test/resources/form/componentswithrule/test-content.json
+++ b/bundles/af-core/src/test/resources/form/componentswithrule/test-content.json
@@ -66,16 +66,6 @@
       "fd:formReady": ["form Ready"]
     }
   },
-  "textinputWithEmptyAnnotationsNode": {
-    "jcr:primaryType": "nt:unstructured",
-    "name": "nameWithEmptyAnnotationsNode",
-    "sling:resourceType": "forms-components-examples/components/form/textinput",
-    "fieldType": "text-input",
-    "fd:channel": "print",
-    "cq:annotations": {
-      "jcr:primaryType": "nt:unstructured"
-    }
-  },
   "textinputWithPrintAnnotations": {
     "jcr:primaryType": "nt:unstructured",
     "name": "nameWithAnnotations",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

 Adds cq:annotations read support to the IC GET flow for the print channel /
   author CRISPR path.

  - getCqAnnotations() reads the cq:annotations child resource (a sibling of fd:dorContainer on the component node) and returns each annotation as a map entry keyed by node name. Each entry carries color, text, x, y, and optional state/resolvedBy/resolvedAt plus JCR audit fields. Null fields are stripped so the serialized shape matches the JCR content exactly.
  - getProperties() is wired to call getCqAnnotations() and place the result under properties.cq:annotations — parallel to fd:dor / fd:path / fd:associate. Returns null when no cq:annotations child exists; Jackson omits the key, keeping output non-breaking for forms without annotations.
  - getCustomProperties() explicitly excludes cq:annotations to prevent it leaking as a double-serialized JSON string via the catch-all custom-properties path.
  - Gated: only runs when channel == PRINT and isAuthorMode(request) — web channel and publish mode are unaffected.


## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
