### PR TITLE
fix: add jcr:primaryType to table child node in tablerow and tableheader

### DIFF
--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/tableheader/v1/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/tableheader/v1/.content.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
           jcr:primaryType="nt:unstructured">
-    <table/>
+    <tableheader/>
 </jcr:root>

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/tableheader/v1/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/tableheader/v1/.content.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
           jcr:primaryType="nt:unstructured">
-    <tableheader/>
+    <tableheader jcr:primaryType="nt:unstructured"/>
 </jcr:root>

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/tablerow/v1/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/tablerow/v1/.content.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
           jcr:primaryType="nt:unstructured">
-    <tablerow/>
+    <tablerow jcr:primaryType="nt:unstructured"/>
 </jcr:root>

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/tablerow/v1/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/tablerow/v1/.content.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
           jcr:primaryType="nt:unstructured">
-    <table/>
+    <tablerow/>
 </jcr:root>


### PR DESCRIPTION
Filevault rejects empty nodes without jcr:primaryType when filter mode=replace.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
