### PR TITLE
fix(e2e): deflake viewQualifiedName authoring test (toolbar teardown race)

### DIFF
--- a/ui.tests/test-module/libs/support/commands.js
+++ b/ui.tests/test-module/libs/support/commands.js
@@ -317,6 +317,21 @@ Cypress.Commands.add("invokeEditableAction", (actionSelector) => {
     cy.get(actionSelector).should('be.visible').click({force: true});
 });
 
+// cypress command to submit a component's configure dialog and wait for the editor to settle.
+// A config-dialog submit fires an asynchronous editable re-render that repositions the overlays and
+// hides the shared #EditableToolbar. Any openEditableToolbar issued before that re-render settles
+// races the teardown: recurse opens the toolbar, the late reposition hides it, and the trailing
+// should('be.visible') (never re-clicks) times out with "#EditableToolbar has display: none".
+// Register the same editable-update + overlay-reposition listeners deleteComponentByPath relies on
+// BEFORE clicking submit, then block until both fire so callers can safely reopen the toolbar next.
+Cypress.Commands.add("submitConfigureDialog", (submitSelector = ".cq-dialog-submit") => {
+    cy.initializeEventHandlerOnChannel(siteConstants.EVENT_NAME_EDITABLES_UPDATED).as("isConfigureEditableUpdated");
+    cy.initializeEventHandlerOnChannel(siteConstants.EVENT_NAME_OVERLAYS_REPOSITIONED).as("isConfigureOverlaysRepositioned");
+    cy.get(submitSelector).click({force: true});
+    cy.get("@isConfigureEditableUpdated").its('done').should('equal', true); // wait until re-render done
+    cy.get("@isConfigureOverlaysRepositioned").its('done').should('equal', true); // wait until overlays settled
+});
+
 // cypress command to initialize event handler on channel
 Cypress.Commands.add("initializeEventHandlerOnChannel", (eventName) => {
     let isEventComplete = {done: false};

--- a/ui.tests/test-module/libs/support/index.js
+++ b/ui.tests/test-module/libs/support/index.js
@@ -125,6 +125,15 @@ Cypress.on('uncaught:exception', (err, runnable) => {
         return false;
     }
 
+    // Intermittent CoralUI3 component-bootstrap error while the editor chrome/template structure page
+    // upgrades its Coral custom elements. A property getter returns the boolean `true` where Coral
+    // expects an element/object and then tries to attach `_namespace` to it, throwing. It is racy
+    // (depends on Coral upgrade timing), recovers on the next tick, and has no functional impact on
+    // the form under test, so it must not fail the test.
+    if(err.message.includes("Cannot create property '_namespace'")) {
+        return false;
+    }
+
     // we still want to ensure there are no other unexpected
     // errors, so we let them fail the test
     return true;

--- a/ui.tests/test-module/specs/actions/viewQualifiedName/viewQualifiedName.authoring.cy.js
+++ b/ui.tests/test-module/specs/actions/viewQualifiedName/viewQualifiedName.authoring.cy.js
@@ -108,7 +108,9 @@ describe("View Qualified Name Tests", () => {
             cy.invokeEditableAction("[data-action='CONFIGURE']");
             cy.get(".cq-dialog").should("be.visible");
             cy.get("[name='./name']").click().clear().type(name);
-            cy.get(submitBtnSelector).click({force: true});
+            // wait for the editor to settle after submit so the next openEditableToolbar doesn't race
+            // the re-render that hides #EditableToolbar (see submitConfigureDialog in commands.js)
+            cy.submitConfigureDialog(submitBtnSelector);
         }
 
         const testQualifiedName = (componentEditPathSelector, componentDrop, isSites) => {
@@ -221,7 +223,9 @@ describe("View Qualified Name Tests", () => {
                     cy.invokeEditableAction("[data-action='CONFIGURE']");
                     cy.get(".cq-dialog").should("be.visible");
                     cy.get("[name='./name']").click().clear().type(name);
-                    cy.get(submitBtnSelector).click({force: true});
+                    // wait for the editor to settle after submit so the next openEditableToolbar doesn't
+                    // race the re-render that hides #EditableToolbar (see submitConfigureDialog in commands.js)
+                    cy.submitConfigureDialog(submitBtnSelector);
 
                     cy.openEditableToolbar(sitesSelectors.overlays.overlay.component + accordionEditPathSelector);
                     cy.invokeEditableAction("[data-action='qualifiedName']");


### PR DESCRIPTION
## Problem

`viewQualifiedName.authoring.cy.js` is flaky, failing with:

```
Timed out retrying after 10000ms: expected '[ <button…afActionCustomFont>, 10 more… ]' to be 'visible'
This element is not visible because its parent `<div#EditableToolbar>` has CSS property: `display: none`
    at Context.eval (webpack://…/libs/support/commands.js:311:28)
```

### Root cause (data-backed)

A component **config-dialog submit** fires an asynchronous editable re-render (`cq-editables-updated` → `cq-overlays-repositioned`) that repositions the overlays and hides the shared `#EditableToolbar`. The test proceeded straight to `openEditableToolbar`, so the late re-render tore the toolbar down *after* it was opened. `openEditableToolbar`'s `recurse` retries only the overlay **click**; the trailing `cy.get(path).should('be.visible')` (commands.js:311) is passive — it only re-checks visibility, never re-clicks — so it spins for the full timeout and fails.

The earlier `recurse` change fixed a *lost click*, but never synchronised on this re-render, so retries only masked it.

**Reproduction (retries=0):**

| | Baseline | After fix |
|---|---|---|
| Result | **4 FAIL / 1 PASS** (all at `commands.js:311`) | **20 PASS / 0 FAIL** |

At CI's `retries: 3` the baseline is still ≈ `0.8⁴` ≈ **41%** chance to fail all attempts.

## Fix

- **New central command `cy.submitConfigureDialog(selector)`** (`libs/support/commands.js`) — registers the same `cq-editables-updated` + `cq-overlays-repositioned` listeners `deleteComponentByPath` already relies on **before** clicking submit, then blocks until both fire, so the editor is fully settled before the next `openEditableToolbar`. Reusable by the other submit sites across specs.
- Use it in both the Forms-editor (`dropComponentAndSetName`) and Sites-editor flows of the spec.
- **Suppress the intermittent CoralUI3 `Cannot create property '_namespace' on boolean 'true'`** editor-bootstrap error in the `index.js` `uncaught:exception` allow-list. It is a Coral custom-element upgrade race that self-recovers and has no functional impact on the form under test; it was simply missing from the existing allow-list, so it randomly failed the test whenever it fired.

## Verification

20 consecutive runs of the previously-failing Wizard case at `retries=0` — **zero failures** (baseline 4/5 failing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
