### PR TITLE
[FORMS-15359] Hide Read Only option in Single Checkbox v1 property dialog

### DIFF
--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/checkbox/v1/checkbox/_cq_dialog/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/checkbox/v1/checkbox/_cq_dialog/.content.xml
@@ -106,6 +106,12 @@
                                               sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                               fieldLabel="Default value"
                                               name="./default"/>
+                                            <readonly
+                                                    jcr:primaryType="nt:unstructured"
+                                                    sling:hideResource="{Boolean}true"/>
+                                            <readonly-typehint
+                                                    jcr:primaryType="nt:unstructured"
+                                                    sling:hideResource="{Boolean}true"/>
                                             <fieldType
                                                     jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="granite/ui/components/coral/foundation/form/select"


### PR DESCRIPTION
## Summary
- Hides the **Read Only** option from the Single Checkbox v1 property dialog (`checkbox/v1/_cq_dialog/.content.xml`), which was incorrectly surfaced since Read Only is not a valid property for a checkbox component.
- Adds `sling:hideResource=true` to the `readonly` and `readonly-typehint` dialog nodes.

## Root Cause
The dialog inherited `readonly` nodes from a parent definition, but the Read Only property does not apply to checkbox behaviour and should not be shown in the authoring UI.

## Test Plan
- [ ] Open the Single Checkbox v1 property dialog in author mode
- [ ] Verify the **Read Only** option is no longer present
- [ ] Verify no other dialog fields are affected
- [ ] Verify checkbox functionality (check/uncheck, value submission) is unchanged

## Jira
https://jira.corp.adobe.com/browse/FORMS-15359

🤖 Generated with [Claude Code](https://claude.com/claude-code) via OrcaFix skill