### PR TITLE
chore(skill): close create-core-component gaps surfaced by Date Input

### DIFF
--- a/.claude/skills/create-core-component/SKILL.md
+++ b/.claude/skills/create-core-component/SKILL.md
@@ -78,41 +78,54 @@ Read `references/templates.md` for the full template set. Read `references/compo
    - Label container with label + question mark
    - Widget area (component-specific)
    - Short description, long description, error message sections
+   - Wrap any **hard-coded default UI text** (e.g. fallback sub-labels) with `@ i18n`
+   - **Composite widgets**: put `name` only on the **hidden combined input**, never on the visible sub-inputs (avoids stray submitted params); find sub-inputs in JS by class
+   - Any **BEM modifier class** you emit (e.g. `--hidden`) MUST have a matching CSS rule — a class with no style is a no-op feature
    - **CRITICAL**: Read `references/accessibility-checklist.md` and ensure every applicable item is satisfied
 
 6. **Renderer JS** — Return paths to shared field templates
 
 7. **Dialog XML** — Include base dialog fields via `granite/ui/components/coral/foundation/include`, add component-specific tabs/fields
 
-8. **Site clientlib** — `.content.xml`, `js.txt`, `css.txt`, view JS, LESS styles
+8. **Site clientlib** — `.content.xml`, `js.txt`, `css.txt`, view JS, styles. **Before writing the view JS, read `references/runtime-view-js.md`** — it defines the `FormFieldBase` override contract (`super` calls, `updateEmptyStatus`, composite-widget focus guard).
 
-9. **Editor clientlib** — `.content.xml` with editor category
+9. **Editor clientlib** — `.content.xml` with editor category. In editor JS use `textContent` (never `innerHTML`) and don't wrap locale-neutral format strings in `Granite.I18n.get`.
+
+10. **Register the runtime clientlib** — embed the component's `core.forms.components.{componentname}.v1.runtime` category in `ui.af.apps/.../af-clientlibs/core-forms-components-runtime-all/.content.xml`. Missing this silently breaks the runtime Cypress suite.
 
 #### 3c. Tests
 
-10. **Unit test** — JUnit 5 with `@ExtendWith(AemContextExtension.class)`:
+Unit tests alone are NOT enough — they only cover the Java model. **Cypress specs are
+required** (they catch HTL/view-JS/dialog/sync bugs that unit tests cannot). Read
+`references/cypress-tests.md`.
+
+11. **Unit test** — JUnit 5 with `@ExtendWith(AemContextExtension.class)`:
     - Use `FormsCoreComponentTestContext.newAemContext()`
     - Load `test-content.json` in `@BeforeEach`
     - Test `getFieldType()`, `getName()`, `getLabel()`, visibility, enabled, readOnly
     - Test JSON export with `Utils.testJSONExport()`
-    - Test all custom properties and methods
+    - Test **every** custom getter (incl. absent-when-default), **boolean props in both states**, any overridden `getConstraintMessages()`, and exclusive-constraint nulling
 
-11. **Test content JSON** — Mock JCR nodes with `sling:resourceType` matching the FormConstants value
+12. **Test content JSON** — Mock JCR nodes with `sling:resourceType` matching the FormConstants value
 
-12. **Exporter JSON** — Expected JSON output for export validation
+13. **Exporter JSON** — Expected JSON output for export validation
+
+14. **Cypress runtime spec** — `ui.tests/test-module/specs/{componentname}/{componentname}.runtime.cy.js` (+ IT content under `it/content/.../samples/{componentname}/basic/`, and a `formsConstants.js` entry). Mind the Cypress gotchas in `references/cypress-tests.md` (hidden-input visibility, chained `should('not.have.attr')`).
+
+15. **Cypress authoring spec** — `ui.tests/test-module/specs/{componentname}/{componentname}.authoring.cy.js` (Forms editor + Sites editor dialogs).
 
 #### 3d. Examples & IT Content
 
-13. **Example proxy component** — `.content.xml` with `sling:resourceSuperType` pointing to the component
-14. **Example content page** — Page structure with `guideContainer` and sample component instance
-15. **Register in example index** — Add entry to `examples/ui.content/.../adaptive-form/.content.xml`
+16. **Example proxy component** — `.content.xml` with `sling:resourceSuperType` pointing to the component
+17. **Example content page** — Page structure with `guideContainer` and sample component instance
+18. **Register in example index** — Add entry to `examples/ui.content/.../adaptive-form/.content.xml`
 
 ### Phase 4: Accessibility Verification
 
 After generating all files, read `references/accessibility-checklist.md` and verify:
 
-1. **HTL template** — Every interactive element has `aria-label` or `<label for>`, error div has `aria-live="assertive"`, descriptions have `aria-live="polite"`
-2. **JS view** — `updateValidity()` sets `aria-invalid`, `updateReadOnly()` sets `aria-readonly`, focus/blur handlers call `setActive()`/`setInactive()`
+1. **HTL template** — Every interactive element has `aria-label` or `<label for>`, error div has `aria-live="assertive"`, descriptions have `aria-live="polite"`. For a grouped widget, give the group `aria-label="${component.label.value}"` — **the shared label template emits no `id`, so `aria-labelledby="...__label"` is broken** (see `references/runtime-view-js.md` and the accessibility checklist).
+2. **JS view** — Prefer the inherited `FormFieldBase` handlers. If you override `updateValidity` / `updateEnabled` / `updateReadOnly` / `updateValue`, **call `super.<handler>(value, state)` first** so `data-cmp-*` attributes, the error message, and `--filled`/`--empty` stay in sync; only then add component-specific behaviour. Focus/blur handlers call `setActive()`/`setInactive()`. Read `references/runtime-view-js.md` — this is the #1 source of runtime bugs.
 3. **LESS styles** — `:focus` has visible `outline` with `2px` minimum, error states use color + text
 4. **Keyboard** — All interactive elements have `tabindex` if not natively focusable
 5. **BEM** — All class names follow `cmp-adaptiveform-{componentname}__{element}` convention
@@ -125,8 +138,8 @@ Run the component validator script to check all files, conventions, and accessib
 python3 scripts/validate_component.py {componentname} --repo-root /path/to/aem-core-forms-components
 ```
 
-The validator performs **90+ checks** across 12 categories:
-1. File existence (all 19+ required files)
+The validator performs checks across these categories:
+1. File existence (all required files)
 2. FormConstants registration
 3. Java interface annotations (`@ConsumerType`, copyright, base interface)
 4. Java implementation annotations (`@Model`, `@Exporter`, adaptables, injection strategy)
@@ -138,6 +151,10 @@ The validator performs **90+ checks** across 12 categories:
 10. BEM consistency (all elements present across HTL, JS, CSS, styleConfig)
 11. Example content (namespace declarations, guideContainer, proxy resourceSuperType)
 12. Tests (AemContext, JSON export, fieldType, resourceType)
+13. Runtime view-JS override contract (`super` calls on `update*`, `updateEmptyStatus` in `updateValue`)
+14. Editor clientlib JS safety (no `innerHTML`)
+15. BEM modifier classes emitted in HTL have a matching CSS rule; no empty design dialog
+16. Cypress specs (runtime + authoring), `formsConstants.js` entry, runtime-all embed, and Cypress-gotcha lint
 
 Fix all FAILs before proceeding. WARNs should be reviewed but may be acceptable.
 
@@ -155,12 +172,29 @@ Run tests:
 cd bundles/af-core && mvn test -pl . -Dtest={ComponentName}ImplTest 2>&1 | tail -30
 ```
 
+### Phase 7: Runtime Verification (Cypress)
+
+Unit tests cannot catch HTL/view-JS/sync bugs. Deploy and run the runtime spec
+against a live instance (`localhost:4502`):
+
+```bash
+mvn -pl ui.af.apps clean install -PautoInstallPackage         # redeploy after any view-JS/HTL change
+cd ui.tests/test-module && ./node_modules/.bin/cypress run --browser chrome --headless \
+  --spec "specs/{componentname}/{componentname}.runtime.cy.js"
+```
+
+The runtime spec must be green before the component is considered done — it is the
+only layer that surfaces the override-contract and composite-widget focus bugs
+described in `references/runtime-view-js.md`.
+
 ## Key References
 
-- `references/component-anatomy.md` — Full file checklist, interface/implementation hierarchy, FormConstants pattern
+- `references/component-anatomy.md` — Full file checklist (incl. Cypress + wiring), interface/implementation hierarchy, FormConstants pattern
 - `references/templates.md` — Copy-paste-ready templates for every file type with placeholders
+- `references/runtime-view-js.md` — **The `FormFieldBase` override contract** (super calls, `updateEmptyStatus`, composite widgets) — read before writing any view JS
+- `references/cypress-tests.md` — Required runtime + authoring specs, wiring, and Cypress gotchas
 - `references/accessibility-checklist.md` — WCAG 2.1 AA checklist with AEM-specific ARIA patterns
-- `scripts/validate_component.py` — Automated validator (90+ checks) — run after generating all files
+- `scripts/validate_component.py` — Automated validator — run after generating all files
 
 ## Critical Rules
 
@@ -175,3 +209,9 @@ cd bundles/af-core && mvn test -pl . -Dtest={ComponentName}ImplTest 2>&1 | tail 
 9. **Use `@ValueMapValue` with `InjectionStrategy.OPTIONAL`** — Never use `REQUIRED`; missing properties should use defaults
 10. **Test both `Resource` and `SlingHttpServletRequest` adaptation** — The `@Model` annotation must list both `adaptables`
 11. **Widget ID convention** — Always `{componentId}-widget` via `${'{0}-{1}' @ format=[component.id, 'widget']}`
+12. **Call `super` when overriding `update*` handlers** — `FormFieldBase` keeps the root `data-cmp-*` attributes, the error message, and `--filled`/`--empty` in sync; an override that skips `super` silently breaks them. An overridden `updateValue` must also end with `this.updateEmptyStatus()`. See `references/runtime-view-js.md`.
+13. **Cypress specs are mandatory** — ship `{componentname}.runtime.cy.js` + `{componentname}.authoring.cy.js`, the IT sample content, the `formsConstants.js` entry, and the runtime-all embed. Run the runtime spec green against `localhost:4502` before sign-off.
+14. **No empty styling or dialogs** — every BEM modifier class you emit must have a CSS rule; never ship an empty `_cq_design_dialog` tab.
+15. **Group label uses `aria-label`** — the shared label template emits no `id`, so `aria-labelledby="...__label"` is broken; use `aria-label="${component.label.value}"` for `role="group"` widgets.
+16. **Composite widgets**: only the hidden combined input carries `name`; never repopulate a sub-input the user is actively editing.
+17. **Editor JS safety** — use `textContent` not `innerHTML`; don't wrap locale-neutral format strings (`'YYYY-MM-DD'`) in `Granite.I18n.get`.

--- a/.claude/skills/create-core-component/references/accessibility-checklist.md
+++ b/.claude/skills/create-core-component/references/accessibility-checklist.md
@@ -87,14 +87,30 @@ Every component follows this naming pattern:
 
 ## JS View Accessibility Methods
 
-Every view class MUST implement:
+`FormFieldBase` already implements all of these and keeps the root `data-cmp-*`
+attributes, the error message, and the `--filled`/`--empty` modifier in sync.
+**Only override a handler if you need extra behaviour, and when you do, call
+`super.<handler>(value, state)` first** — otherwise you silently drop the base
+behaviour (stale `data-cmp-enabled`, unrendered error message, etc.). See
+`references/runtime-view-js.md` for the full override contract; it is the most
+common source of runtime bugs.
 
-| Method | Purpose |
-|--------|---------|
-| `updateValidity(validity)` | Set `aria-invalid` on widget based on `validity.valid` |
-| `updateReadOnly(readonly)` | Set `aria-readonly` and `disabled` on widget |
-| `updateEnabled(enabled)` | Toggle `disabled` attribute on widget |
-| `setModel(model)` | Register focus/blur listeners for `setActive()`/`setInactive()` |
+| Method | If you override it… |
+|--------|---------------------|
+| `updateValidity(validity, state)` | call `super` (it renders the error message + sets `data-cmp-valid`), then mirror `aria-invalid` onto extra sub-widgets |
+| `updateReadOnly(readOnly, state)` | call `super` (sets `data-cmp-readonly`), then set `aria-readonly`/`readonly` on sub-widgets |
+| `updateEnabled(enabled, state)` | call `super` (sets `data-cmp-enabled`), then toggle `disabled` on sub-widgets |
+| `updateValue(value)` | end with `this.updateEmptyStatus()`; for composite widgets, don't repopulate a focused sub-input |
+| `setModel(model)` | register focus/blur listeners for `setActive()`/`setInactive()` |
+
+## Group label pitfall (`aria-labelledby`)
+
+The shared label template (`af-commons/.../label.html`) renders
+`<label for="${componentId}" class="...__label">` with **no `id`**. So
+`aria-labelledby="${component.id}__label"` (or `${widgetId}__label`) points at a
+non-existent element and gives the group **no accessible name**. For a grouped
+widget (`role="group"`/`role="radiogroup"`) use `aria-label="${component.label.value}"`
+instead, or only reference an `id` you have actually rendered.
 
 ## Testing Accessibility
 

--- a/.claude/skills/create-core-component/references/component-anatomy.md
+++ b/.claude/skills/create-core-component/references/component-anatomy.md
@@ -31,22 +31,34 @@ To create a new component `{componentname}` at version v1, the following files a
 | 11 | `{componentname}/v1/{componentname}/clientlibs/site/.content.xml` | Runtime clientlib definition |
 | 12 | `{componentname}/v1/{componentname}/clientlibs/site/js/{componentname}view.js` | Client-side view class |
 | 13 | `{componentname}/v1/{componentname}/clientlibs/site/js.txt` | JS manifest |
-| 14 | `{componentname}/v1/{componentname}/clientlibs/site/css/{componentname}.less` | Styles |
+| 14 | `{componentname}/v1/{componentname}/clientlibs/site/css/{componentname}view.css` | Styles (`.css`; some legacy components use `.less`) |
 | 15 | `{componentname}/v1/{componentname}/clientlibs/site/css.txt` | CSS manifest |
 | 16 | `{componentname}/v1/{componentname}/clientlibs/editor/.content.xml` | Editor clientlib |
+| 17 | `{componentname}/v1/{componentname}/_cq_styleConfig/.content.xml` | Style System config (BEM-aligned style classes) |
+
+> Optional: `_cq_design_dialog/.content.xml` and `_cq_template.xml`. **Do not ship an
+> empty design dialog** (a tab containing only a comment) — omit it until it has real
+> fields.
 
 ### Examples
 
 | # | File | Purpose |
 |---|------|---------|
-| 17 | `examples/ui.apps/.../form/{componentname}/.content.xml` | Example proxy component |
-| 18 | `examples/ui.content/.../adaptive-form/{componentname}/.content.xml` | Example content page |
+| 18 | `examples/ui.apps/.../form/{componentname}/.content.xml` | Example proxy component |
+| 19 | `examples/ui.content/.../adaptive-form/{componentname}/.content.xml` | Example content page (Sites editor target) |
 
-### Integration Tests
+### Tests (Cypress) & wiring — REQUIRED
 
 | # | File | Purpose |
 |---|------|---------|
-| 19 | `it/content/.../samples/{componentname}/{componentname}v1/basic/.content.xml` | IT test content |
+| 20 | `ui.tests/test-module/specs/{componentname}/{componentname}.runtime.cy.js` | Runtime behaviour spec (model↔view, validation, rules) |
+| 21 | `ui.tests/test-module/specs/{componentname}/{componentname}.authoring.cy.js` | Edit-dialog spec (Forms + Sites editors) |
+| 22 | `it/content/.../samples/{componentname}/basic/.content.xml` | IT form the runtime spec loads via `previewForm` |
+| 23 | `ui.tests/test-module/libs/commons/formsConstants.js` (edit) | Add `resourceType.form{componentname}` entry |
+| 24 | `ui.af.apps/.../af-clientlibs/core-forms-components-runtime-all/.content.xml` (edit) | **Embed the runtime clientlib category** — the form runtime loads this aggregate; a missing embed silently breaks Cypress |
+
+See `references/cypress-tests.md`. Skipping any of #20–24 produces a component that
+"works" in unit tests but fails or never loads in the runtime suite.
 
 ---
 
@@ -79,6 +91,11 @@ Choose the appropriate base class:
 - **Options-based field** (checkboxes, radios, selects) -> extend `AbstractOptionsFieldImpl`
 - **Container/panel** -> extend `AbstractContainerImpl`
 - **Non-input component** (button, text, image) -> extend `AbstractBaseImpl`
+- **Composite / split widget** (e.g. day/month/year, multiple visible inputs feeding
+  one value) -> still extend the field base that matches the data type
+  (`AbstractFieldImpl` for date), but render **one hidden combined `<input>`** as the
+  value-bearing widget plus the visible sub-inputs. This category has extra runtime
+  rules — read `references/runtime-view-js.md` before writing the view JS.
 
 ---
 

--- a/.claude/skills/create-core-component/references/cypress-tests.md
+++ b/.claude/skills/create-core-component/references/cypress-tests.md
@@ -1,0 +1,78 @@
+# Cypress tests (runtime + authoring) — REQUIRED, not optional
+
+Unit tests + the exporter JSON only exercise the Java model. They do **not** cover
+the HTL render, the runtime view JS, dialogs, or the model↔view sync — which is
+where most real defects live. Every new component MUST ship two Cypress specs:
+
+| File | Covers |
+|------|--------|
+| `ui.tests/test-module/specs/{componentname}/{componentname}.runtime.cy.js` | rendered HTML, model↔view sync, value entry, enable/disable, read-only, visibility, validation/error messages, `--filled`/`--empty`, rule-engine (set/clear/show/hide/enable) |
+| `ui.tests/test-module/specs/{componentname}/{componentname}.authoring.cy.js` | edit-dialog tabs/fields in both the Forms editor and the Sites editor |
+
+These depend on content that the file checklist also requires:
+- `it/content/.../samples/{componentname}/basic/.content.xml` — the IT form the runtime spec loads (`previewForm`). Include sibling fields + `fd:events` rules if the runtime spec asserts rule-driven behaviour.
+- An entry in `ui.tests/test-module/libs/commons/formsConstants.js` (`resourceType.form{componentname}`).
+- The component's runtime clientlib category embedded in
+  `ui.af.apps/.../af-clientlibs/core-forms-components-runtime-all/.content.xml`
+  (the form runtime loads the aggregate; a missing embed silently breaks the spec).
+
+## Running
+
+```bash
+cd ui.tests/test-module
+./node_modules/.bin/cypress run --browser chrome --headless \
+  --spec "specs/{componentname}/{componentname}.runtime.cy.js"
+```
+
+`cypress.config.js` `baseUrl` is `http://localhost:4502`. The component must be
+deployed first: `mvn -pl ui.af.apps clean install -PautoInstallPackage`. After a
+view-JS change, redeploy — the spec loads the aggregated runtime clientlib, not
+your source file.
+
+## Cypress gotchas that bite forms components
+
+### 1. Hidden inputs fail `should('be.visible')`
+
+Cypress treats `input[type="hidden"]` as not visible (by design). Composite
+components render a hidden combined input, so a blanket descendant visibility check
+inside `within()` fails. Exclude hidden inputs:
+
+```js
+// BAD — fails on the hidden combined input
+cy.get('*').should('be.visible');
+// GOOD
+cy.get('*:not([type=hidden])').should('be.visible');
+```
+
+### 2. Don't chain two `should('(not.)have.attr', name)` calls
+
+`should('have.attr', name)` / `should('not.have.attr', name)` yields the
+**attribute value** (`undefined` when absent) as the subject for the next command,
+so a chained second attr assertion runs against `undefined` and fails with
+`expected undefined not to have attribute ...`. Re-query instead:
+
+```js
+// BAD
+cy.get(sel).should('not.have.attr', 'disabled').should('not.have.attr', 'readonly');
+// GOOD
+cy.get(sel).should('not.have.attr', 'disabled');
+cy.get(sel).should('not.have.attr', 'readonly');
+```
+
+### 3. Real-browser-only bugs
+
+The runtime spec is the only place that catches focus/typing races (e.g. a model
+repaint wiping an in-progress edit — see `runtime-view-js.md`). Never sign off a
+component on unit tests alone.
+
+## Unit-test coverage the validator and reviewers expect
+
+Beyond `getFieldType` / `getName` / `getLabel` / JSON export, add a test for:
+- **every custom getter** (placeholder/title/format/etc.), including the
+  absent-when-default case;
+- **boolean properties in both states** (e.g. `hideTitleDate` true *and* default false);
+- **any overridden `getConstraintMessages()`** — assert the added MINIMUM/MAXIMUM
+  (or other) entries are present (this override is commonly left uncovered and
+  shows up as a codecov gap);
+- **exclusive constraints** — assert both that the exclusive value is set *and*
+  that the non-exclusive min/max is nulled out by `@PostConstruct`.

--- a/.claude/skills/create-core-component/references/runtime-view-js.md
+++ b/.claude/skills/create-core-component/references/runtime-view-js.md
@@ -1,0 +1,105 @@
+# Runtime View JS — the `FormFieldBase` override contract
+
+The client-side view class (`clientlibs/site/js/{componentname}view.js`) extends
+`FormView.FormFieldBase`. The base class is not just a registration shim — its
+`update*` handlers keep the **root element's `data-cmp-*` attributes**, the
+**`--filled`/`--empty` BEM modifier**, the **`aria-invalid` flag**, and the
+**rendered error message** in sync with the model. Overriding a handler *replaces*
+that behaviour. Most runtime bugs in new components come from overriding a handler
+and silently dropping what the base used to do.
+
+> The single most important rule: **when you override an `update*` handler, call
+> `super.<handler>(value, state)` first, then do your component-specific work.**
+> Handlers are dispatched by `FormFieldBase.subscribe()` as
+> `this[fn](change.currentValue, state)`, so always accept and forward the second
+> `state` argument.
+
+## What each base handler does (and therefore what you must preserve)
+
+| Handler | Base behaviour you lose if you don't call `super` |
+|---------|----------------------------------------------------|
+| `updateValue(value)` | sets `this.widget.value`, then calls `updateEmptyStatus()` which toggles `{bem}--filled` / `{bem}--empty` on the root |
+| `updateEnabled(enabled, state)` | sets `data-cmp-enabled` on the root **and** toggles `disabled` on the widget |
+| `updateReadOnly(readOnly, state)` | sets `data-cmp-readonly` on the root **and** toggles `readonly` on the widget |
+| `updateRequired(required, state)` | sets `data-cmp-required` + `required` on the widget |
+| `updateValidity(validity, state)` | sets `data-cmp-valid` on the root, `aria-invalid` on the widget, **and calls `updateValidationMessage()` which renders the error text into `__errormessage`** |
+| `updateVisible(visible, state)` | sets `data-cmp-visible` + `aria-hidden` |
+
+### Correct override pattern
+
+```js
+updateEnabled(enabled, state) {
+    super.updateEnabled(enabled, state);              // keeps data-cmp-enabled in sync
+    ["D", "M", "Y"].forEach((t) => {                  // then the component-specific work
+        const input = this.#getInputByToken(t);
+        if (input) input.toggleAttribute("disabled", !enabled);
+    });
+}
+
+updateValidity(validity, state) {
+    super.updateValidity(validity, state);            // renders the error message + data-cmp-valid
+    // mirror aria-invalid onto sub-widgets if the component has more than one
+}
+```
+
+**Anti-pattern (do NOT do this):** an override that only sets `aria-invalid` /
+`disabled` on the widget and never calls `super`. The root `data-cmp-*` attributes
+go stale and the error message never renders — and unit tests won't catch it because
+the initial server-rendered HTML looks correct; the bug only appears after a model
+change. The runtime Cypress suite's `checkHTML` helper and the min/max
+error-message tests are what surface it.
+
+## `updateEmptyStatus()` — required in any overridden `updateValue`
+
+The base `updateValue` ends with `this.updateEmptyStatus()`. If you override
+`updateValue` (almost always necessary for composite widgets), you MUST call
+`this.updateEmptyStatus()` yourself or the `--filled`/`--empty` modifier never
+updates after the first render.
+
+Also note: `setModelValue(v)` dispatches a `UIChange` that is **not echoed back**
+to the originating field's `updateValue`. So when the user types, `updateValue`
+does not run — any `--filled`/`--empty` (or other view) sync triggered by typing
+must be done in your input handler / value-sync method, not left to `updateValue`.
+
+## Composite / multi-widget components (split widgets, hidden combined input)
+
+A "composite" component renders several visible sub-inputs (e.g. day/month/year)
+plus a single hidden `<input type="hidden">` that carries the combined submitted
+value. Extra rules:
+
+1. **`getWidget()` returns the hidden combined input** (the value-bearing element
+   the model binds to). The visible sub-inputs are UI only.
+2. **Do not put `name` on the visible sub-inputs.** Only the hidden combined input
+   gets `name="${component.name}"`. Otherwise the browser submits stray
+   `name-day` / `name-month` params alongside the real value. Find sub-inputs in
+   JS by **class selector**, never by name.
+3. **`updateValue` must not clobber a sub-input the user is editing.** Model
+   notifications fire on focus/enter, and re-populating the sub-inputs from the
+   model value will wipe the digits being typed (classic symptom: typing `2024`
+   lands as `024`). Guard it:
+
+   ```js
+   updateValue(modelValue) {
+       const active = document.activeElement;
+       const editing = active && ["D","M","Y"].some(t => active === this.#getInputByToken(t));
+       if (!editing) this.#splitValue(modelValue);   // only repopulate when not focused
+       const combined = this.getWidget();
+       if (combined) combined.value = modelValue || "";
+       this.updateEmptyStatus();                       // always
+   }
+   ```
+
+   This class of bug **only reproduces in a real browser** (Cypress against a live
+   instance) — unit tests and static review will not catch it. Always run the
+   runtime Cypress spec.
+4. Override `updateEnabled` / `updateReadOnly` / `updateValidity` to fan the state
+   out to every sub-input (after calling `super`, per the contract above).
+
+## Editor clientlib JS (`clientlibs/editor/js/*.js`)
+
+- **Never assign `innerHTML`** from a value — use `textContent`. Even
+  `Granite.I18n.get(...)` output should go through `textContent` (a translator
+  could introduce markup).
+- **Do not wrap locale-neutral format strings** (e.g. `'YYYY-MM-DD'`) in
+  `Granite.I18n.get(...)`. Use a plain constant; only run genuinely translatable
+  sentences through `I18n.get`.

--- a/.claude/skills/create-core-component/scripts/validate_component.py
+++ b/.claude/skills/create-core-component/scripts/validate_component.py
@@ -490,6 +490,100 @@ def validate_component(component_name, repo_root):
 
         check_file_contains(result, test_content, '"fieldType"', "Test content JSON: fieldType property present")
 
+    # ==========================================
+    # SECTION 13: Runtime View JS — override contract
+    # ==========================================
+    print("\n  --- Runtime View JS Contract ---")
+
+    if view_js.exists():
+        js = view_js.read_text()
+        # An overridden update* handler must call super, or it silently drops the base
+        # behaviour (root data-cmp-* attributes, error-message rendering, etc.).
+        for handler in ("updateEnabled", "updateReadOnly", "updateValidity", "updateRequired"):
+            if re.search(rf'\b{handler}\s*\(', js):
+                if re.search(rf'super\.{handler}\s*\(', js):
+                    result.ok(f"View JS: {handler}() override calls super")
+                else:
+                    result.fail(f"View JS: {handler}() overridden but never calls super.{handler}() "
+                                f"— root data-cmp-*/error message will go stale")
+        # An overridden updateValue must end by calling updateEmptyStatus().
+        if re.search(r'\bupdateValue\s*\(', js):
+            if 'updateEmptyStatus' in js:
+                result.ok("View JS: updateValue() override calls updateEmptyStatus()")
+            else:
+                result.fail("View JS: updateValue() overridden without updateEmptyStatus() "
+                            "— --filled/--empty modifier will not update")
+
+    # ==========================================
+    # SECTION 14: Editor clientlib JS safety
+    # ==========================================
+    print("\n  --- Editor Clientlib JS ---")
+
+    editor_js_dir = ui_base / "clientlibs/editor/js"
+    if editor_js_dir.exists():
+        for jsf in sorted(editor_js_dir.glob("*.js")):
+            content = jsf.read_text()
+            if re.search(r'\.innerHTML\s*=', content):
+                result.fail(f"Editor JS ({jsf.name}): assigns innerHTML — use textContent")
+            else:
+                result.ok(f"Editor JS ({jsf.name}): no innerHTML assignment")
+
+    # ==========================================
+    # SECTION 15: BEM modifier classes must have CSS
+    # ==========================================
+    print("\n  --- BEM Modifier Styling ---")
+
+    if htl_path.exists() and style_path is not None and style_path.exists():
+        htl = htl_path.read_text()
+        css = style_path.read_text()
+        modifiers = sorted(set(re.findall(rf'{re.escape(bem_block)}__[a-z0-9-]+--[a-z0-9-]+', htl)))
+        if not modifiers:
+            result.ok("BEM modifiers: none emitted literally in HTL")
+        for mod in modifiers:
+            if mod in css:
+                result.ok(f"BEM modifier: '{mod}' has a CSS rule")
+            else:
+                result.warn(f"BEM modifier: '{mod}' emitted in HTL but has no CSS rule — likely a no-op feature")
+
+    # Empty design dialog (a tab/container with only a comment) is noise — omit it.
+    design_dialog = ui_base / "_cq_design_dialog/.content.xml"
+    if design_dialog.exists():
+        dd = design_dialog.read_text()
+        if re.search(r'<items[^>]*>\s*(<!--.*?-->)?\s*</items>', dd, re.DOTALL):
+            result.warn("Design dialog: contains an empty tab/container — remove it or add real fields")
+
+    # ==========================================
+    # SECTION 16: Cypress specs & test wiring
+    # ==========================================
+    print("\n  --- Cypress Tests & Wiring ---")
+
+    runtime_spec = repo_root / f"ui.tests/test-module/specs/{component_name}/{component_name}.runtime.cy.js"
+    authoring_spec = repo_root / f"ui.tests/test-module/specs/{component_name}/{component_name}.authoring.cy.js"
+    check_file_exists(result, runtime_spec, "Cypress runtime spec")
+    check_file_exists(result, authoring_spec, "Cypress authoring spec")
+
+    forms_constants = repo_root / "ui.tests/test-module/libs/commons/formsConstants.js"
+    if forms_constants.exists() and component_name in forms_constants.read_text():
+        result.ok("formsConstants.js: component entry present")
+    else:
+        result.warn(f"formsConstants.js: no entry referencing '{component_name}'")
+
+    runtime_all = repo_root / "ui.af.apps/src/main/content/jcr_root/apps/core/fd/af-clientlibs/core-forms-components-runtime-all/.content.xml"
+    if runtime_all.exists() and f"core.forms.components.{component_name}.v1.runtime" in runtime_all.read_text():
+        result.ok("runtime-all: component runtime clientlib embedded")
+    else:
+        result.fail(f"runtime-all: 'core.forms.components.{component_name}.v1.runtime' not embedded "
+                    f"— the runtime Cypress suite will silently break")
+
+    if runtime_spec.exists():
+        spec = runtime_spec.read_text()
+        if re.search(r"cy\.get\(\s*['\"]\*['\"]\s*\)", spec):
+            result.warn("Cypress runtime spec: cy.get('*') fails be.visible on hidden inputs "
+                        "— use \"*:not([type=hidden])\"")
+        if re.search(r"have\.attr['\"][^)]*\)\s*\.should\([^)]*have\.attr", spec):
+            result.warn("Cypress runtime spec: chained should('(not.)have.attr') detected "
+                        "— re-query for each assertion (the first yields the attr value)")
+
     # Print final report
     return result.print_report()
 


### PR DESCRIPTION
## Description

Closes gaps in the `create-core-component` skill that were surfaced while building and reviewing the Date Input component (PR #1881). Every defect found in that component traced back to a missing or actively-misleading instruction in the skill — this PR updates the skill (workflow, references, validator) so future components don't repeat them.

## Gaps identified & addressed

**1. Runtime view-JS override contract was missing / wrong (root cause of most runtime bugs)**
- The accessibility checklist instructed overriding `updateValidity`/`updateEnabled`/`updateReadOnly` to *only* set ARIA/`disabled`, with no mention of calling `super` — which silently drops the base behaviour (`data-cmp-*` attributes, error-message rendering, `--filled`/`--empty`).
- Added `references/runtime-view-js.md` documenting the full `FormFieldBase` override contract: call `super.<handler>(value, state)` first; an overridden `updateValue` must call `updateEmptyStatus()`; `setModelValue` is not echoed back to the originating field.
- Rewrote the checklist's "JS View Methods" table and SKILL.md Phase 4 accordingly.

**2. No guidance for composite / split widgets**
- The focus-clobber bug (typing `2024` → `024`) and stray submitted sub-field params came from having no pattern for multi-input widgets.
- Added a "Composite / split widget" base-class category and a dedicated section: one hidden combined input carries the value + `name`; never put `name` on visible sub-inputs; never repopulate a sub-input the user is actively editing.

**3. Cypress tests were entirely absent from the skill**
- The skill only covered unit tests + exporter JSON, so HTL/view-JS/dialog/sync bugs were never caught.
- Added `references/cypress-tests.md` (required runtime + authoring specs, IT content, `formsConstants.js` entry, runtime-all embed) plus the two Cypress gotchas: hidden inputs fail `be.visible`; chained `should('(not.)have.attr')` breaks because the first yields the attribute value.

**4. Broken `aria-labelledby` pattern**
- The shared label template emits no `id`, so `aria-labelledby="...__label"` references a non-existent element. Documented; grouped widgets must use `aria-label`.

**5. BEM modifier classes with no CSS**
- `hideTitleDate` shipped a `--hidden` class that had no styling (dead feature). Added the rule: every emitted modifier must have a matching CSS rule; never ship an empty design dialog.

**6. Editor-JS safety & i18n**
- Use `textContent` not `innerHTML`; don't wrap locale-neutral format strings in `Granite.I18n.get`; wrap hard-coded default UI text with `@ i18n`.

**7. Incomplete/incorrect file checklist (`component-anatomy.md`)**
- Was missing the Cypress specs, `_cq_styleConfig`, the runtime-all embed and the `formsConstants.js` entry; had the wrong IT-content path and listed `.less` instead of `.css`. Corrected.

**8. Validator (`scripts/validate_component.py`) extended with 4 new check categories**
- view-JS override contract (`super` on `update*`, `updateEmptyStatus` in `updateValue`)
- editor-JS `innerHTML` usage
- BEM modifier classes have a CSS rule + empty-design-dialog warning
- Cypress specs / `formsConstants` entry / runtime-all embed existence + Cypress-gotcha lints

## Types of changes

- [x] Skill / tooling improvement (no runtime component code changed)
