### PR TITLE
fix(af-core): stop dropping properties and properties.$path rule targets

### DIFF
--- a/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImpl.java
+++ b/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImpl.java
@@ -377,11 +377,15 @@ public class AbstractFormComponentImpl extends AbstractComponentImpl implements 
      */
     protected final Map<String, String> getRulesForResource(Resource resource) {
         String[] VALID_RULES = new String[] { "description", "enabled", "enum", "enumNames",
-            "exclusiveMaximum", "exclusiveMinimum", "label", "maximum", "minimum",
+            "exclusiveMaximum", "exclusiveMinimum", "label", "maximum", "minimum", "properties",
             "readOnly", "required", "value", "visible" };
 
-        Predicate<Map.Entry<String, Object>> isRuleNameValid = obj -> Arrays.stream(VALID_RULES).anyMatch(validKey -> validKey.equals(obj
-            .getKey()));
+        // A rule target may be one of the fixed editable properties (which includes the whole
+        // `properties` bag), or a granular custom-variable target keyed `properties.<path>` (e.g.
+        // properties.employer or properties.employer.category) that the runtime routes to the
+        // PropertiesManager per key. Preserve both the bag and the per-key targets.
+        Predicate<Map.Entry<String, Object>> isRuleNameValid = obj -> obj.getKey().startsWith("properties.")
+            || Arrays.stream(VALID_RULES).anyMatch(validKey -> validKey.equals(obj.getKey()));
 
         Predicate<Map.Entry<String, Object>> isRuleValid = isEntryNonEmpty.and(isRuleNameValid);
 

--- a/bundles/af-core/src/test/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImplTest.java
+++ b/bundles/af-core/src/test/java/com/adobe/cq/forms/core/components/util/AbstractFormComponentImplTest.java
@@ -53,6 +53,7 @@ public class AbstractFormComponentImplTest {
     private static final String PATH_COMPONENT_WITH_NO_VALIDATION_STATUS = CONTENT_ROOT + "/datepicker2";
     private static final String PATH_COMPONENT_WITH_INVALID_VALIDATION_STATUS = CONTENT_ROOT + "/datepicker3";
     private static final String PATH_COMPONENT_WITH_NO_RULE = CONTENT_ROOT + "/numberinput";
+    private static final String PATH_COMPONENT_WITH_PROPERTIES_RULE = CONTENT_ROOT + "/textinputWithPropertiesRule";
     private static final String PATH_COMPONENT_WITH_DISABLED_XFA_SCRIPTS = CONTENT_ROOT + "/xfacomponent";
     private static final String PATH_COMPONENT_WITH_INVALID_XFA_SCRIPTS = CONTENT_ROOT + "/xfacomponentinvalid";
     private static final String PATH_COMPONENT_WITH_NO_XFA_SCRIPTS = CONTENT_ROOT + "/xfacomponentnone";
@@ -145,6 +146,39 @@ public class AbstractFormComponentImplTest {
         Map<String, Object> properties = abstractFormComponentImpl.getProperties();
         assertNull(properties.get("fd:rules"),
             "fd:rules should not appear when publish view attribute is set even in author WCMMode");
+    }
+
+    @Test
+    public void testGranularPropertiesRulesPreserved() {
+        // A rule keyed `properties.<path>` is a granular custom-variable target routed by the
+        // runtime to the PropertiesManager; the exporter must not drop flat or nested ones.
+        AbstractFormComponentImpl abstractFormComponentImpl = prepareTestClass(PATH_COMPONENT_WITH_PROPERTIES_RULE);
+        Map<String, String> rules = abstractFormComponentImpl.getRules();
+        assertEquals("some property expression", rules.get("properties.employer"),
+            "flat properties.<key> rule should be preserved");
+        assertEquals("some nested property expression", rules.get("properties.employer.category"),
+            "nested properties.<a.b> rule should be preserved");
+    }
+
+    @Test
+    public void testBarePropertiesAndWhitelistedRulesPreserved() {
+        // The whole `properties` bag is an editable property, and standard whitelisted targets
+        // (e.g. visible) must keep working alongside the granular properties.<path> targets.
+        AbstractFormComponentImpl abstractFormComponentImpl = prepareTestClass(PATH_COMPONENT_WITH_PROPERTIES_RULE);
+        Map<String, String> rules = abstractFormComponentImpl.getRules();
+        assertEquals("some expression", rules.get("visible"));
+        assertEquals("merge($field.properties, {a: 1})", rules.get("properties"),
+            "the whole properties bag rule should be preserved");
+    }
+
+    @Test
+    public void testUnknownRulesDropped() {
+        // Keys that are neither whitelisted nor a genuine properties.<path> target are filtered
+        // out, including a `properties`-prefixed key without the dot separator.
+        AbstractFormComponentImpl abstractFormComponentImpl = prepareTestClass(PATH_COMPONENT_WITH_PROPERTIES_RULE);
+        Map<String, String> rules = abstractFormComponentImpl.getRules();
+        assertNull(rules.get("notARule"), "non-whitelisted, non-properties rule keys should be dropped");
+        assertNull(rules.get("propertiesFoo"), "a properties-prefixed key without a dot is not a valid target");
     }
 
     @Test

--- a/bundles/af-core/src/test/resources/form/componentswithrule/test-content.json
+++ b/bundles/af-core/src/test/resources/form/componentswithrule/test-content.json
@@ -15,6 +15,21 @@
     "sling:resourceType": "forms-components-examples/components/form/numberinput",
     "fieldType": "number-input"
   },
+  "textinputWithPropertiesRule": {
+    "jcr:primaryType": "nt:unstructured",
+    "name": "name",
+    "sling:resourceType": "forms-components-examples/components/form/textinput",
+    "fieldType": "text-input",
+    "fd:rules": {
+      "jcr:primaryType": "nt:unstructured",
+      "visible": "some expression",
+      "properties": "merge($field.properties, {a: 1})",
+      "properties.employer": "some property expression",
+      "properties.employer.category": "some nested property expression",
+      "notARule": "should be dropped",
+      "propertiesFoo": "should be dropped"
+    }
+  },
   "datepicker": {
     "jcr:primaryType": "nt:unstructured",
     "name": "datepicker1666939496905",


### PR DESCRIPTION
## Problem

`AbstractFormComponentImpl.getRulesForResource` filters `fd:rules` keys against a fixed `VALID_RULES` whitelist using **exact string match**. The forms runtime supports:

- the whole `properties` bag as an editable property, and
- granular per-key targets keyed `properties.<path>` — `properties.x` (flat) and `properties.x.y` (nested) — routed to the `PropertiesManager` (see af2-web-runtime `6eea762a`, "support granular properties.<key> rule target").

Neither `properties` nor `properties.<path>` was in the whitelist, so these rules were **silently stripped** from the exported form JSON — the runtime feature never received its rules.

## Fix

- Add `properties` to `VALID_RULES` (the whole bag is an editable property).
- Accept any key prefixed `properties.` so flat and nested per-key targets survive.
- Keys that are neither whitelisted nor a genuine `properties.<path>` target (including a `properties`-prefixed key without the dot, e.g. `propertiesFoo`) are still filtered out.

All three supported forms now export: `properties`, `properties.x`, `properties.x.y`.

## Tests

Added `textinputWithPropertiesRule` fixture and three cases in `AbstractFormComponentImplTest`:
- `testGranularPropertiesRulesPreserved` — flat + nested preserved
- `testBarePropertiesAndWhitelistedRulesPreserved` — whole bag + `visible` preserved
- `testUnknownRulesDropped` — `notARule` and `propertiesFoo` dropped

Verified failing before the fix, passing after. Full `AbstractFormComponentImplTest` green (30 tests).

## Note — companion spec/schema change

The adaptive-form JSON schema restricts `rules` keys via `propertyNames.enum` (lists `properties` but not `properties.*`). That schema is a versioned snapshot of the published spec and is **not** touched here. For full spec conformance the authoritative schema needs its `rules` `propertyNames` to also permit a `^properties\.` pattern. Runtime does not enforce the schema, so this exporter fix makes the feature work end-to-end today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)