### PR TITLE
FORMS-25983 Add min/max cross-validation to authoring dialogs

### DIFF
--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/af-commons/v1/clientlibs/editor/utils/utils.js
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/af-commons/v1/clientlibs/editor/utils/utils.js
@@ -340,18 +340,11 @@
                 var minField = getCoralField(minSelector);
                 var maxField = getCoralField(maxSelector);
                 if (!minField || !maxField) return;
-                var compare = compareFn || function(a, b) { return parseInt(a, 10) > parseInt(b, 10); };
+                var compare = compareFn || INT_COMPARE;
                 function validate() {
-                    var minVal = minField.value, maxVal = maxField.value;
-                    var invalid = !!(minVal && maxVal && compare(minVal, maxVal));
-                    minField.invalid = invalid;
-                    maxField.invalid = invalid;
-                    if (invalid) {
-                        minField.errorMessage = Granite.I18n.getMessage(minMsg);
-                        maxField.errorMessage = Granite.I18n.getMessage(maxMsg);
-                    }
+                    $(minField).trigger("change");
+                    $(maxField).trigger("change");
                 }
-                validate();
                 minField.addEventListener("change", validate);
                 maxField.addEventListener("change", validate);
             };
@@ -369,7 +362,7 @@
          * @param {Function} [compareFn]       Optional (a, b) => boolean. Defaults to numeric comparison.
          */
         static registerMinMaxValidator(minFieldSelector, maxFieldSelector, minMsg, maxMsg, compareFn) {
-            var compare = compareFn || function(a, b) { return parseInt(a, 10) > parseInt(b, 10); };
+            var compare = compareFn || INT_COMPARE;
             $(window).adaptTo("foundation-registry").register("foundation.validation.validator", {
                 selector: minFieldSelector + ", " + maxFieldSelector,
                 validate: function(el) {
@@ -389,50 +382,19 @@
         }
     }
 
-    // ─── Central min/max validation registry ────────────────────────────────
-    // Each entry describes one pair of min/max fields in an authoring dialog.
-    // To add validation for a new component, append an entry here — no changes
-    // needed in the component's own editDialog.js.
-    var DATE_COMPARE = function(a, b) { return new Date(a) > new Date(b); };
+    // ─── Shared min/max validation for container components ──────────────────
+    // panelcontainer__minOccur / __maxOccur is shared across accordion, wizard,
+    // tabsontop, verticaltabs, and fragment — none of which have their own
+    // editDialog.js — so registration is centralised here.
+    var INT_COMPARE = function(a, b) { return parseInt(a, 10) > parseInt(b, 10); };
 
     var MIN_MAX_PAIRS = [
-        {
-            minSelector: ".cmp-adaptiveform-textinput__minlength coral-numberinput",
-            maxSelector: ".cmp-adaptiveform-textinput__maxlength coral-numberinput",
-            minMsg: "Minimum length cannot be greater than maximum length",
-            maxMsg: "Maximum length cannot be less than minimum length"
-        },
-        {
-            minSelector: ".cmp-adaptiveform-numberinput__minimum",
-            maxSelector: ".cmp-adaptiveform-numberinput__maximum",
-            minMsg: "Minimum value cannot be greater than maximum value",
-            maxMsg: "Maximum value cannot be less than minimum value"
-        },
-        {
-            minSelector: ".cmp-adaptiveform-fileinput__minimumFiles coral-numberinput",
-            maxSelector: ".cmp-adaptiveform-fileinput__maximumFiles coral-numberinput",
-            minMsg: "Minimum files cannot be greater than maximum files",
-            maxMsg: "Maximum files cannot be less than minimum files"
-        },
-        {
-            minSelector: ".cmp-adaptiveform-datepicker__mindate coral-datepicker",
-            maxSelector: ".cmp-adaptiveform-datepicker__maxdate coral-datepicker",
-            minMsg: "Minimum date cannot be after maximum date",
-            maxMsg: "Maximum date cannot be before minimum date",
-            compareFn: DATE_COMPARE
-        },
-        {
-            minSelector: ".cmp-adaptiveform-datetime__editdialog coral-datepicker[name='./minimumDateTime']",
-            maxSelector: ".cmp-adaptiveform-datetime__editdialog coral-datepicker[name='./maximumDateTime']",
-            minMsg: "Minimum date-time cannot be after maximum date-time",
-            maxMsg: "Maximum date-time cannot be before minimum date-time",
-            compareFn: DATE_COMPARE
-        },
         {
             minSelector: ".cmp-adaptiveform-panelcontainer__minOccur coral-numberinput",
             maxSelector: ".cmp-adaptiveform-panelcontainer__maxOccur coral-numberinput",
             minMsg: "Minimum occurrence cannot be greater than maximum occurrence",
-            maxMsg: "Maximum occurrence cannot be less than minimum occurrence"
+            maxMsg: "Maximum occurrence cannot be less than minimum occurrence",
+            compareFn: INT_COMPARE
         }
     ];
 
@@ -451,17 +413,20 @@
 
     // Auto-wire real-time change listeners whenever any dialog opens.
     channel.on("foundation-contentloaded", function(e) {
-        var dialog = $(e.target);
-        MIN_MAX_PAIRS.forEach(function(pair) {
-            if (dialog.find(pair.minSelector).length && dialog.find(pair.maxSelector).length) {
-                Utils.handleMinMaxValidation(
-                    pair.minSelector,
-                    pair.maxSelector,
-                    pair.minMsg,
-                    pair.maxMsg,
-                    pair.compareFn
-                )(e.target);
-            }
+        if (!$(e.target).find(".cq-dialog-content").length) return;
+        Coral.commons.ready(e.target, function() {
+            var dialog = $(e.target);
+            MIN_MAX_PAIRS.forEach(function(pair) {
+                if (dialog.find(pair.minSelector).length && dialog.find(pair.maxSelector).length) {
+                    Utils.handleMinMaxValidation(
+                        pair.minSelector,
+                        pair.maxSelector,
+                        pair.minMsg,
+                        pair.maxMsg,
+                        pair.compareFn
+                    )(e.target);
+                }
+            });
         });
     });
 

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/af-commons/v1/clientlibs/editor/utils/utils.js
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/af-commons/v1/clientlibs/editor/utils/utils.js
@@ -316,6 +316,153 @@
                 hiddenFields[i].remove();
             }
         }
+
+        /**
+         * Returns an initializeEditDialog-compatible handler that validates min < max in real time.
+         * Works for both wrapperClass selectors (class on a wrapper div) and granite:class selectors
+         * (class on the coral field itself) by looking for a coral-numberinput or coral-datepicker
+         * inside the selector before falling back to the selector element itself.
+         *
+         * @param {String}   minSelector  Dialog-prefixed CSS selector for the min field or its wrapper
+         * @param {String}   maxSelector  Dialog-prefixed CSS selector for the max field or its wrapper
+         * @param {String}   minMsg       Error message shown on the min field when min > max
+         * @param {String}   maxMsg       Error message shown on the max field when min > max
+         * @param {Function} [compareFn]  Optional (a, b) => boolean. Defaults to numeric comparison.
+         */
+        static handleMinMaxValidation(minSelector, maxSelector, minMsg, maxMsg, compareFn) {
+            return function(dialog) {
+                function getCoralField(selector) {
+                    var container = dialog.find(selector);
+                    if (!container.length) return null;
+                    var inner = container.find("coral-numberinput, coral-datepicker");
+                    return (inner.length ? inner : container)[0];
+                }
+                var minField = getCoralField(minSelector);
+                var maxField = getCoralField(maxSelector);
+                if (!minField || !maxField) return;
+                var compare = compareFn || function(a, b) { return parseInt(a, 10) > parseInt(b, 10); };
+                function validate() {
+                    var minVal = minField.value, maxVal = maxField.value;
+                    var invalid = !!(minVal && maxVal && compare(minVal, maxVal));
+                    minField.invalid = invalid;
+                    maxField.invalid = invalid;
+                    if (invalid) {
+                        minField.errorMessage = Granite.I18n.getMessage(minMsg);
+                        maxField.errorMessage = Granite.I18n.getMessage(maxMsg);
+                    }
+                }
+                validate();
+                minField.addEventListener("change", validate);
+                maxField.addEventListener("change", validate);
+            };
+        }
+
+        /**
+         * Registers a foundation.validation.validator that blocks dialog submission when min > max.
+         * Must be called once at module scope (not inside initializeEditDialog) to avoid stacking
+         * duplicate validators on every dialog open.
+         *
+         * @param {String}   minFieldSelector  Bare CSS selector targeting the coral field for min
+         * @param {String}   maxFieldSelector  Bare CSS selector targeting the coral field for max
+         * @param {String}   minMsg            Error message for the min field
+         * @param {String}   maxMsg            Error message for the max field
+         * @param {Function} [compareFn]       Optional (a, b) => boolean. Defaults to numeric comparison.
+         */
+        static registerMinMaxValidator(minFieldSelector, maxFieldSelector, minMsg, maxMsg, compareFn) {
+            var compare = compareFn || function(a, b) { return parseInt(a, 10) > parseInt(b, 10); };
+            $(window).adaptTo("foundation-registry").register("foundation.validation.validator", {
+                selector: minFieldSelector + ", " + maxFieldSelector,
+                validate: function(el) {
+                    var dialog = $(el).closest("coral-dialog");
+                    var minField = dialog.find(minFieldSelector)[0];
+                    var maxField = dialog.find(maxFieldSelector)[0];
+                    if (!minField || !maxField) return;
+                    var minVal = minField.value, maxVal = maxField.value;
+                    if (minVal && maxVal && compare(minVal, maxVal)) {
+                        if (el === minField) {
+                            return Granite.I18n.getMessage(minMsg);
+                        }
+                        return Granite.I18n.getMessage(maxMsg);
+                    }
+                }
+            });
+        }
     }
+
+    // ─── Central min/max validation registry ────────────────────────────────
+    // Each entry describes one pair of min/max fields in an authoring dialog.
+    // To add validation for a new component, append an entry here — no changes
+    // needed in the component's own editDialog.js.
+    var DATE_COMPARE = function(a, b) { return new Date(a) > new Date(b); };
+
+    var MIN_MAX_PAIRS = [
+        {
+            minSelector: ".cmp-adaptiveform-textinput__minlength coral-numberinput",
+            maxSelector: ".cmp-adaptiveform-textinput__maxlength coral-numberinput",
+            minMsg: "Minimum length cannot be greater than maximum length",
+            maxMsg: "Maximum length cannot be less than minimum length"
+        },
+        {
+            minSelector: ".cmp-adaptiveform-numberinput__minimum",
+            maxSelector: ".cmp-adaptiveform-numberinput__maximum",
+            minMsg: "Minimum value cannot be greater than maximum value",
+            maxMsg: "Maximum value cannot be less than minimum value"
+        },
+        {
+            minSelector: ".cmp-adaptiveform-fileinput__minimumFiles coral-numberinput",
+            maxSelector: ".cmp-adaptiveform-fileinput__maximumFiles coral-numberinput",
+            minMsg: "Minimum files cannot be greater than maximum files",
+            maxMsg: "Maximum files cannot be less than minimum files"
+        },
+        {
+            minSelector: ".cmp-adaptiveform-datepicker__mindate coral-datepicker",
+            maxSelector: ".cmp-adaptiveform-datepicker__maxdate coral-datepicker",
+            minMsg: "Minimum date cannot be after maximum date",
+            maxMsg: "Maximum date cannot be before minimum date",
+            compareFn: DATE_COMPARE
+        },
+        {
+            minSelector: ".cmp-adaptiveform-datetime__editdialog coral-datepicker[name='./minimumDateTime']",
+            maxSelector: ".cmp-adaptiveform-datetime__editdialog coral-datepicker[name='./maximumDateTime']",
+            minMsg: "Minimum date-time cannot be after maximum date-time",
+            maxMsg: "Maximum date-time cannot be before minimum date-time",
+            compareFn: DATE_COMPARE
+        },
+        {
+            minSelector: ".cmp-adaptiveform-panelcontainer__minOccur coral-numberinput",
+            maxSelector: ".cmp-adaptiveform-panelcontainer__maxOccur coral-numberinput",
+            minMsg: "Minimum occurrence cannot be greater than maximum occurrence",
+            maxMsg: "Maximum occurrence cannot be less than minimum occurrence"
+        }
+    ];
+
+    var Utils = window.CQ.FormsCoreComponents.Utils.v1;
+
+    // Register all foundation submit-time validators once at page load.
+    MIN_MAX_PAIRS.forEach(function(pair) {
+        Utils.registerMinMaxValidator(
+            pair.minSelector,
+            pair.maxSelector,
+            pair.minMsg,
+            pair.maxMsg,
+            pair.compareFn
+        );
+    });
+
+    // Auto-wire real-time change listeners whenever any dialog opens.
+    channel.on("foundation-contentloaded", function(e) {
+        var dialog = $(e.target);
+        MIN_MAX_PAIRS.forEach(function(pair) {
+            if (dialog.find(pair.minSelector).length && dialog.find(pair.maxSelector).length) {
+                Utils.handleMinMaxValidation(
+                    pair.minSelector,
+                    pair.maxSelector,
+                    pair.minMsg,
+                    pair.maxMsg,
+                    pair.compareFn
+                )(e.target);
+            }
+        });
+    });
 
 })(jQuery, jQuery(document), Coral);

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/af-commons/v1/clientlibs/editor/utils/utils.js
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/af-commons/v1/clientlibs/editor/utils/utils.js
@@ -342,9 +342,16 @@
                 if (!minField || !maxField) return;
                 var compare = compareFn || INT_COMPARE;
                 function validate() {
-                    $(minField).trigger("change");
-                    $(maxField).trigger("change");
+                    var minVal = minField.value, maxVal = maxField.value;
+                    var invalid = !!(minVal && maxVal && compare(minVal, maxVal));
+                    minField.invalid = invalid;
+                    maxField.invalid = invalid;
+                    if (invalid) {
+                        minField.errorMessage = Granite.I18n.getMessage(minMsg);
+                        maxField.errorMessage = Granite.I18n.getMessage(maxMsg);
+                    }
                 }
+                validate();
                 minField.addEventListener("change", validate);
                 maxField.addEventListener("change", validate);
             };
@@ -424,7 +431,7 @@
                         pair.minMsg,
                         pair.maxMsg,
                         pair.compareFn
-                    )(e.target);
+                    )(dialog);
                 }
             });
         });

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/af-commons/v1/clientlibs/editor/utils/utils.js
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/af-commons/v1/clientlibs/editor/utils/utils.js
@@ -344,11 +344,24 @@
                 function validate() {
                     var minVal = minField.value, maxVal = maxField.value;
                     var invalid = !!(minVal && maxVal && compare(minVal, maxVal));
-                    minField.invalid = invalid;
-                    maxField.invalid = invalid;
+                    var minErrMsg = Granite.I18n.getMessage(minMsg);
+                    var maxErrMsg = Granite.I18n.getMessage(maxMsg);
                     if (invalid) {
-                        minField.errorMessage = Granite.I18n.getMessage(minMsg);
-                        maxField.errorMessage = Granite.I18n.getMessage(maxMsg);
+                        minField.invalid = true;
+                        maxField.invalid = true;
+                        minField.errorMessage = minErrMsg;
+                        maxField.errorMessage = maxErrMsg;
+                    } else {
+                        // Only clear invalid if this listener set it — avoids clobbering
+                        // required/pattern errors that another validator placed on the field.
+                        if (minField.errorMessage === minErrMsg) {
+                            minField.invalid = false;
+                            minField.errorMessage = "";
+                        }
+                        if (maxField.errorMessage === maxErrMsg) {
+                            maxField.invalid = false;
+                            maxField.errorMessage = "";
+                        }
                     }
                 }
                 validate();

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v1/container/_cq_dialog/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v1/container/_cq_dialog/.content.xml
@@ -92,6 +92,7 @@
                                             fieldLabel="Redirect URL/Path"
                                             rootPath="/content"
                                             name="./redirect"
+                                            validation="forms.redirect.absolutepath"
                                             filter="nosystem"/>
                                     <thankYouMessage
                                             jcr:primaryType="nt:unstructured"

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v1/container/clientlibs/editor/js/editDialog.js
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v1/container/clientlibs/editor/js/editDialog.js
@@ -256,6 +256,18 @@
         });
     }
 
+    $(window).adaptTo("foundation-registry").register("foundation.validation.validator", {
+        selector: "[data-validation~='forms.redirect.absolutepath']",
+        validate: function(el) {
+            var value = el.value;
+            if (value && !value.startsWith("/") && !/^https?:\/\/.+$/i.test(value)) {
+                return Granite.I18n.getMessage(
+                    "Please enter an absolute path (starting with '/') or an absolute URL (starting with 'http://' or 'https://')."
+                );
+            }
+        }
+    });
+
     Utils.initializeEditDialog(EDIT_DIALOG_FORM)(handleAsyncSubmissionAndThankYouOption, handleSubmitAction,
         registerSubmitActionSubDialogClientLibs, registerRestEndPointDialogClientlibs, registerFDMDialogClientlibs, registerEmailDialogClientlibs, initialiseDataModel, registerAutoSaveDialogAction);
 

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v2/container/_cq_dialog/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v2/container/_cq_dialog/.content.xml
@@ -300,6 +300,7 @@
                                       fieldLabel="Redirect URL/Path"
                                       rootPath="/content"
                                       name="./redirect"
+                                      validation="forms.redirect.absolutepath"
                                       filter="nosystem"/>
                                     <thankYouMessage
                                       jcr:primaryType="nt:unstructured"

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/datepicker/v1/datepicker/clientlibs/editor/js/editDialog.js
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/datepicker/v1/datepicker/clientlibs/editor/js/editDialog.js
@@ -26,6 +26,8 @@
         DATEPICKER_DEFAULTDATE = EDIT_DIALOG + " .cmp-adaptiveform-datepicker__defaultdate",
         DATEPICKER_MINDATE = EDIT_DIALOG + " .cmp-adaptiveform-datepicker__mindate",
         DATEPICKER_MAXDATE = EDIT_DIALOG + " .cmp-adaptiveform-datepicker__maxdate",
+        DATEPICKER_MIN_FIELD = ".cmp-adaptiveform-datepicker__mindate coral-datepicker",
+        DATEPICKER_MAX_FIELD = ".cmp-adaptiveform-datepicker__maxdate coral-datepicker",
         Utils = window.CQ.FormsCoreComponents.Utils.v1;
 
 
@@ -69,5 +71,30 @@
         maxDateTooltip.innerHTML = fieldDescription;
     }
 
-    Utils.initializeEditDialog(EDIT_DIALOG)(handleDisplayPatternDropDown,handleDisplayFormat,handleEditPatternDropDown,handleEditFormat,handleLang,handleDatePlaceholders);
+    var DATE_COMPARE = function(a, b) {
+        var da = new Date(a), db = new Date(b);
+        return !isNaN(da) && !isNaN(db) && da > db;
+    };
+
+    Utils.registerMinMaxValidator(
+        DATEPICKER_MIN_FIELD, DATEPICKER_MAX_FIELD,
+        "Minimum date cannot be after maximum date",
+        "Maximum date cannot be before minimum date",
+        DATE_COMPARE
+    );
+
+    Utils.initializeEditDialog(EDIT_DIALOG)(
+        handleDisplayPatternDropDown,
+        handleDisplayFormat,
+        handleEditPatternDropDown,
+        handleEditFormat,
+        handleLang,
+        handleDatePlaceholders,
+        Utils.handleMinMaxValidation(
+            DATEPICKER_MIN_FIELD, DATEPICKER_MAX_FIELD,
+            "Minimum date cannot be after maximum date",
+            "Maximum date cannot be before minimum date",
+            DATE_COMPARE
+        )
+    );
 })(jQuery);

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/datetime/v1/datetime/_cq_dialog/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/datetime/v1/datetime/_cq_dialog/.content.xml
@@ -77,6 +77,7 @@
                                                     type="datetime"
                                                     emptyText="YYYY-MM-DD HH:mm"
                                                     name="./minimumDateTime"
+                                                    wrapperClass="cmp-adaptiveform-datetime__minimumDateTime"
                                                     valueFormat="YYYY-MM-DD[T]HH:mm:ss.000-00:00"/> <!-- Enforce UTC timezone to be timezone agnostic -->
                                             <minimumMessage
                                                     jcr:primaryType="nt:unstructured"
@@ -93,6 +94,7 @@
                                                     emptyText="YYYY-MM-DD HH:mm"
                                                     type="datetime"
                                                     name="./maximumDateTime"
+                                                    wrapperClass="cmp-adaptiveform-datetime__maximumDateTime"
                                                     valueFormat="YYYY-MM-DD[T]HH:mm:ss.000-00:00"/> <!-- Enforce UTC timezone to be timezone agnostic -->
                                             <maximumMessage
                                                     jcr:primaryType="nt:unstructured"

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/datetime/v1/datetime/clientlibs/editor/js/editDialog.js
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/datetime/v1/datetime/clientlibs/editor/js/editDialog.js
@@ -15,4 +15,30 @@
  ******************************************************************************/
 (function($) {
     "use strict";
+
+    var EDIT_DIALOG = ".cmp-adaptiveform-datetime__editdialog",
+        DATETIME_MIN_FIELD = ".cmp-adaptiveform-datetime__minimumDateTime coral-datepicker",
+        DATETIME_MAX_FIELD = ".cmp-adaptiveform-datetime__maximumDateTime coral-datepicker",
+        Utils = window.CQ.FormsCoreComponents.Utils.v1;
+
+    var DATE_COMPARE = function(a, b) {
+        var da = new Date(a), db = new Date(b);
+        return !isNaN(da) && !isNaN(db) && da > db;
+    };
+
+    Utils.registerMinMaxValidator(
+        DATETIME_MIN_FIELD, DATETIME_MAX_FIELD,
+        "Minimum date-time cannot be after maximum date-time",
+        "Maximum date-time cannot be before minimum date-time",
+        DATE_COMPARE
+    );
+
+    Utils.initializeEditDialog(EDIT_DIALOG)(
+        Utils.handleMinMaxValidation(
+            DATETIME_MIN_FIELD, DATETIME_MAX_FIELD,
+            "Minimum date-time cannot be after maximum date-time",
+            "Maximum date-time cannot be before minimum date-time",
+            DATE_COMPARE
+        )
+    );
 })(jQuery);

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/fileinput/v1/fileinput/clientlibs/editor/js/editDialog.js
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/fileinput/v1/fileinput/clientlibs/editor/js/editDialog.js
@@ -21,6 +21,8 @@
         FILEINPUT_MINITEMS_ERRMSG = EDIT_DIALOG + " .cmp-adaptiveform-fileinput__minimumFilesMessage",
         FILEINPUT_MAXITEMS = EDIT_DIALOG + " .cmp-adaptiveform-fileinput__maximumFiles",
         FILEINPUT_MAXITEMS_ERRMSG = EDIT_DIALOG + " .cmp-adaptiveform-fileinput__maximumFilesMessage",
+        FILEINPUT_MIN_FIELD = ".cmp-adaptiveform-fileinput__minimumFiles coral-numberinput",
+        FILEINPUT_MAX_FIELD = ".cmp-adaptiveform-fileinput__maximumFiles coral-numberinput",
     Utils = window.CQ.FormsCoreComponents.Utils.v1;
 
     /**
@@ -46,6 +48,19 @@
             hideAndShowElements();
         });
     }
-    Utils.initializeEditDialog(EDIT_DIALOG)(handleMultiSelection);
+    Utils.registerMinMaxValidator(
+        FILEINPUT_MIN_FIELD, FILEINPUT_MAX_FIELD,
+        "Minimum files cannot be greater than maximum files",
+        "Maximum files cannot be less than minimum files"
+    );
+
+    Utils.initializeEditDialog(EDIT_DIALOG)(
+        handleMultiSelection,
+        Utils.handleMinMaxValidation(
+            FILEINPUT_MIN_FIELD, FILEINPUT_MAX_FIELD,
+            "Minimum files cannot be greater than maximum files",
+            "Maximum files cannot be less than minimum files"
+        )
+    );
 
 })(jQuery);

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/numberinput/v1/numberinput/clientlibs/editor/js/editDialog.js
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/numberinput/v1/numberinput/clientlibs/editor/js/editDialog.js
@@ -22,6 +22,8 @@
         NUMERICINPUT_EXCLUDEMAXCHECK = EDIT_DIALOG + " .cmp-adaptiveform-numberinput__excludeMaximumCheck",
         NUMERICINPUT_MINIMUM = EDIT_DIALOG + " .cmp-adaptiveform-numberinput__minimum",
         NUMERICINPUT_EXCLUDEMINCHECK = EDIT_DIALOG + " .cmp-adaptiveform-numberinput__excludeMinimumCheck",
+        NUMERICINPUT_MIN_FIELD = ".cmp-adaptiveform-numberinput__minimum",
+        NUMERICINPUT_MAX_FIELD = ".cmp-adaptiveform-numberinput__maximum",
         NUMERICINPUT_DISPLAYPATTERN = EDIT_DIALOG + " .cmp-adaptiveform-numberinput__displaypattern",
         NUMERICINPUT_DISPLAYFORMAT = EDIT_DIALOG + " .cmp-adaptiveform-numberinput__displayformat",
         NUMERICINPUT_LANG = EDIT_DIALOG + " .cmp-adaptiveform-numberinput__lang",
@@ -96,5 +98,25 @@
         Utils.handlePatternFormat(dialog,NUMERICINPUT_LANGDISPLAYVALUE,NUMERICINPUT_LANG);
     }
 
-    Utils.initializeEditDialog(EDIT_DIALOG)(handleDisplayPatternDropDown,handleDisplayFormat,handleLang, handleTypeDropdown);
+    var NUMBER_COMPARE = function(a, b) { return Number(a) > Number(b); };
+
+    Utils.registerMinMaxValidator(
+        NUMERICINPUT_MIN_FIELD, NUMERICINPUT_MAX_FIELD,
+        "Minimum value cannot be greater than maximum value",
+        "Maximum value cannot be less than minimum value",
+        NUMBER_COMPARE
+    );
+
+    Utils.initializeEditDialog(EDIT_DIALOG)(
+        handleDisplayPatternDropDown,
+        handleDisplayFormat,
+        handleLang,
+        handleTypeDropdown,
+        Utils.handleMinMaxValidation(
+            NUMERICINPUT_MIN_FIELD, NUMERICINPUT_MAX_FIELD,
+            "Minimum value cannot be greater than maximum value",
+            "Maximum value cannot be less than minimum value",
+            NUMBER_COMPARE
+        )
+    );
 })(jQuery);

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/textinput/v1/textinput/clientlibs/editor/js/editDialog.js
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/textinput/v1/textinput/clientlibs/editor/js/editDialog.js
@@ -20,6 +20,8 @@
         TEXTINPUT_ALLOWRICHTEXT = EDIT_DIALOG + " .cmp-adaptiveform-textinput__allowrichtext",
         TEXTINPUT_MAXLENGTH = EDIT_DIALOG + " .cmp-adaptiveform-textinput__maxlength",
         TEXTINPUT_MINLENGTH = EDIT_DIALOG + " .cmp-adaptiveform-textinput__minlength",
+        TEXTINPUT_MIN_FIELD = ".cmp-adaptiveform-textinput__minlength coral-numberinput",
+        TEXTINPUT_MAX_FIELD = ".cmp-adaptiveform-textinput__maxlength coral-numberinput",
         BASE_PLACEHOLDER = EDIT_DIALOG + " .cmp-adaptiveform-base__placeholder",
         TEXTINPUT_VALUE = EDIT_DIALOG + " .cmp-adaptiveform-textinput__value",
         TEXTINPUT_RICHTEXTVALUE = EDIT_DIALOG + " .cmp-adaptiveform-textinput__richtextvalue",
@@ -76,6 +78,23 @@
         patternComponent.addEventListener("change", updateDisplayValueExpression);
     }
 
-    Utils.initializeEditDialog(EDIT_DIALOG)(handleValidationPatternDropDown,handleValidationFormat,handleDisplayPatternDropDown,handleDisplayFormat,handleDisplayValueExpression);
+    Utils.registerMinMaxValidator(
+        TEXTINPUT_MIN_FIELD, TEXTINPUT_MAX_FIELD,
+        "Minimum length cannot be greater than maximum length",
+        "Maximum length cannot be less than minimum length"
+    );
+
+    Utils.initializeEditDialog(EDIT_DIALOG)(
+        handleValidationPatternDropDown,
+        handleValidationFormat,
+        handleDisplayPatternDropDown,
+        handleDisplayFormat,
+        handleDisplayValueExpression,
+        Utils.handleMinMaxValidation(
+            TEXTINPUT_MIN_FIELD, TEXTINPUT_MAX_FIELD,
+            "Minimum length cannot be greater than maximum length",
+            "Maximum length cannot be less than minimum length"
+        )
+    );
 
 })(jQuery);

--- a/ui.tests/test-module/specs/numberinput/numberinput.authoring.cy.js
+++ b/ui.tests/test-module/specs/numberinput/numberinput.authoring.cy.js
@@ -132,6 +132,49 @@ describe('Page - Authoring', function () {
         });
 });
 
+        it('shows inline error when minimum is set greater than maximum', function () {
+            dropNumberInputInContainer();
+            cy.openEditableToolbar(sitesSelectors.overlays.overlay.component + numberInputEditPathSelector);
+            cy.invokeEditableAction(editDialogConfigurationSelector);
+            cy.get(numberInputBlockBemSelector + '__editdialog').contains('Validation').click();
+
+            // Set maximum = 5, then minimum = 10 (invalid: min > max)
+            cy.get(numberInputBlockBemSelector + '__maximum').clear().type('5').blur();
+            cy.get(numberInputBlockBemSelector + '__minimum').clear().type('10').blur();
+
+            // Both fields should be marked invalid
+            cy.get(numberInputBlockBemSelector + '__minimum').should('have.attr', 'invalid');
+            cy.get(numberInputBlockBemSelector + '__maximum').should('have.attr', 'invalid');
+
+            // Fix by lowering minimum below maximum
+            cy.get(numberInputBlockBemSelector + '__minimum').clear().type('3').blur();
+
+            // Both fields should no longer be invalid
+            cy.get(numberInputBlockBemSelector + '__minimum').should('not.have.attr', 'invalid');
+            cy.get(numberInputBlockBemSelector + '__maximum').should('not.have.attr', 'invalid');
+
+            cy.get('.cq-dialog-cancel').should('be.visible').click();
+            cy.deleteComponentByPath(numberInputDrop);
+        });
+
+        it('blocks dialog save when minimum is greater than maximum', function () {
+            dropNumberInputInContainer();
+            cy.openEditableToolbar(sitesSelectors.overlays.overlay.component + numberInputEditPathSelector);
+            cy.invokeEditableAction(editDialogConfigurationSelector);
+            cy.get(numberInputBlockBemSelector + '__editdialog').contains('Validation').click();
+
+            // Set an invalid state: minimum > maximum
+            cy.get(numberInputBlockBemSelector + '__maximum').clear().type('5').blur();
+            cy.get(numberInputBlockBemSelector + '__minimum').clear().type('10').blur();
+
+            // Attempt to save — dialog should remain open
+            cy.get('.cq-dialog-submit').click();
+            cy.get('coral-dialog[open]').should('exist');
+
+            cy.get('.cq-dialog-cancel').should('be.visible').click();
+            cy.deleteComponentByPath(numberInputDrop);
+        });
+
         // todo: leadDigits and fracDigits are not supported as of today
         it.skip('verify editFormat Value Getting saved correctly', function () {
             dropNumberInputInContainer();

--- a/ui.tests/test-module/specs/numberinput/numberinput.authoring.cy.js
+++ b/ui.tests/test-module/specs/numberinput/numberinput.authoring.cy.js
@@ -139,9 +139,9 @@ describe('Page - Authoring', function () {
             cy.get(numberInputBlockBemSelector + '__editdialog').contains('Validation').click();
 
             // Set maximum = 5, then minimum = 10 (invalid: min > max)
-            cy.get(numberInputBlockBemSelector + '__maximum').clear().type('5');
+            cy.get(numberInputBlockBemSelector + '__maximum').find('input').clear().type('5');
             cy.focused().blur();
-            cy.get(numberInputBlockBemSelector + '__minimum').clear().type('10');
+            cy.get(numberInputBlockBemSelector + '__minimum').find('input').clear().type('10');
             cy.focused().blur();
 
             // Both fields should be marked invalid
@@ -149,7 +149,7 @@ describe('Page - Authoring', function () {
             cy.get(numberInputBlockBemSelector + '__maximum').should('have.attr', 'invalid');
 
             // Fix by lowering minimum below maximum
-            cy.get(numberInputBlockBemSelector + '__minimum').clear().type('3');
+            cy.get(numberInputBlockBemSelector + '__minimum').find('input').clear().type('3');
             cy.focused().blur();
 
             // Both fields should no longer be invalid
@@ -167,9 +167,9 @@ describe('Page - Authoring', function () {
             cy.get(numberInputBlockBemSelector + '__editdialog').contains('Validation').click();
 
             // Set an invalid state: minimum > maximum
-            cy.get(numberInputBlockBemSelector + '__maximum').clear().type('5');
+            cy.get(numberInputBlockBemSelector + '__maximum').find('input').clear().type('5');
             cy.focused().blur();
-            cy.get(numberInputBlockBemSelector + '__minimum').clear().type('10');
+            cy.get(numberInputBlockBemSelector + '__minimum').find('input').clear().type('10');
             cy.focused().blur();
 
             // Attempt to save — dialog should remain open

--- a/ui.tests/test-module/specs/numberinput/numberinput.authoring.cy.js
+++ b/ui.tests/test-module/specs/numberinput/numberinput.authoring.cy.js
@@ -139,15 +139,18 @@ describe('Page - Authoring', function () {
             cy.get(numberInputBlockBemSelector + '__editdialog').contains('Validation').click();
 
             // Set maximum = 5, then minimum = 10 (invalid: min > max)
-            cy.get(numberInputBlockBemSelector + '__maximum').clear().type('5').blur();
-            cy.get(numberInputBlockBemSelector + '__minimum').clear().type('10').blur();
+            cy.get(numberInputBlockBemSelector + '__maximum').clear().type('5');
+            cy.focused().blur();
+            cy.get(numberInputBlockBemSelector + '__minimum').clear().type('10');
+            cy.focused().blur();
 
             // Both fields should be marked invalid
             cy.get(numberInputBlockBemSelector + '__minimum').should('have.attr', 'invalid');
             cy.get(numberInputBlockBemSelector + '__maximum').should('have.attr', 'invalid');
 
             // Fix by lowering minimum below maximum
-            cy.get(numberInputBlockBemSelector + '__minimum').clear().type('3').blur();
+            cy.get(numberInputBlockBemSelector + '__minimum').clear().type('3');
+            cy.focused().blur();
 
             // Both fields should no longer be invalid
             cy.get(numberInputBlockBemSelector + '__minimum').should('not.have.attr', 'invalid');
@@ -164,8 +167,10 @@ describe('Page - Authoring', function () {
             cy.get(numberInputBlockBemSelector + '__editdialog').contains('Validation').click();
 
             // Set an invalid state: minimum > maximum
-            cy.get(numberInputBlockBemSelector + '__maximum').clear().type('5').blur();
-            cy.get(numberInputBlockBemSelector + '__minimum').clear().type('10').blur();
+            cy.get(numberInputBlockBemSelector + '__maximum').clear().type('5');
+            cy.focused().blur();
+            cy.get(numberInputBlockBemSelector + '__minimum').clear().type('10');
+            cy.focused().blur();
 
             // Attempt to save — dialog should remain open
             cy.get('.cq-dialog-submit').click();

--- a/ui.tests/test-module/specs/textinput/textinput.authoring.cy.js
+++ b/ui.tests/test-module/specs/textinput/textinput.authoring.cy.js
@@ -218,15 +218,18 @@ describe('Page - Authoring', function () {
             cy.get('.cmp-adaptiveform-textinput__editdialog').contains('Validation').click({force: true});
 
             // Set maxLength = 5, then minLength = 10 (invalid: min > max)
-            cy.get('.cmp-adaptiveform-textinput__maxlength coral-numberinput').clear().type('5').blur();
-            cy.get('.cmp-adaptiveform-textinput__minlength coral-numberinput').clear().type('10').blur();
+            cy.get('.cmp-adaptiveform-textinput__maxlength coral-numberinput').clear().type('5');
+            cy.focused().blur();
+            cy.get('.cmp-adaptiveform-textinput__minlength coral-numberinput').clear().type('10');
+            cy.focused().blur();
 
             // Both fields should be marked invalid
             cy.get('.cmp-adaptiveform-textinput__minlength coral-numberinput').should('have.attr', 'invalid');
             cy.get('.cmp-adaptiveform-textinput__maxlength coral-numberinput').should('have.attr', 'invalid');
 
             // Fix by lowering minLength below maxLength
-            cy.get('.cmp-adaptiveform-textinput__minlength coral-numberinput').clear().type('3').blur();
+            cy.get('.cmp-adaptiveform-textinput__minlength coral-numberinput').clear().type('3');
+            cy.focused().blur();
 
             // Both fields should no longer be invalid
             cy.get('.cmp-adaptiveform-textinput__minlength coral-numberinput').should('not.have.attr', 'invalid');
@@ -243,8 +246,10 @@ describe('Page - Authoring', function () {
             cy.get('.cmp-adaptiveform-textinput__editdialog').contains('Validation').click({force: true});
 
             // Set an invalid state: minLength > maxLength
-            cy.get('.cmp-adaptiveform-textinput__maxlength coral-numberinput').clear().type('5').blur();
-            cy.get('.cmp-adaptiveform-textinput__minlength coral-numberinput').clear().type('10').blur();
+            cy.get('.cmp-adaptiveform-textinput__maxlength coral-numberinput').clear().type('5');
+            cy.focused().blur();
+            cy.get('.cmp-adaptiveform-textinput__minlength coral-numberinput').clear().type('10');
+            cy.focused().blur();
 
             // Attempt to save — dialog should remain open
             cy.get('.cq-dialog-submit').click();

--- a/ui.tests/test-module/specs/textinput/textinput.authoring.cy.js
+++ b/ui.tests/test-module/specs/textinput/textinput.authoring.cy.js
@@ -218,9 +218,9 @@ describe('Page - Authoring', function () {
             cy.get('.cmp-adaptiveform-textinput__editdialog').contains('Validation').click({force: true});
 
             // Set maxLength = 5, then minLength = 10 (invalid: min > max)
-            cy.get('.cmp-adaptiveform-textinput__maxlength coral-numberinput').clear().type('5');
+            cy.get('.cmp-adaptiveform-textinput__maxlength coral-numberinput').find('input').clear().type('5');
             cy.focused().blur();
-            cy.get('.cmp-adaptiveform-textinput__minlength coral-numberinput').clear().type('10');
+            cy.get('.cmp-adaptiveform-textinput__minlength coral-numberinput').find('input').clear().type('10');
             cy.focused().blur();
 
             // Both fields should be marked invalid
@@ -228,7 +228,7 @@ describe('Page - Authoring', function () {
             cy.get('.cmp-adaptiveform-textinput__maxlength coral-numberinput').should('have.attr', 'invalid');
 
             // Fix by lowering minLength below maxLength
-            cy.get('.cmp-adaptiveform-textinput__minlength coral-numberinput').clear().type('3');
+            cy.get('.cmp-adaptiveform-textinput__minlength coral-numberinput').find('input').clear().type('3');
             cy.focused().blur();
 
             // Both fields should no longer be invalid
@@ -246,9 +246,9 @@ describe('Page - Authoring', function () {
             cy.get('.cmp-adaptiveform-textinput__editdialog').contains('Validation').click({force: true});
 
             // Set an invalid state: minLength > maxLength
-            cy.get('.cmp-adaptiveform-textinput__maxlength coral-numberinput').clear().type('5');
+            cy.get('.cmp-adaptiveform-textinput__maxlength coral-numberinput').find('input').clear().type('5');
             cy.focused().blur();
-            cy.get('.cmp-adaptiveform-textinput__minlength coral-numberinput').clear().type('10');
+            cy.get('.cmp-adaptiveform-textinput__minlength coral-numberinput').find('input').clear().type('10');
             cy.focused().blur();
 
             // Attempt to save — dialog should remain open

--- a/ui.tests/test-module/specs/textinput/textinput.authoring.cy.js
+++ b/ui.tests/test-module/specs/textinput/textinput.authoring.cy.js
@@ -211,6 +211,49 @@ describe('Page - Authoring', function () {
             });
         });
 
+        it('shows inline error when minLength is set greater than maxLength', function () {
+            dropTextInputInContainer();
+            cy.openEditableToolbar(sitesSelectors.overlays.overlay.component + textInputEditPathSelector);
+            cy.invokeEditableAction("[data-action='CONFIGURE']");
+            cy.get('.cmp-adaptiveform-textinput__editdialog').contains('Validation').click({force: true});
+
+            // Set maxLength = 5, then minLength = 10 (invalid: min > max)
+            cy.get('.cmp-adaptiveform-textinput__maxlength coral-numberinput').clear().type('5').blur();
+            cy.get('.cmp-adaptiveform-textinput__minlength coral-numberinput').clear().type('10').blur();
+
+            // Both fields should be marked invalid
+            cy.get('.cmp-adaptiveform-textinput__minlength coral-numberinput').should('have.attr', 'invalid');
+            cy.get('.cmp-adaptiveform-textinput__maxlength coral-numberinput').should('have.attr', 'invalid');
+
+            // Fix by lowering minLength below maxLength
+            cy.get('.cmp-adaptiveform-textinput__minlength coral-numberinput').clear().type('3').blur();
+
+            // Both fields should no longer be invalid
+            cy.get('.cmp-adaptiveform-textinput__minlength coral-numberinput').should('not.have.attr', 'invalid');
+            cy.get('.cmp-adaptiveform-textinput__maxlength coral-numberinput').should('not.have.attr', 'invalid');
+
+            cy.get('.cq-dialog-cancel').should('be.visible').click();
+            cy.deleteComponentByPath(textInputDrop);
+        });
+
+        it('blocks dialog save when minLength is greater than maxLength', function () {
+            dropTextInputInContainer();
+            cy.openEditableToolbar(sitesSelectors.overlays.overlay.component + textInputEditPathSelector);
+            cy.invokeEditableAction("[data-action='CONFIGURE']");
+            cy.get('.cmp-adaptiveform-textinput__editdialog').contains('Validation').click({force: true});
+
+            // Set an invalid state: minLength > maxLength
+            cy.get('.cmp-adaptiveform-textinput__maxlength coral-numberinput').clear().type('5').blur();
+            cy.get('.cmp-adaptiveform-textinput__minlength coral-numberinput').clear().type('10').blur();
+
+            // Attempt to save — dialog should remain open
+            cy.get('.cq-dialog-submit').click();
+            cy.get('coral-dialog[open]').should('exist');
+
+            cy.get('.cq-dialog-cancel').should('be.visible').click();
+            cy.deleteComponentByPath(textInputDrop);
+        });
+
         it('should switch validation pattern dropdown to "Custom" when an unmapped regex is authored', function () {
             const customValidationFormatValue = '^custom-regex-[0-9]{3}$';
 


### PR DESCRIPTION
Prevent authors from setting a minimum value greater than its paired maximum (minLength/maxLength, minimum/maximum, minItems/maxItems, minimumDate/maximumDate, minimumDateTime/maximumDateTime, minOccur/maxOccur) across all affected form components.

All pairs are registered centrally in Utils so new components only need one entry added — no per-component editDialog.js changes required. Real-time inline feedback via change listeners; dialog save blocked via foundation.validation.validator registered once at page load.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
