### PR TITLE
FORMS-27300: log unresolved form asset for "Item not available" draft/submission entries

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/forms/core/components/internal/models/v1/formsportal/DraftsAndSubmissionsImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/forms/core/components/internal/models/v1/formsportal/DraftsAndSubmissionsImpl.java
@@ -136,6 +136,11 @@ public class DraftsAndSubmissionsImpl extends PortalListerImpl implements Drafts
                     LOGGER.error("[FP] Could not parse render link", e);
                 }
             }
+        } else {
+            LOGGER.info("[FP] Form asset not resolvable on this environment for {} record; listing an 'Item not available' placeholder. "
+                + "id={}, formPath={}, resolvedAssetPath={}. Likely causes: the form was deleted/unpublished here, "
+                + "or the record originates from another environment sharing this store.",
+                typeEnum, id, formPath, formAssetPath);
         }
 
         PortalListerImpl.Item item = new PortalListerImpl.Item();

--- a/bundles/core/src/test/java/com/adobe/cq/forms/core/components/internal/models/v1/formsportal/draftsandsubmissions/DraftsAndSubmissionsImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/forms/core/components/internal/models/v1/formsportal/draftsandsubmissions/DraftsAndSubmissionsImplTest.java
@@ -38,6 +38,7 @@ import com.adobe.cq.forms.core.components.internal.services.formsportal.DiscardD
 import com.adobe.cq.forms.core.components.internal.services.formsportal.OpenDraftOperation;
 import com.adobe.cq.forms.core.components.internal.services.formsportal.OperationManagerImpl;
 import com.adobe.cq.forms.core.components.models.formsportal.DraftsAndSubmissions;
+import com.adobe.cq.forms.core.components.models.formsportal.PortalLister;
 import com.adobe.cq.forms.core.components.models.services.formsportal.OperationManager;
 import com.adobe.cq.forms.core.context.FormsCoreComponentTestContext;
 import com.adobe.fd.fp.api.exception.FormsPortalException;
@@ -174,6 +175,27 @@ public class DraftsAndSubmissionsImplTest {
 
         DraftsAndSubmissions component = getInstanceUnderTest(DEFAULT_COMPONENT_PATH);
         Assert.assertEquals(2, component.getElements().size());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testFormAssetNotResolvable() {
+        // Draft points to a form that does not resolve on this environment (deleted/unpublished here,
+        // or a record leaked from another environment sharing the store). The item must still be listed,
+        // as an "Item not available" placeholder with no form link.
+        Mockito.when(draftModel.getLastModifiedTime()).thenReturn(new Calendar.Builder().setInstant(12345678)
+            .build());
+        Mockito.when(draftModel.getFormPath()).thenReturn(CONTENT_ROOT + "/dam/formsanddocuments/deleted-form");
+        context.registerInjectActivateService(new DiscardDraftOperation());
+
+        DraftsAndSubmissions component = getInstanceUnderTest(DRAFT_COMPONENT_PATH);
+        List<PortalLister.Item> data = (List<PortalLister.Item>) component.getElements().get("data");
+        Assertions.assertEquals(1, data.size());
+        PortalLister.Item item = data.get(0);
+        Assertions.assertEquals("Item not available", item.getTitle());
+        Assertions.assertEquals("The item is not available. Contact your administrator for more information.",
+            item.getDescription());
+        Assertions.assertNull(item.getFormLink());
     }
 
     private DraftsAndSubmissions getInstanceUnderTest(String resourcePath) {


### PR DESCRIPTION
### Problem
Forms Portal lists an "Item not available" placeholder in Drafts/Submissions when a
draft/submission record's form cannot be resolved on the current environment (form deleted or
unpublished here, or the record originates from another environment sharing the same store).
When this happens, `DraftsAndSubmissionsImpl.getItem()` silently falls back to the placeholder
with no server-side signal, so the entry is impossible to triage from logs.

### Root cause
In `getItem()`, when `resourceResolver.getResource(formAssetPath)` returns `null`, the method
falls through to the hardcoded "Item not available" placeholder and still adds the item to the
list — with no logging on that branch.

### Fix
Add an INFO log on the null-resource branch capturing `type`, `id`, `formPath` and the resolved
asset path, so the placeholder entry can be traced and its cause (deleted-here vs. cross-environment
record) identified from logs. No behavior change — the item is still listed exactly as before.

### Tests
- New unit test `testFormAssetNotResolvable` covering the previously-untested null-resource branch:
  asserts the placeholder title/description and null form link.
- `DraftsAndSubmissionsImplTest` green (7/7); bundle compiles.