### PR TITLE
fix(recaptcha): auto-fetch captcha token and submit handling on no-iframe XFA embeds

### DIFF
--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v2/container/clientlibs/site/js/formcontainerview.js
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/container/v2/container/clientlibs/site/js/formcontainerview.js
@@ -34,7 +34,9 @@
             this._model.subscribe((action) => {
                 let state = action.target.getState();
                 // execute the handler only if there are no rules configured on submitSuccess event.
-                if (!state.events.submitSuccess || state.events.submitSuccess.length === 0) {
+                // getState() omits `events` in the XFA runtime, so guard the access (optional
+                // chaining) to avoid a TypeError; a missing events object means no rule is configured.
+                if (!state.events?.submitSuccess || state.events.submitSuccess.length === 0) {
                     const globals = {
                         form: self.getModel().getRuleNode(),
                         event: {
@@ -48,7 +50,7 @@
             this._model.subscribe((action) => {
                 let state = action.target.getState();
                 // execute the handler only if there are no rules configured on submitError event.
-                if (!state.events.submitError || state.events.submitError.length === 0) {
+                if (!state.events?.submitError || state.events.submitError.length === 0) {
                     let defaultSubmissionError = FormView.LanguageUtils.getTranslatedString(self.getLang(), "InternalFormSubmissionError");
                     const globals = {
                         form: self.getModel().getRuleNode(),
@@ -64,7 +66,7 @@
             this._model.subscribe((action) => {
                 let state = action.target.getState();
                 // execute the handler only if there are no rules configured on custom:saveSuccess event.
-                if (!state.events['custom:saveSuccess'] || state.events['custom:saveSuccess'].length === 0) {
+                if (!state.events?.['custom:saveSuccess'] || state.events['custom:saveSuccess'].length === 0) {
                     console.log("Draft id = " + action?.payload?.body?.draftId);
                     window.alert(FormView.LanguageUtils.getTranslatedString(self.getLang(), "saveDraftSuccessMessage"));
                 }
@@ -72,7 +74,7 @@
             this._model.subscribe((action) => {
                 let state = action.target.getState();
                 // execute the handler only if there are no rules configured on custom:saveError event.
-                if (!state.events['custom:saveError'] || state.events['custom:saveError'].length === 0) {
+                if (!state.events?.['custom:saveError'] || state.events['custom:saveError'].length === 0) {
                     window.alert(FormView.LanguageUtils.getTranslatedString(self.getLang(), "saveDraftErrorMessage"));
                 }
             }, "saveError");

--- a/ui.frontend/src/index.js
+++ b/ui.frontend/src/index.js
@@ -37,6 +37,14 @@ import {customFunctions} from "./customFunctions";
  */
 window.guideBridge = new GuideBridge();
 
+// Register the repo's custom functions at bundle load so BOTH runtimes get them. In the XFA
+// bundle (main-xfa.js) this populates af-core-xfa's FunctionRuntime before the XFA form model is
+// created; the container view only ever registers into the non-XFA runtime via window.FormView, so
+// the XFA rule engine would otherwise see only its built-in defaults and have no fetchCaptchaToken
+// (breaking auto-fetch captcha - invisible/enterprise-score/v3 - on no-iframe XFA embeds).
+// registerFunctions is idempotent, so the later setupFormContainer registration is unaffected.
+FunctionRuntime.registerFunctions(customFunctions);
+
 /**
  * The `Actions` object contains predefined action constants.
  * @type {object}


### PR DESCRIPTION
## Problem

On XFA-backed adaptive forms embedded with **"do not use iframe"**, captchas that auto-fetch a token at submit (invisible reCAPTCHA v2, reCAPTCHA **enterprise-score**, and reCAPTCHA **v3**) were broken: clicking Submit logged `fetchCaptchaToken is not defined`, no token was fetched, and no submit request was sent. This is a pre-existing gap that affects XFA-backed forms in no-iframe embeds; non-XFA AFv2 forms and iframe-mode XFA forms are unaffected.

## Root cause

The runtime ships two bundles — non-XFA (`@aemforms/af-core`) and XFA (`@aemforms/af-core-xfa`) — each with its **own** `FunctionRuntime`. Custom functions were registered only via `setupFormContainer` into the non-XFA runtime (through the single `window.FormView`), while the XFA form's rule engine runs in af-core-xfa and never received `fetchCaptchaToken`. af-core-xfa ships no default `fetchCaptchaToken`, so its built-in `submitForm` errored.

## Changes (two commits)

1. **Register custom functions into the XFA runtime at bundle load** (`ui.frontend/src/index.js`) — each bundle now populates its own `FunctionRuntime` at load, so the XFA runtime has `fetchCaptchaToken` (and the repo's other custom functions) before the XFA form model / function-table snapshot is created. `registerFunctions` is idempotent, so the existing `setupFormContainer` registration is unaffected.
2. **Guard container-view submit/save handlers against a missing `state.events`** (`formcontainerview.js`) — the XFA runtime's `getState()` omits `events`, which crashed the submit/save success/error handlers (`Cannot read properties of undefined`) once submit progressed. Guarded with optional chaining; a missing events object means no rule is configured, so the default handler runs. No-op for the non-XFA runtime.

## Testing

Verified end-to-end on a local AEM instance with an **enterprise-score** reCAPTCHA on an XFA form embedded no-iframe:
- The XFA rule engine now exposes `fetchCaptchaToken`.
- On Submit the token is fetched and set, `POST /adobe/forms/af/submit/... -> 200 OK`, and the thank-you / success handling runs.
- No `fetchCaptchaToken is not defined` and no `Cannot read properties of undefined (reading 'submitSuccess')` errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
