### PR TITLE
fix: build jsdocs via frontend-maven-plugin instead of exec-maven-plugin

### DIFF
--- a/jsdocs/package.json
+++ b/jsdocs/package.json
@@ -5,6 +5,9 @@
   "keywords": [],
   "author": "",
   "license": "Apache-2.0",
+  "scripts": {
+    "jsdoc": "jsdoc -c jsdoc.conf.json"
+  },
   "devDependencies": {
     "ink-docstrap": "^1.1.4",
     "jscs": "^2.11.0",

--- a/jsdocs/pom.xml
+++ b/jsdocs/pom.xml
@@ -52,31 +52,6 @@
         </license>
     </licenses>
 
-    <profiles>
-        <profile>
-            <id>Windows</id>
-            <activation>
-                <os>
-                    <family>Windows</family>
-                </os>
-            </activation>
-            <properties>
-                <script.file>jsdoc.cmd</script.file>
-            </properties>
-        </profile>
-        <profile>
-            <id>unix</id>
-            <activation>
-                <os>
-                    <family>unix</family>
-                </os>
-            </activation>
-            <properties>
-                <script.file>jsdoc</script.file>
-            </properties>
-        </profile>
-    </profiles>
-
     <build>
         <plugins>
             <!-- Plugin to install npm artifacts -->
@@ -100,6 +75,16 @@
                         <goals>
                             <goal>npm</goal>
                         </goals>
+                    </execution>
+                    <execution>
+                        <id>run-exec-generate-jsdocs</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>run jsdoc</arguments>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -128,25 +113,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>3.0.0</version>
-                <executions>
-                    <execution>
-                        <id>run-exec-generate-jsdocs</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <executable>${project.basedir}/node_modules/.bin/${script.file}</executable>
-                    <commandlineArgs>-c jsdoc.conf.json</commandlineArgs>
-                </configuration>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
## Description

`jsdocs/pom.xml` used `exec-maven-plugin` to invoke `node_modules/.bin/jsdoc` directly. That script has a `#!/usr/bin/env node` shebang, which requires a global `node` binary on `PATH`. Build environments that don't have Node installed globally (e.g. Adobe Cloud Manager's build container, which only has the Node that `frontend-maven-plugin` installs locally into `jsdocs/node/`) fail with:

```
--- exec:3.0.0:exec (run-exec-generate-jsdocs) @ core-forms-components-af-jsapi ---
/usr/bin/env: 'node': No such file or directory
...
Failed to execute goal org.codehaus.mojo:exec-maven-plugin:3.0.0:exec (run-exec-generate-jsdocs) on project core-forms-components-af-jsapi: Command execution failed. Process exited with an error: 127 (Exit value: 127)
```

This fix routes the jsdoc generation through `frontend-maven-plugin`'s own `npm` goal (`npm run jsdoc`, added as a script in `package.json`), which correctly resolves and prepends its own locally-installed Node/npm to `PATH` for the child process. This matches the pattern already used by other modules in this repo (e.g. `ui.frontend/pom.xml`) and removes the now-unneeded Windows/unix `script.file` profiles.

## Related Issue

Found while diagnosing a downstream Cloud Manager build failure that vendors this module.

## Motivation and Context

Without this fix, any build environment lacking a global `node` binary on `PATH` fails to build the `core-forms-components-af-jsapi` module, even though the module already manages its own Node install via `frontend-maven-plugin`.

## How Has This Been Tested?

Ran `mvn clean package` in `jsdocs/` standalone — build succeeds and the jsdoc jar/HTML output is generated correctly, both with and without a global Node on `PATH`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the Adobe Open Source CLA.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.