### PR TITLE
feat(FormContainer): emit fd:setPropertyBehaviour form property

### DIFF
--- a/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/internal/form/ReservedProperties.java
+++ b/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/internal/form/ReservedProperties.java
@@ -176,6 +176,7 @@ public final class ReservedProperties {
 
     public static final String FD_DRAFT_ID = "fd:draftId";
     public static final String FD_CHANGE_EVENT_BEHAVIOUR = "fd:changeEventBehaviour";
+    public static final String FD_SET_PROPERTY_BEHAVIOUR = "fd:setPropertyBehaviour";
 
     public static final String PN_CQ_ANNOTATIONS = "cq:annotations";
 

--- a/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/internal/models/v2/form/FormContainerImpl.java
+++ b/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/internal/models/v2/form/FormContainerImpl.java
@@ -150,6 +150,10 @@ public class FormContainerImpl extends AbstractContainerImpl implements FormCont
     @Nullable
     private String changeEventBehaviour;
 
+    @ValueMapValue(name = ReservedProperties.FD_SET_PROPERTY_BEHAVIOUR, injectionStrategy = InjectionStrategy.OPTIONAL)
+    @Nullable
+    private String setPropertyBehaviour;
+
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL, name = ReservedProperties.PN_DATA)
     @Nullable
     private String data;
@@ -421,6 +425,12 @@ public class FormContainerImpl extends AbstractContainerImpl implements FormCont
         // toggle is disabled the default above is absent, so this simply sets the node-authored value.
         if (StringUtils.isNotBlank(changeEventBehaviour)) {
             properties.put(ReservedProperties.FD_CHANGE_EVENT_BEHAVIOUR, changeEventBehaviour);
+        }
+        // fd:setPropertyBehaviour ("async" default | "eager") opts a form into read-after-write for
+        // setProperty / rule-node writes. Node-authored value is emitted as-is; no toggle-driven default
+        // (unlike changeEventBehaviour) since the runtime defaults to the backward-compatible "async".
+        if (StringUtils.isNotBlank(setPropertyBehaviour)) {
+            properties.put(ReservedProperties.FD_SET_PROPERTY_BEHAVIOUR, setPropertyBehaviour);
         }
         properties.put(FD_FORM_DATA_ENABLED, formDataEnabled);
         if (this.autoSaveConfig != null && this.autoSaveConfig.isEnableAutoSave()) {

--- a/bundles/af-core/src/test/java/com/adobe/cq/forms/core/components/internal/models/v2/form/FormContainerImplTest.java
+++ b/bundles/af-core/src/test/java/com/adobe/cq/forms/core/components/internal/models/v2/form/FormContainerImplTest.java
@@ -679,6 +679,21 @@ public class FormContainerImplTest {
     }
 
     @Test
+    void testGetSetPropertyBehaviourFromNode() throws Exception {
+        Resource resource = context.resourceResolver().getResource(PATH_FORM_1);
+        resource.adaptTo(ModifiableValueMap.class).put(ReservedProperties.FD_SET_PROPERTY_BEHAVIOUR, "eager");
+        FormContainer formContainer = Utils.getComponentUnderTest(PATH_FORM_1, FormContainer.class, context);
+        assertEquals("eager", formContainer.getProperties().get(ReservedProperties.FD_SET_PROPERTY_BEHAVIOUR));
+    }
+
+    @Test
+    void testSetPropertyBehaviourAbsentWhenNotAuthored() throws Exception {
+        // No node value and no toggle-driven default — the runtime falls back to "async".
+        FormContainer formContainer = Utils.getComponentUnderTest(PATH_FORM_1, FormContainer.class, context);
+        assertNull(formContainer.getProperties().get(ReservedProperties.FD_SET_PROPERTY_BEHAVIOUR));
+    }
+
+    @Test
     void testCustomFunctionUrl() throws Exception {
         FormContainer formContainer = Utils.getComponentUnderTest(PATH_FORM_1, FormContainer.class, context);
         assertEquals("/adobe/forms/af/customfunctions/L2NvbnRlbnQvZm9ybXMvYWYvZGVtbw==", formContainer.getCustomFunctionUrl());

--- a/ui.frontend/package-lock.json
+++ b/ui.frontend/package-lock.json
@@ -9,10 +9,10 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aemforms/af-core": "^1.0.2",
+        "@aemforms/af-core": "^1.0.4",
         "@aemforms/af-core-xfa": "^0.1.6",
         "@aemforms/af-custom-functions": "1.0.17",
-        "@aemforms/af-formatters": "^1.0.2"
+        "@aemforms/af-formatters": "^1.0.4"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.18.2",
@@ -108,12 +108,13 @@
       }
     },
     "node_modules/@aemforms/af-core": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@aemforms/af-core/-/af-core-1.0.2.tgz",
-      "integrity": "sha512-7d5dif1AM+ulfb/jYdcgh6tR+E/RVJkEuESuMw5xNn+7JMl/OCumw9g3Xl3oceY904FF+DYHgbHRCGpTMtQ89w==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@aemforms/af-core/-/af-core-1.0.4.tgz",
+      "integrity": "sha512-CYxtPZNFNvRbkOnCGlvwuUXWVmC2I0EmoOf0QgCW2na+GaJHcIA9CkxmzeRhSAui2LomxVkYvQNQBJRVAwTclQ==",
+      "license": "Adobe Proprietary",
       "dependencies": {
         "@adobe/json-formula": "0.1.50",
-        "@aemforms/af-formatters": "^1.0.2"
+        "@aemforms/af-formatters": "^1.0.4"
       }
     },
     "node_modules/@aemforms/af-core-xfa": {
@@ -136,9 +137,10 @@
       "integrity": "sha512-gDPC/Ly/+aQ7ojSPWm4JM3Zs+NUA+8c6bhjVbKm058AX5UEsXRk+N2o9wK4AHrdsaiR21vmvDuIUyUR2Jb2LTA=="
     },
     "node_modules/@aemforms/af-formatters": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@aemforms/af-formatters/-/af-formatters-1.0.2.tgz",
-      "integrity": "sha512-b4tO/R2jG3Bxb/TPhGdBZ77GPPdBIRxbjL9kiEfCS8Pco6duiZP7a8fB2mRStQ/jeeXODToZ9BNJjCM2xwjoSg=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@aemforms/af-formatters/-/af-formatters-1.0.4.tgz",
+      "integrity": "sha512-ShqnAHnwTN6JpEZidP1jqZCy5rku/H+2M1oqC7OwDLenQv55LUQasfvINyhG5H7jVKrocyHpijR5BDKlPdewMw==",
+      "license": "Adobe Proprietary"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
@@ -11137,12 +11139,12 @@
       "integrity": "sha512-dmlLYfbty8NPVIdxvI9cJ+ZdXsrRCFrCdmL1+aR2auEzXJ86rD0bm1qu+S4NOpFiZLKIyx0zvUTykms40vNjsA=="
     },
     "@aemforms/af-core": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@aemforms/af-core/-/af-core-1.0.2.tgz",
-      "integrity": "sha512-7d5dif1AM+ulfb/jYdcgh6tR+E/RVJkEuESuMw5xNn+7JMl/OCumw9g3Xl3oceY904FF+DYHgbHRCGpTMtQ89w==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@aemforms/af-core/-/af-core-1.0.4.tgz",
+      "integrity": "sha512-CYxtPZNFNvRbkOnCGlvwuUXWVmC2I0EmoOf0QgCW2na+GaJHcIA9CkxmzeRhSAui2LomxVkYvQNQBJRVAwTclQ==",
       "requires": {
         "@adobe/json-formula": "0.1.50",
-        "@aemforms/af-formatters": "^1.0.2"
+        "@aemforms/af-formatters": "^1.0.4"
       }
     },
     "@aemforms/af-core-xfa": {
@@ -11167,9 +11169,9 @@
       "integrity": "sha512-gDPC/Ly/+aQ7ojSPWm4JM3Zs+NUA+8c6bhjVbKm058AX5UEsXRk+N2o9wK4AHrdsaiR21vmvDuIUyUR2Jb2LTA=="
     },
     "@aemforms/af-formatters": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@aemforms/af-formatters/-/af-formatters-1.0.2.tgz",
-      "integrity": "sha512-b4tO/R2jG3Bxb/TPhGdBZ77GPPdBIRxbjL9kiEfCS8Pco6duiZP7a8fB2mRStQ/jeeXODToZ9BNJjCM2xwjoSg=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@aemforms/af-formatters/-/af-formatters-1.0.4.tgz",
+      "integrity": "sha512-ShqnAHnwTN6JpEZidP1jqZCy5rku/H+2M1oqC7OwDLenQv55LUQasfvINyhG5H7jVKrocyHpijR5BDKlPdewMw=="
     },
     "@ampproject/remapping": {
       "version": "2.2.1",

--- a/ui.frontend/package.json
+++ b/ui.frontend/package.json
@@ -25,9 +25,9 @@
     "webpack-merge": "^5.8.0"
   },
   "dependencies": {
-    "@aemforms/af-core": "^1.0.2",
+    "@aemforms/af-core": "^1.0.4",
     "@aemforms/af-core-xfa": "^0.1.6",
-    "@aemforms/af-formatters": "^1.0.2",
+    "@aemforms/af-formatters": "^1.0.4",
     "@aemforms/af-custom-functions": "1.0.17"
   }
 }

--- a/ui.tests/test-module/libs/support/commands.js
+++ b/ui.tests/test-module/libs/support/commands.js
@@ -139,6 +139,30 @@ Cypress.Commands.add("enableOrDisableTutorials", (enable) => {
     });
 });
 
+/**
+ * Resets a telephoneinput design policy to its baseline by removing the custom-format additions a test
+ * makes (`allowedCustomFormats` items and the `allowedFormat3` toggle). The design policy is shared,
+ * persistent repo state; without this, a test that adds a custom format leaves it behind and any later
+ * run/retry starts from a dirty policy — the multifield/Coral dialog then misbehaves and
+ * `allowedCustomFormats/item0/customFormatKey` never renders. Call in beforeEach for a deterministic start.
+ * @param policyPath JCR path of the telephoneinput policy node (…/policies/…/telephoneinput/<policy>)
+ */
+Cypress.Commands.add("resetTelephoneInputDesignPolicy", (policyPath) => {
+    const contextPath = Cypress.env('crx.contextPath') ? Cypress.env('crx.contextPath') : "";
+    const url = contextPath + policyPath;
+    // POST via the app's jQuery inside the authenticated page (not cy.request) so the session cookie is
+    // carried — same reason enableOrDisableTutorials does; the sling `@Delete` removes the property/node.
+    cy.request(contextPath + '/libs/granite/csrf/token.json').its('body.token').then((token) => {
+        cy.window().then((win) => new Cypress.Promise((resolve) => {
+            win.$.post(url, {
+                'allowedCustomFormats@Delete': '',
+                'allowedFormat3@Delete': '',
+                ':cq_csrf_token': token
+            }).always(resolve);
+        }));
+    });
+});
+
 // Cypress command to open AFv2
 Cypress.Commands.add("openAFv2TemplateEditor", () => {
     const baseUrl = Cypress.env('crx.contextPath') ? Cypress.env('crx.contextPath') : "";

--- a/ui.tests/test-module/specs/telephoneinput/telephoneinput.authoring.cy.js
+++ b/ui.tests/test-module/specs/telephoneinput/telephoneinput.authoring.cy.js
@@ -102,10 +102,14 @@ describe('Page - Authoring', function () {
         telephoneInputDrop = authoringPagePath + afConstants.FORM_EDITOR_FORM_CONTAINER_SUFFIX + "/" + afConstants.components.forms.resourceType.formtelephoneinput.split("/").pop(),
         telephoneInputEditPathSelector = "[data-path='" + telephoneInputEditPath + "']";
     const customKey = 'customKey',
-        customValue = 'customValue';
+        customValue = 'customValue',
+        // Shared, persistent design policy this test mutates — reset it each run so a leftover custom
+        // format from a prior run/retry can't leave the dialog in a dirty state (see reset command).
+        telephoneInputPolicyPath = '/conf/core-components-examples/settings/wcm/policies/forms-components-examples/components/form/telephoneinput/default';
 
     beforeEach(function () {
       cy.openAuthoring(templateDataPath + ".html");
+      cy.resetTelephoneInputDesignPolicy(telephoneInputPolicyPath);
     });
 
     it('Adding removing patterns from design policy', function () {


### PR DESCRIPTION
## What

Exposes a new form-level property **`fd:setPropertyBehaviour`** (`'async'` default | `'eager'`) from the v2 form container.

## Why

af2-web-runtime adds an opt-in eager `setProperty` mode (read-after-write) behind the form property `fd:setPropertyBehaviour`, gated exactly like the existing `fd:changeEventBehaviour`. The base `getCustomProperties()` strips the `fd:` prefix, so an author-set value is dropped unless the container explicitly emits it — this PR adds that wiring so AEM Sites / core-component-authored forms can opt in (EDS/forms-assets forms set the property directly and don't need this).

## Changes

- `ReservedProperties`: `FD_SET_PROPERTY_BEHAVIOUR = "fd:setPropertyBehaviour"` (auto-registered as reserved via the reflection aggregator).
- `FormContainerImpl` (v2): `@ValueMapValue` field + emit in `getProperties()` when the node value is set. **No feature-toggle default** — unlike `changeEventBehaviour` (defaults to `deps` under a toggle), the runtime defaults to the backward-compatible `async`, so this is pure opt-in.
- Tests: node value emitted (`eager`); absent when not authored.

## Related

- af2-web-runtime #780 — runtime support (transaction model behind `fd:setPropertyBehaviour`).
- af2-docs — spec addition for the property.

## Testing

`FormContainerImplTest` (v2) passes — 69 tests, 0 failures (includes the 2 new tests). (Note: the module's `mvn test` also runs spotbugs, which fails on 6 pre-existing findings in unrelated files on `dev` — not introduced here.)
