### PR TITLE
Show custom acceptMessage for unsupported file type in File Attachment

### DIFF
--- a/it/content/src/main/content/jcr_root/content/forms/af/core-components-it/samples/fileinput/fileinputv4/basic/.content.xml
+++ b/it/content/src/main/content/jcr_root/content/forms/af/core-components-it/samples/fileinput/fileinputv4/basic/.content.xml
@@ -108,6 +108,7 @@
                     jcr:title="File Input - 7"
                     sling:resourceType="core/fd/components/form/fileinput/v4/fileinput"
                     accept="[audio/*, video/*, image/*, text/*, application/pdf,.ifc]"
+                    acceptMessage="This file type is not supported!"
                     fieldType="file-input"
                     readOnly="{Boolean}false"
                     name="fileinput7"

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/fileinput/v4/fileinput/clientlibs/site/js/fileinputwidget.js
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/fileinput/v4/fileinput/clientlibs/site/js/fileinputwidget.js
@@ -191,7 +191,7 @@ if (typeof window.FileInputWidget === 'undefined') {
             const messages = {
                 [this.invalidFeature.SIZE]: customMessages.maxFileSize || FormView.LanguageUtils.getTranslatedString(this.lang, "FileSizeGreater", [fileNames, this.options.maxFileSize]),
                 [this.invalidFeature.NAME]: customMessages.invalidFileName || FormView.LanguageUtils.getTranslatedString(this.lang, "FileNameInvalid", [fileNames]),
-                [this.invalidFeature.MIMETYPE]: customMessages.invalidMimeType || FormView.LanguageUtils.getTranslatedString(this.lang, "FileMimeTypeInvalid", [fileNames]),
+                [this.invalidFeature.MIMETYPE]: customMessages.accept || FormView.LanguageUtils.getTranslatedString(this.lang, "FileMimeTypeInvalid", [fileNames]),
                 [this.invalidFeature.SIZE_ZERO]: customMessages.zeroFileSize || FormView.LanguageUtils.getTranslatedString(this.lang, "FileSizeZero", [fileNames])
             };
             return messages[invalidFeature];

--- a/ui.frontend/src/view/FormFileInputWidgetBase.js
+++ b/ui.frontend/src/view/FormFileInputWidgetBase.js
@@ -340,7 +340,7 @@ class FormFileInputWidgetBase {
             const messages = {
                 [this.invalidFeature.SIZE]: customMessages.maxFileSize || FormView.LanguageUtils.getTranslatedString(this.lang, "FileSizeGreater", [fileName, this.options.maxFileSize]),
                 [this.invalidFeature.NAME]: customMessages.invalidFileName || FormView.LanguageUtils.getTranslatedString(this.lang, "FileNameInvalid", [fileName]),
-                [this.invalidFeature.MIMETYPE]: customMessages.invalidMimeType || FormView.LanguageUtils.getTranslatedString(this.lang, "FileMimeTypeInvalid", [fileName])
+                [this.invalidFeature.MIMETYPE]: customMessages.accept || FormView.LanguageUtils.getTranslatedString(this.lang, "FileMimeTypeInvalid", [fileName])
             };
         
             alert(messages[invalidFeature]);

--- a/ui.tests/test-module/specs/fileinput/fileinputv4.runtime.cy.js
+++ b/ui.tests/test-module/specs/fileinput/fileinputv4.runtime.cy.js
@@ -272,6 +272,16 @@ describe('Click on button tag (V-4)', () => {
         });
     });
 
+    it('should display a custom error message configured by the user for unsupported file type', () => {
+        const [id, fieldView] = Object.entries(formContainer._fields)[6];
+        const model = formContainer._model.getElement(id);
+        const fileInput = 'input[name=\'fileinput7\']';
+        cy.attachFile(fileInput, ['sample.afe']);
+        cy.on('window:alert', (alertText) => {
+            expect(alertText).to.equal(model.getState().constraintMessages.accept);
+        });
+    });
+
     it('file when uploaded again should give actual size', () => {
         let sampleFileNames = ['sample.svg'];
         const fileInput = "input[name='fileinput2']";


### PR DESCRIPTION
Original PR #1928 couldn't be merged due to a fork. 

## Summary
- The file-input widget's `invalidMessage()` looked up `constraintMessages.invalidMimeType` for the "unsupported file type" alert, but `invalidMimeType` is not an authorable constraint message key — the schema only exposes `constraintMessages.accept` (backed by the `acceptMessage` dialog property, see `AbstractBaseImpl.ConstraintMessages#getAcceptConstraintMessage`).
- As a result, the custom message authors configure for file-type validation was always ignored in favor of the generic fallback string, while the analogous `maxFileSize` custom message worked correctly since its key matched (`constraintMessages.maxFileSize`).
- Fixed in both the webpack source (`ui.frontend/src/view/FormFileInputWidgetBase.js`) and the apps clientlib copy (`ui.af.apps/.../fileinput/v4/fileinput/clientlibs/site/js/fileinputwidget.js`).

## Root cause (reproduced live)
| File uploaded | Alert before fix | Alert after fix |
|---|---|---|
| Oversized file (allowed type) | Custom `maxFileSize` message ✅ | unchanged ✅ |
| Unsupported file type | Generic fallback message ❌ (ignored author's `acceptMessage`) | Custom `accept`/`acceptMessage` text ✅ |

## Test plan
- [x] `node --check` on both modified JS files
- [x] Added Cypress test `should display a custom error message configured by the user for unsupported file type` in `fileinputv4.runtime.cy.js`, mirroring the existing `maxFileSize` custom-message test
- [x] Added `acceptMessage` to the `fileinput7` fixture field in the IT sample content used by that spec
- [ ] Full Cypress IT run against a live AEM instance (not run in this environment — no AEM instance available)