### PR TITLE
fix(checkbox): guard against null uncheckedValue when JCR property is absent

### DIFF
--- a/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/util/AbstractCheckboxImpl.java
+++ b/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/util/AbstractCheckboxImpl.java
@@ -46,7 +46,11 @@ public abstract class AbstractCheckboxImpl extends AbstractOptionsFieldImpl {
             checkedValue = String.valueOf(getEnums()[0]);
             uncheckedValue = getEnums().length > 1 ? String.valueOf(getEnums()[1]) : null;
         }
-        enums = (checkedValue != null) ? (Boolean.TRUE.equals(enableUncheckedValue)) ? new String[] { checkedValue, uncheckedValue }
+        // Guard against null uncheckedValue: when enableUncheckedValue is true the JCR property
+        // may be absent (e.g. because the push mechanism skipped an empty-string value), which
+        // would put null into the enum array and crash the runtime on .toString() at init time.
+        String safeUncheckedValue = uncheckedValue != null ? uncheckedValue : "";
+        enums = (checkedValue != null) ? (Boolean.TRUE.equals(enableUncheckedValue)) ? new String[] { checkedValue, safeUncheckedValue }
             : new String[] { checkedValue } : null;
     }
 

--- a/bundles/af-core/src/test/java/com/adobe/cq/forms/core/components/internal/models/v1/form/CheckBoxImplTest.java
+++ b/bundles/af-core/src/test/java/com/adobe/cq/forms/core/components/internal/models/v1/form/CheckBoxImplTest.java
@@ -58,6 +58,7 @@ public class CheckBoxImplTest {
 
     private static final String PATH_CHECKBOX_ENABLEUNCHECKEDOFF = CONTENT_ROOT + "/checkbox-enableUncheckedValueFalse";
     private static final String PATH_CHECKBOX_WITHOUT_FIELDTYPE = CONTENT_ROOT + "/checkbox-without-fieldtype";
+    private static final String PATH_CHECKBOX_ENABLEUNCHECKED_MISSING = CONTENT_ROOT + "/checkbox-enableUncheckedValueMissingFromJcr";
     private final AemContext context = FormsCoreComponentTestContext.newAemContext();
 
     @BeforeEach
@@ -348,6 +349,15 @@ public class CheckBoxImplTest {
     void shouldOnlyHaveOnEnumIfEnableUncheckedValueOff() {
         CheckBox checkbox = getCheckBoxUnderTest(PATH_CHECKBOX_ENABLEUNCHECKEDOFF);
         assertArrayEquals(new String[] { "on" }, checkbox.getEnums());
+    }
+
+    @Test
+    void shouldUseEmptyStringWhenUncheckedValueMissingFromJcr() {
+        // Regression: when enableUncheckedValue=true but the uncheckedValue JCR property is absent
+        // (e.g. because the content push mechanism skipped an empty-string value), the enum array
+        // must not contain null — null.toString() in the AFB runtime crashes the form at init time.
+        CheckBox checkbox = getCheckBoxUnderTest(PATH_CHECKBOX_ENABLEUNCHECKED_MISSING);
+        assertArrayEquals(new String[] { ".", "" }, checkbox.getEnums());
     }
 
     private CheckBox getCheckBoxUnderTest(String resourcePath) {

--- a/bundles/af-core/src/test/resources/form/checkbox/test-content.json
+++ b/bundles/af-core/src/test/resources/form/checkbox/test-content.json
@@ -94,6 +94,16 @@
       "jcr:primaryType": "nt:unstructured"
     }
   },
+  "checkbox-enableUncheckedValueMissingFromJcr" : {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType"    : "core/fd/components/form/checkbox/v1/checkbox",
+    "name" : "abc",
+    "jcr:title" : "def",
+    "type" : "string",
+    "checkedValue":  ".",
+    "enableUncheckedValue": true,
+    "fieldType": "checkbox"
+  },
   "checkbox-without-fieldtype" : {
     "id": "checkbox-wo-fieldtype1",
     "jcr:primaryType": "nt:unstructured",


### PR DESCRIPTION
## Summary

- **Root cause**: When `enableUncheckedValue=true` and `uncheckedValue` is empty string, content push mechanisms omit empty-string properties when writing to JCR. The property is absent, so `@ValueMapValue(OPTIONAL)` injects `null`. `AbstractCheckboxImpl.initBaseCheckboxModel()` builds `enum: [".", null]`.
- **Crash**: AFB runtime calls `.toString()` on every enum value at init — `null.toString()` throws `TypeError` in `createFormInstance` / `RuleEngineWorker`, crashing the form before any screen renders.
- **Fix**: Default `uncheckedValue` to `""` when the JCR property is absent.
- **Test**: Fixture `checkbox-enableUncheckedValueMissingFromJcr` omits `uncheckedValue` from JCR; asserts `getEnums()` returns `[".", ""]` not `[".", null]`.

## Why af-form-json-converter did not catch this

The converter loads form JSON via `context.load().json()` into a mock JCR (HashMap-backed). The mock stores the literal empty string and returns it to the Sling model. Real AEM never receives that empty string because the push pipeline drops empty-string properties — so the property is absent and `uncheckedValue` is injected as `null`.

## Test plan
- [x] `CheckBoxImplTest#shouldUseEmptyStringWhenUncheckedValueMissingFromJcr` passes
- [x] All 35 existing `CheckBoxImplTest` tests still pass
- [ ] Verify on HDFC env after bumping core components version

Generated with [Claude Code](https://claude.com/claude-code)