### PR TITLE
FORMS-24185: add regression test for fragment without a panel

### DIFF
--- a/ui.tests/test-module/specs/fragment/fragment.runtime.cy.js
+++ b/ui.tests/test-module/specs/fragment/fragment.runtime.cy.js
@@ -210,3 +210,36 @@ describe("Form Runtime with Fragment", () => {
         cy.get(`#${model.items[0].id}`).should('have.text', 'Thanks');
     });
 })
+
+describe("Form Runtime with Fragment without a panel", () => {
+    // Regression test for FORMS-24185 (found while fixing FORMS-24163).
+    // PR #1603 (reverted) added an updateLabel override that derived the BEM class from
+    // the element's classList and assumed a `.<bemClass>__label-container` descendant always
+    // exists. That assumption broke rendering (with a console error) for a fragment whose
+    // fragmentPath resolves directly to fields with no wrapping panel. The other fixture used
+    // in this file (test-fragment) always wraps its fields in a panel, so this shape went
+    // uncaught; container-rules.html embeds test-fragment-container-rules, which has none.
+    const pagePath = "content/forms/af/core-components-it/samples/fragment/container-rules.html";
+    const bemBlock = 'cmp-adaptiveform-fragment';
+
+    before(() => {
+        cy.attachConsoleErrorSpy();
+    });
+
+    it("renders the fragment and its label without a console error", () => {
+        cy.previewForm(pagePath).then(formContainer => {
+            expect(formContainer, "formContainer is initialized").to.not.be.null;
+
+            const [textInputId] = Object.entries(formContainer._fields)[0];
+            cy.get(`#${textInputId}`).should('be.visible');
+
+            // Only asserting the container exists here - checked against a live author
+            // (localhost:4502) and this page's fragment label doesn't render text via this
+            // element on this content, so a stricter text/visibility check on `__label`
+            // would be asserting behavior this fixture doesn't actually exhibit.
+            cy.get(`.${bemBlock}__label-container`).should('exist');
+
+            cy.expectNoConsoleErrors();
+        });
+    });
+})


### PR DESCRIPTION
PR #1603 (reverted, see FORMS-24163) assumed every fragment's label container used the generic panel class, which threw when a fragment's fragmentPath resolved directly to fields with no wrapping panel. The existing fixture (test-fragment) always wraps fields in a panel, so this shape went uncaught. Reuses the existing container-rules.html page, which already embeds a panel-less fragment.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
