### PR TITLE
FORMS-26813: Show custom acceptMessage for unsupported file type in File Attachment

### DIFF
--- a/it/content/src/main/content/jcr_root/content/forms/af/core-components-it/samples/fileinput/fileinputv4/basic/.content.xml
+++ b/it/content/src/main/content/jcr_root/content/forms/af/core-components-it/samples/fileinput/fileinputv4/basic/.content.xml
@@ -53,6 +53,7 @@
                     jcr:title="File Input - 3"
                     sling:resourceType="core/fd/components/form/fileinput/v4/fileinput"
                     accept="[application/pdf]"
+                    acceptMessage="This file type is not supported!"
                     description="This is long description"
                     fieldType="file-input"
                     id="fileinput_tooltip_scenario_test"

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/fileinput/v4/fileinput/clientlibs/site/js/fileinputwidget.js
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/fileinput/v4/fileinput/clientlibs/site/js/fileinputwidget.js
@@ -183,7 +183,7 @@ if (typeof window.FileInputWidget === 'undefined') {
             const messages = {
                 [this.invalidFeature.SIZE]: customMessages.maxFileSize || FormView.LanguageUtils.getTranslatedString(this.lang, "FileSizeGreater", [fileNames, this.options.maxFileSize]),
                 [this.invalidFeature.NAME]: customMessages.invalidFileName || FormView.LanguageUtils.getTranslatedString(this.lang, "FileNameInvalid", [fileNames]),
-                [this.invalidFeature.MIMETYPE]: customMessages.invalidMimeType || FormView.LanguageUtils.getTranslatedString(this.lang, "FileMimeTypeInvalid", [fileNames]),
+                [this.invalidFeature.MIMETYPE]: customMessages.accept || FormView.LanguageUtils.getTranslatedString(this.lang, "FileMimeTypeInvalid", [fileNames]),
                 [this.invalidFeature.SIZE_ZERO]: customMessages.zeroFileSize || FormView.LanguageUtils.getTranslatedString(this.lang, "FileSizeZero", [fileNames])
             };
             return messages[invalidFeature];

--- a/ui.frontend/src/view/FormFileInputWidgetBase.js
+++ b/ui.frontend/src/view/FormFileInputWidgetBase.js
@@ -338,7 +338,7 @@ class FormFileInputWidgetBase {
             const messages = {
                 [this.invalidFeature.SIZE]: customMessages.maxFileSize || FormView.LanguageUtils.getTranslatedString(this.lang, "FileSizeGreater", [fileName, this.options.maxFileSize]),
                 [this.invalidFeature.NAME]: customMessages.invalidFileName || FormView.LanguageUtils.getTranslatedString(this.lang, "FileNameInvalid", [fileName]),
-                [this.invalidFeature.MIMETYPE]: customMessages.invalidMimeType || FormView.LanguageUtils.getTranslatedString(this.lang, "FileMimeTypeInvalid", [fileName])
+                [this.invalidFeature.MIMETYPE]: customMessages.accept || FormView.LanguageUtils.getTranslatedString(this.lang, "FileMimeTypeInvalid", [fileName])
             };
         
             alert(messages[invalidFeature]);

--- a/ui.tests/test-module/specs/fileinput/fileinputv4.runtime.cy.js
+++ b/ui.tests/test-module/specs/fileinput/fileinputv4.runtime.cy.js
@@ -272,6 +272,16 @@ describe('Click on button tag (V-4)', () => {
         });
     });
 
+    it('should display a custom error message configured by the user for unsupported file type', () => {
+        const [id, fieldView] = Object.entries(formContainer._fields)[2];
+        const model = formContainer._model.getElement(id);
+        const fileInput = "input[name='fileinput3']";
+        cy.attachFile(fileInput, ['sample.svg']);
+        cy.on('window:alert', (alertText) => {
+            expect(alertText).to.equal(model.getState().constraintMessages.accept);
+        });
+    });
+
     it('file when uploaded again should give actual size', () => {
         let sampleFileNames = ['sample.svg'];
         const fileInput = "input[name='fileinput2']";


### PR DESCRIPTION
Backport #1928 

The File Attachment (fileinput) widget's invalidMessage() looked up the custom unsupported-file-type message under constraintMessages.invalidMimeType, which is not a real constraint key. The authorable key is `accept` (ConstraintType.ACCEPT), backed by the acceptMessage dialog property, so the custom message was always undefined and a generic fallback was shown. The maxFileSize custom message worked because it already uses the correct key.

Fix: read constraintMessages.accept for the MIMETYPE case, in both the ui.frontend source (FormFileInputWidgetBase.js) and the v4 clientlib copy (fileinputwidget.js). Backport of master PR #1928 to release/650.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
