### PR TITLE
[FORMS-10306] Fix default Maximum file size showing empty instead of 2 MB in File Attachment v1 dialog

### DIFF
--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/fileinput/v1/fileinput/_cq_dialog/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/fileinput/v1/fileinput/_cq_dialog/.content.xml
@@ -145,7 +145,7 @@
                                                     sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"
                                                     fieldLabel="Maximum file size (MB)"
                                                     name="./maxFileSize"
-                                                    defaultValue="">
+                                                    defaultValue="2">
                                             </fileSizeLimit>
                                             <maxFileSizeMessage
                                                     jcr:primaryType="nt:unstructured"


### PR DESCRIPTION
## Summary
- Fixes the File Attachment v1 property dialog where the **Maximum file size** field appears empty instead of showing the default value of **2 MB**.
- Changes `defaultValue` from empty string to `2` for the `fileSizeLimit` numberfield in `fileinput/v1/fileinput/_cq_dialog/.content.xml`.

## Root Cause
The `defaultValue` attribute for the file size limit numberfield was set to an empty string, causing the dialog to render a blank field instead of the expected default of 2 MB.

## Test Plan
- [ ] Open the File Attachment v1 component property dialog in author mode
- [ ] Verify the **Maximum file size** field shows **2** (MB) by default when no value has been previously set
- [ ] Verify saving and re-opening the dialog persists the value correctly
- [ ] Verify file upload still enforces the size limit at runtime

## Jira
https://jira.corp.adobe.com/browse/FORMS-10306

🤖 Generated with [Claude Code](https://claude.com/claude-code) via OrcaFix skill