### PR TITLE
[FORMS-25355] Make checkedValue required in Checkbox v1 dialog to prevent silent 'on' submission

### DIFF
--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/checkbox/v1/checkbox/_cq_dialog/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/checkbox/v1/checkbox/_cq_dialog/.content.xml
@@ -75,7 +75,8 @@
                                                   sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                   fieldLabel="When Checked, return value"
                                                   fieldDescription="Value submitted when the checkbox is checked. Enter the value as text. For boolean fields, use true. For numeric intent, enter values such as 1 as text."
-                                                  name="./checkedValue"/>
+                                                  name="./checkedValue"
+                                                  required="{Boolean}true"/>
                                                 <enableUncheckedValue
                                                   jcr:primaryType="nt:unstructured"
                                                   sling:resourceType="granite/ui/components/coral/foundation/form/switch"


### PR DESCRIPTION
## Summary
- Makes the **Checked Value** field required in the Checkbox v1 property dialog (`checkbox/v1/_cq_dialog/.content.xml`), preventing authors from leaving it blank.
- Adds `required="{Boolean}true"` to the `checkedValue` textfield node.

## Root Cause
When the Checked Value field is left empty, the checkbox silently submits the string `"on"` instead of the intended value. This is a hidden data quality issue — authors have no visual indication that leaving the field blank changes submission behaviour.

## Test Plan
- [ ] Open the Checkbox v1 component property dialog in author mode
- [ ] Verify the **Checked Value** field is marked as required (asterisk / validation)
- [ ] Verify the dialog cannot be saved when Checked Value is empty
- [ ] Verify a form with a properly configured checkbox still submits the correct value

## Jira
https://jira.corp.adobe.com/browse/FORMS-25355

🤖 Generated with [Claude Code](https://claude.com/claude-code) via OrcaFix skill