### PR TITLE
FORMS-26424: Add Next Gen Dynamic Media (NGDM) image picker support (release/650)

### DIFF
--- a/bundles/af-core/pom.xml
+++ b/bundles/af-core/pom.xml
@@ -90,6 +90,7 @@
                             <!-- https://github.com/jhy/jsoup/issues/1616 -->
                             javax.annotation;version=!;resolution:=optional,javax.annotation.meta;version=!;resolution:=optional,
                             <!-- com.adobe.cq.wcm.core.components.models;version="[12.0.0,13.0.0)", -->
+                            com.adobe.cq.ui.wcm.commons.config;resolution:=optional,
                             *
                         </Import-Package>
                         <Embed-Dependency>

--- a/bundles/af-core/pom.xml
+++ b/bundles/af-core/pom.xml
@@ -496,6 +496,12 @@
             <artifactId>uber-jar</artifactId>
         </dependency>
 
+        <!-- Needed for NextGenDynamicMediaConfig, used by the NGDM image picker. -->
+        <dependency>
+            <groupId>com.adobe.aem</groupId>
+            <artifactId>aem-sdk-api</artifactId>
+        </dependency>
+
         <!-- End of AEM and forms sdk versions -->
 
 

--- a/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/internal/form/FeatureToggleConstants.java
+++ b/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/internal/form/FeatureToggleConstants.java
@@ -106,4 +106,14 @@ public final class FeatureToggleConstants {
      * System property: same name ({@code FT_FORMS-25252}); set to {@code "true"} to enable.
      */
     public static final String FT_SERVER_SIDE_VALIDATION = "FT_FORMS-25252";
+
+    /**
+     * When enabled, the Image field's authoring dialog shows the "Pick" dropdown (Local/Remote)
+     * for selecting a Next Gen Dynamic Media asset, and the component resolves NGDM references to
+     * a delivery URL. When disabled, the dialog shows the original Browse Assets/Upload UI, and any
+     * previously-saved NGDM reference is treated as a plain (unresolvable) fileReference instead.
+     * <p>
+     * System property: same name ({@code FT_FORMS-26424}); set to {@code "true"} to enable.
+     */
+    public static final String FT_NGDM_IMAGE_PICKER = "FT_FORMS-26424";
 }

--- a/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/internal/models/v1/form/NgdmImageUtils.java
+++ b/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/internal/models/v1/form/NgdmImageUtils.java
@@ -1,0 +1,79 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2026 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.forms.core.components.internal.models.v1.form;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.adobe.cq.ui.wcm.commons.config.NextGenDynamicMediaConfig;
+
+/**
+ * Utility methods for resolving Next Gen Dynamic Media (NGDM) asset references
+ * (of the form {@code /urn:aaid:aem:<asset-id>/<seo-name>.<format>}) into delivery URLs.
+ */
+public final class NgdmImageUtils {
+
+    private static final String NGDM_REFERENCE_PREFIX = "/urn:";
+    private static final String PATH_PLACEHOLDER_ASSET_ID = "{asset-id}";
+    private static final String PATH_PLACEHOLDER_SEO_NAME = "{seo-name}";
+    private static final String PATH_PLACEHOLDER_FORMAT = "{format}";
+    private static final String DEFAULT_NGDM_ASSET_EXTENSION = "jpg";
+    private static final int DEFAULT_NGDM_ASSET_WIDTH = 640;
+
+    private NgdmImageUtils() {
+    }
+
+    public static boolean isNgdmImageReference(String fileReference) {
+        if (StringUtils.isBlank(fileReference) || !fileReference.startsWith(NGDM_REFERENCE_PREFIX)) {
+            return false;
+        }
+        // must have a non-empty asset-id segment and a non-empty seo-name segment, i.e.
+        // "/urn:<asset-id>/<seo-name>[.<format>]", otherwise buildNgdmImageSrc() has nothing to parse.
+        String withoutLeadingSlash = fileReference.substring(1);
+        int slashIndex = withoutLeadingSlash.indexOf('/');
+        return slashIndex > 0 && slashIndex < withoutLeadingSlash.length() - 1;
+    }
+
+    public static boolean isNgdmSupportAvailable(NextGenDynamicMediaConfig nextGenDynamicMediaConfig) {
+        return nextGenDynamicMediaConfig != null && nextGenDynamicMediaConfig.enabled()
+            && StringUtils.isNotBlank(nextGenDynamicMediaConfig.getRepositoryId());
+    }
+
+    /**
+     * Builds the Next Gen Dynamic Media delivery URL for an asset reference of the form
+     * {@code /urn:aaid:aem:<asset-id>/<seo-name>.<format>}.
+     */
+    public static String buildNgdmImageSrc(String fileReference, NextGenDynamicMediaConfig nextGenDynamicMediaConfig) {
+        String withoutLeadingSlash = fileReference.substring(1);
+        int slashIndex = withoutLeadingSlash.indexOf('/');
+        String assetId = withoutLeadingSlash.substring(0, slashIndex);
+        String assetFileName = withoutLeadingSlash.substring(slashIndex + 1);
+
+        // split on the LAST dot, not the first: seo-names can legitimately contain dots
+        // (e.g. "product.hero.png"), and a first-dot split would truncate the name and
+        // produce the wrong extension.
+        int lastDotIndex = assetFileName.lastIndexOf('.');
+        String assetName = lastDotIndex >= 0 ? assetFileName.substring(0, lastDotIndex) : assetFileName;
+        String assetExtension = lastDotIndex >= 0 ? assetFileName.substring(lastDotIndex + 1) : DEFAULT_NGDM_ASSET_EXTENSION;
+
+        String imageDeliveryPath = nextGenDynamicMediaConfig.getImageDeliveryBasePath()
+            .replace(PATH_PLACEHOLDER_ASSET_ID, assetId)
+            .replace(PATH_PLACEHOLDER_SEO_NAME, assetName)
+            .replace(PATH_PLACEHOLDER_FORMAT, assetExtension);
+
+        return "https://" + nextGenDynamicMediaConfig.getRepositoryId() + imageDeliveryPath
+            + "?width=" + DEFAULT_NGDM_ASSET_WIDTH + "&preferwebp=true";
+    }
+}

--- a/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/internal/models/v1/form/StaticImageImpl.java
+++ b/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/internal/models/v1/form/StaticImageImpl.java
@@ -17,15 +17,19 @@ package com.adobe.cq.forms.core.components.internal.models.v1.form;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Scanner;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.inject.Inject;
 import javax.jcr.RepositoryException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Exporter;
 import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.Optional;
 import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
 import org.apache.sling.models.annotations.injectorspecific.SlingObject;
 import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
@@ -37,6 +41,7 @@ import com.adobe.cq.forms.core.components.internal.form.ReservedProperties;
 import com.adobe.cq.forms.core.components.models.form.FieldType;
 import com.adobe.cq.forms.core.components.models.form.StaticImage;
 import com.adobe.cq.forms.core.components.util.AbstractFormComponentImpl;
+import com.adobe.cq.ui.wcm.commons.config.NextGenDynamicMediaConfig;
 import com.day.cq.wcm.foundation.Image;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
@@ -50,6 +55,17 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 public class StaticImageImpl extends AbstractFormComponentImpl implements StaticImage {
 
     public static final String DAM_REPO_PATH = "fd:repoPath";
+
+    private static final String NGDM_REFERENCE_PREFIX = "/urn:";
+    private static final String PATH_PLACEHOLDER_ASSET_ID = "{asset-id}";
+    private static final String PATH_PLACEHOLDER_SEO_NAME = "{seo-name}";
+    private static final String PATH_PLACEHOLDER_FORMAT = "{format}";
+    private static final String DEFAULT_NGDM_ASSET_EXTENSION = "jpg";
+    private static final int DEFAULT_NGDM_ASSET_WIDTH = 640;
+
+    @Inject
+    @Optional
+    private NextGenDynamicMediaConfig nextGenDynamicMediaConfig;
 
     private Image image;
 
@@ -79,6 +95,9 @@ public class StaticImageImpl extends AbstractFormComponentImpl implements Static
      */
     @Override
     public String getImageSrc() throws RepositoryException, IOException {
+        if (isNgdmImageReference(fileReference) && isNgdmSupportAvailable()) {
+            return buildNgdmImageSrc(fileReference);
+        }
         image = new Image(this.resource);
         boolean containsData = (image.getData() != null);
         if (containsData) {
@@ -129,7 +148,7 @@ public class StaticImageImpl extends AbstractFormComponentImpl implements Static
     @Override
     public @Nonnull Map<String, Object> getProperties() {
         Map<String, Object> properties = super.getProperties();
-        if (fileReference != null && fileReference.length() > 0) {
+        if (StringUtils.isNotBlank(fileReference) && !isNgdmImageReference(fileReference)) {
             properties.put(DAM_REPO_PATH, fileReference);
         }
         return properties;
@@ -138,5 +157,36 @@ public class StaticImageImpl extends AbstractFormComponentImpl implements Static
     @Override
     public String getFieldType() {
         return super.getFieldType(FieldType.IMAGE);
+    }
+
+    private boolean isNgdmSupportAvailable() {
+        return nextGenDynamicMediaConfig != null && nextGenDynamicMediaConfig.enabled()
+            && StringUtils.isNotBlank(nextGenDynamicMediaConfig.getRepositoryId());
+    }
+
+    /**
+     * Builds the Next Gen Dynamic Media delivery URL for an asset reference of the form
+     * {@code /urn:aaid:aem:<asset-id>/<seo-name>.<format>}.
+     */
+    private String buildNgdmImageSrc(String fileReference) {
+        Scanner scanner = new Scanner(fileReference);
+        scanner.useDelimiter("/");
+        String assetId = scanner.next();
+        scanner = new Scanner(scanner.next());
+        scanner.useDelimiter("\\.");
+        String assetName = scanner.hasNext() ? scanner.next() : assetId;
+        String assetExtension = scanner.hasNext() ? scanner.next() : DEFAULT_NGDM_ASSET_EXTENSION;
+
+        String imageDeliveryPath = nextGenDynamicMediaConfig.getImageDeliveryBasePath()
+            .replace(PATH_PLACEHOLDER_ASSET_ID, assetId)
+            .replace(PATH_PLACEHOLDER_SEO_NAME, assetName)
+            .replace(PATH_PLACEHOLDER_FORMAT, assetExtension);
+
+        return "https://" + nextGenDynamicMediaConfig.getRepositoryId() + imageDeliveryPath
+            + "?width=" + DEFAULT_NGDM_ASSET_WIDTH + "&preferwebp=true";
+    }
+
+    public static boolean isNgdmImageReference(String fileReference) {
+        return StringUtils.isNotBlank(fileReference) && fileReference.startsWith(NGDM_REFERENCE_PREFIX);
     }
 }

--- a/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/internal/models/v1/form/StaticImageImpl.java
+++ b/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/internal/models/v1/form/StaticImageImpl.java
@@ -35,11 +35,13 @@ import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ExporterConstants;
+import com.adobe.cq.forms.core.components.internal.form.FeatureToggleConstants;
 import com.adobe.cq.forms.core.components.internal.form.FormConstants;
 import com.adobe.cq.forms.core.components.internal.form.ReservedProperties;
 import com.adobe.cq.forms.core.components.models.form.FieldType;
 import com.adobe.cq.forms.core.components.models.form.StaticImage;
 import com.adobe.cq.forms.core.components.util.AbstractFormComponentImpl;
+import com.adobe.cq.forms.core.components.util.ComponentUtils;
 import com.adobe.cq.ui.wcm.commons.config.NextGenDynamicMediaConfig;
 import com.day.cq.wcm.foundation.Image;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -87,7 +89,7 @@ public class StaticImageImpl extends AbstractFormComponentImpl implements Static
      */
     @Override
     public String getImageSrc() throws RepositoryException, IOException {
-        if (NgdmImageUtils.isNgdmImageReference(fileReference) && NgdmImageUtils.isNgdmSupportAvailable(nextGenDynamicMediaConfig)) {
+        if (isNgdmReferenceAndFeatureEnabled() && NgdmImageUtils.isNgdmSupportAvailable(nextGenDynamicMediaConfig)) {
             return NgdmImageUtils.buildNgdmImageSrc(fileReference, nextGenDynamicMediaConfig);
         }
         image = new Image(this.resource);
@@ -140,10 +142,21 @@ public class StaticImageImpl extends AbstractFormComponentImpl implements Static
     @Override
     public @Nonnull Map<String, Object> getProperties() {
         Map<String, Object> properties = super.getProperties();
-        if (StringUtils.isNotBlank(fileReference) && !NgdmImageUtils.isNgdmImageReference(fileReference)) {
+        if (StringUtils.isNotBlank(fileReference) && !isNgdmReferenceAndFeatureEnabled()) {
             properties.put(DAM_REPO_PATH, fileReference);
         }
         return properties;
+    }
+
+    /**
+     * Whether {@link #fileReference} is a Next Gen Dynamic Media reference AND the NGDM image
+     * picker feature toggle is enabled. When the toggle is disabled, a previously-saved NGDM
+     * reference is treated like any other (unresolvable) fileReference - matching the dialog,
+     * which falls back to the original Browse Assets/Upload UI in that case.
+     */
+    private boolean isNgdmReferenceAndFeatureEnabled() {
+        return ComponentUtils.isToggleEnabled(FeatureToggleConstants.FT_NGDM_IMAGE_PICKER)
+            && NgdmImageUtils.isNgdmImageReference(fileReference);
     }
 
     @Override

--- a/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/internal/models/v1/form/StaticImageImpl.java
+++ b/bundles/af-core/src/main/java/com/adobe/cq/forms/core/components/internal/models/v1/form/StaticImageImpl.java
@@ -17,7 +17,6 @@ package com.adobe.cq.forms.core.components.internal.models.v1.form;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.Scanner;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -56,13 +55,6 @@ public class StaticImageImpl extends AbstractFormComponentImpl implements Static
 
     public static final String DAM_REPO_PATH = "fd:repoPath";
 
-    private static final String NGDM_REFERENCE_PREFIX = "/urn:";
-    private static final String PATH_PLACEHOLDER_ASSET_ID = "{asset-id}";
-    private static final String PATH_PLACEHOLDER_SEO_NAME = "{seo-name}";
-    private static final String PATH_PLACEHOLDER_FORMAT = "{format}";
-    private static final String DEFAULT_NGDM_ASSET_EXTENSION = "jpg";
-    private static final int DEFAULT_NGDM_ASSET_WIDTH = 640;
-
     @Inject
     @Optional
     private NextGenDynamicMediaConfig nextGenDynamicMediaConfig;
@@ -95,8 +87,8 @@ public class StaticImageImpl extends AbstractFormComponentImpl implements Static
      */
     @Override
     public String getImageSrc() throws RepositoryException, IOException {
-        if (isNgdmImageReference(fileReference) && isNgdmSupportAvailable()) {
-            return buildNgdmImageSrc(fileReference);
+        if (NgdmImageUtils.isNgdmImageReference(fileReference) && NgdmImageUtils.isNgdmSupportAvailable(nextGenDynamicMediaConfig)) {
+            return NgdmImageUtils.buildNgdmImageSrc(fileReference, nextGenDynamicMediaConfig);
         }
         image = new Image(this.resource);
         boolean containsData = (image.getData() != null);
@@ -148,7 +140,7 @@ public class StaticImageImpl extends AbstractFormComponentImpl implements Static
     @Override
     public @Nonnull Map<String, Object> getProperties() {
         Map<String, Object> properties = super.getProperties();
-        if (StringUtils.isNotBlank(fileReference) && !isNgdmImageReference(fileReference)) {
+        if (StringUtils.isNotBlank(fileReference) && !NgdmImageUtils.isNgdmImageReference(fileReference)) {
             properties.put(DAM_REPO_PATH, fileReference);
         }
         return properties;
@@ -157,36 +149,5 @@ public class StaticImageImpl extends AbstractFormComponentImpl implements Static
     @Override
     public String getFieldType() {
         return super.getFieldType(FieldType.IMAGE);
-    }
-
-    private boolean isNgdmSupportAvailable() {
-        return nextGenDynamicMediaConfig != null && nextGenDynamicMediaConfig.enabled()
-            && StringUtils.isNotBlank(nextGenDynamicMediaConfig.getRepositoryId());
-    }
-
-    /**
-     * Builds the Next Gen Dynamic Media delivery URL for an asset reference of the form
-     * {@code /urn:aaid:aem:<asset-id>/<seo-name>.<format>}.
-     */
-    private String buildNgdmImageSrc(String fileReference) {
-        Scanner scanner = new Scanner(fileReference);
-        scanner.useDelimiter("/");
-        String assetId = scanner.next();
-        scanner = new Scanner(scanner.next());
-        scanner.useDelimiter("\\.");
-        String assetName = scanner.hasNext() ? scanner.next() : assetId;
-        String assetExtension = scanner.hasNext() ? scanner.next() : DEFAULT_NGDM_ASSET_EXTENSION;
-
-        String imageDeliveryPath = nextGenDynamicMediaConfig.getImageDeliveryBasePath()
-            .replace(PATH_PLACEHOLDER_ASSET_ID, assetId)
-            .replace(PATH_PLACEHOLDER_SEO_NAME, assetName)
-            .replace(PATH_PLACEHOLDER_FORMAT, assetExtension);
-
-        return "https://" + nextGenDynamicMediaConfig.getRepositoryId() + imageDeliveryPath
-            + "?width=" + DEFAULT_NGDM_ASSET_WIDTH + "&preferwebp=true";
-    }
-
-    public static boolean isNgdmImageReference(String fileReference) {
-        return StringUtils.isNotBlank(fileReference) && fileReference.startsWith(NGDM_REFERENCE_PREFIX);
     }
 }

--- a/bundles/af-core/src/test/java/com/adobe/cq/forms/core/components/internal/models/v1/form/NgdmImageUtilsTest.java
+++ b/bundles/af-core/src/test/java/com/adobe/cq/forms/core/components/internal/models/v1/form/NgdmImageUtilsTest.java
@@ -1,0 +1,118 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2026 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.forms.core.components.internal.models.v1.form;
+
+import org.junit.jupiter.api.Test;
+
+import com.adobe.cq.forms.core.testing.MockNextGenDynamicMediaConfig;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NgdmImageUtilsTest {
+
+    @Test
+    void isNgdmImageReference_WithUrnPrefix_ReturnsTrue() {
+        assertTrue(NgdmImageUtils.isNgdmImageReference("/urn:aaid:aem:e82c3c87-1453-48f5-844b-1822fb610911/cutfruits.png"));
+    }
+
+    @Test
+    void isNgdmImageReference_WithDamPath_ReturnsFalse() {
+        assertFalse(NgdmImageUtils.isNgdmImageReference("/content/dam/some-asset.png"));
+    }
+
+    @Test
+    void isNgdmImageReference_WithNullOrBlank_ReturnsFalse() {
+        assertFalse(NgdmImageUtils.isNgdmImageReference(null));
+        assertFalse(NgdmImageUtils.isNgdmImageReference(""));
+        assertFalse(NgdmImageUtils.isNgdmImageReference("   "));
+    }
+
+    @Test
+    void isNgdmImageReference_WithMissingSeoNameSegment_ReturnsFalse() {
+        assertFalse(NgdmImageUtils.isNgdmImageReference("/urn:aaid:aem:e82c3c87-1453-48f5-844b-1822fb610911"));
+        assertFalse(NgdmImageUtils.isNgdmImageReference("/urn:aaid:aem:e82c3c87-1453-48f5-844b-1822fb610911/"));
+    }
+
+    @Test
+    void isNgdmSupportAvailable_WithEnabledConfigAndRepositoryId_ReturnsTrue() {
+        MockNextGenDynamicMediaConfig config = new MockNextGenDynamicMediaConfig();
+        config.setEnabled(true);
+        config.setRepositoryId("testrepo");
+
+        assertTrue(NgdmImageUtils.isNgdmSupportAvailable(config));
+    }
+
+    @Test
+    void isNgdmSupportAvailable_WithDisabledConfig_ReturnsFalse() {
+        MockNextGenDynamicMediaConfig config = new MockNextGenDynamicMediaConfig();
+        config.setEnabled(false);
+        config.setRepositoryId("testrepo");
+
+        assertFalse(NgdmImageUtils.isNgdmSupportAvailable(config));
+    }
+
+    @Test
+    void isNgdmSupportAvailable_WithBlankRepositoryId_ReturnsFalse() {
+        MockNextGenDynamicMediaConfig config = new MockNextGenDynamicMediaConfig();
+        config.setEnabled(true);
+        config.setRepositoryId("");
+
+        assertFalse(NgdmImageUtils.isNgdmSupportAvailable(config));
+    }
+
+    @Test
+    void isNgdmSupportAvailable_WithNullConfig_ReturnsFalse() {
+        assertFalse(NgdmImageUtils.isNgdmSupportAvailable(null));
+    }
+
+    @Test
+    void buildNgdmImageSrc_BuildsExpectedDeliveryUrl() {
+        MockNextGenDynamicMediaConfig config = new MockNextGenDynamicMediaConfig();
+        config.setRepositoryId("testrepo");
+
+        String src = NgdmImageUtils.buildNgdmImageSrc(
+            "/urn:aaid:aem:e82c3c87-1453-48f5-844b-1822fb610911/cutfruits.png", config);
+
+        assertEquals("https://testrepo/adobe/dynamicmedia/deliver/urn:aaid:aem:e82c3c87-1453-48f5-844b-1822fb610911/cutfruits.png?width=640&preferwebp=true",
+            src);
+    }
+
+    @Test
+    void buildNgdmImageSrc_WithNoFormatSuffix_FallsBackToDefaultExtension() {
+        MockNextGenDynamicMediaConfig config = new MockNextGenDynamicMediaConfig();
+        config.setRepositoryId("testrepo");
+
+        String src = NgdmImageUtils.buildNgdmImageSrc(
+            "/urn:aaid:aem:e82c3c87-1453-48f5-844b-1822fb610911/cutfruits", config);
+
+        assertEquals("https://testrepo/adobe/dynamicmedia/deliver/urn:aaid:aem:e82c3c87-1453-48f5-844b-1822fb610911/cutfruits.jpg?width=640&preferwebp=true",
+            src);
+    }
+
+    @Test
+    void buildNgdmImageSrc_WithMultipleDotsInSeoName_KeepsFullNameAndCorrectExtension() {
+        MockNextGenDynamicMediaConfig config = new MockNextGenDynamicMediaConfig();
+        config.setRepositoryId("testrepo");
+
+        String src = NgdmImageUtils.buildNgdmImageSrc(
+            "/urn:aaid:aem:e82c3c87-1453-48f5-844b-1822fb610911/product.hero.png", config);
+
+        assertEquals("https://testrepo/adobe/dynamicmedia/deliver/urn:aaid:aem:e82c3c87-1453-48f5-844b-1822fb610911/product.hero.png?width=640&preferwebp=true",
+            src);
+    }
+}

--- a/bundles/af-core/src/test/java/com/adobe/cq/forms/core/components/internal/models/v1/form/StaticImageImplTest.java
+++ b/bundles/af-core/src/test/java/com/adobe/cq/forms/core/components/internal/models/v1/form/StaticImageImplTest.java
@@ -32,6 +32,7 @@ import com.adobe.cq.forms.core.components.internal.form.FormConstants;
 import com.adobe.cq.forms.core.components.models.form.FieldType;
 import com.adobe.cq.forms.core.components.models.form.StaticImage;
 import com.adobe.cq.forms.core.context.FormsCoreComponentTestContext;
+import com.adobe.cq.forms.core.testing.MockNextGenDynamicMediaConfig;
 import com.adobe.cq.wcm.core.components.models.datalayer.ComponentData;
 import com.adobe.cq.wcm.style.ComponentStyleInfo;
 import com.day.cq.wcm.foundation.Image;
@@ -53,6 +54,7 @@ public class StaticImageImplTest {
     private static final String PATH_IMAGE = CONTENT_ROOT + "/image";
     private static final String PATH_IMAGE_DATALAYER = CONTENT_ROOT + "/image-datalayer";
     private static final String PATH_IMAGE_WITHOUT_FIELDTYPE = CONTENT_ROOT + "/image-without-fieldtype";
+    private static final String PATH_IMAGE_NGDM = CONTENT_ROOT + "/image-ngdm";
 
     private final AemContext context = FormsCoreComponentTestContext.newAemContext();
 
@@ -214,5 +216,37 @@ public class StaticImageImplTest {
     void testNoFieldType() {
         StaticImage image = Utils.getComponentUnderTest(PATH_IMAGE_WITHOUT_FIELDTYPE, StaticImage.class, context);
         assertEquals(FieldType.IMAGE.getValue(), image.getFieldType());
+    }
+
+    @Test
+    void testNgdmImage() throws RepositoryException, IOException {
+        MockNextGenDynamicMediaConfig config = new MockNextGenDynamicMediaConfig();
+        config.setEnabled(true);
+        config.setRepositoryId("testrepo");
+        context.registerService(com.adobe.cq.ui.wcm.commons.config.NextGenDynamicMediaConfig.class, config);
+
+        StaticImage image = Utils.getComponentUnderTest(PATH_IMAGE_NGDM, StaticImage.class, context);
+        String expectedSrc = "https://testrepo/adobe/dynamicmedia/deliver/urn:aaid:aem:e82c3c87-1453-48f5-844b-1822fb610911/cutfruits.png?width=640&preferwebp=true";
+        assertEquals(expectedSrc, image.getImageSrc());
+        assertEquals(expectedSrc, image.getValue());
+        assertFalse(image.getProperties().containsKey(StaticImageImpl.DAM_REPO_PATH));
+    }
+
+    @Test
+    void testNgdmImageWithConfigDisabled() throws RepositoryException, IOException {
+        MockNextGenDynamicMediaConfig config = new MockNextGenDynamicMediaConfig();
+        config.setEnabled(false);
+        config.setRepositoryId("testrepo");
+        context.registerService(com.adobe.cq.ui.wcm.commons.config.NextGenDynamicMediaConfig.class, config);
+
+        StaticImage image = Utils.getComponentUnderTest(PATH_IMAGE_NGDM, StaticImage.class, context);
+        assertNull(image.getImageSrc());
+        assertFalse(image.getProperties().containsKey(StaticImageImpl.DAM_REPO_PATH));
+    }
+
+    @Test
+    void testNgdmImageWithoutConfig() throws RepositoryException, IOException {
+        StaticImage image = Utils.getComponentUnderTest(PATH_IMAGE_NGDM, StaticImage.class, context);
+        assertNull(image.getImageSrc());
     }
 }

--- a/bundles/af-core/src/test/java/com/adobe/cq/forms/core/components/internal/models/v1/form/StaticImageImplTest.java
+++ b/bundles/af-core/src/test/java/com/adobe/cq/forms/core/components/internal/models/v1/form/StaticImageImplTest.java
@@ -22,12 +22,14 @@ import javax.jcr.RepositoryException;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 
 import com.adobe.cq.forms.core.Utils;
+import com.adobe.cq.forms.core.components.internal.form.FeatureToggleConstants;
 import com.adobe.cq.forms.core.components.internal.form.FormConstants;
 import com.adobe.cq.forms.core.components.models.form.FieldType;
 import com.adobe.cq.forms.core.components.models.form.StaticImage;
@@ -57,6 +59,11 @@ public class StaticImageImplTest {
     private static final String PATH_IMAGE_NGDM = CONTENT_ROOT + "/image-ngdm";
 
     private final AemContext context = FormsCoreComponentTestContext.newAemContext();
+
+    @AfterEach
+    void clearNgdmFeatureToggle() {
+        System.clearProperty(FeatureToggleConstants.FT_NGDM_IMAGE_PICKER);
+    }
 
     @BeforeEach
     void setUp() {
@@ -220,6 +227,7 @@ public class StaticImageImplTest {
 
     @Test
     void testNgdmImage() throws RepositoryException, IOException {
+        System.setProperty(FeatureToggleConstants.FT_NGDM_IMAGE_PICKER, "true");
         MockNextGenDynamicMediaConfig config = new MockNextGenDynamicMediaConfig();
         config.setEnabled(true);
         config.setRepositoryId("testrepo");
@@ -234,6 +242,7 @@ public class StaticImageImplTest {
 
     @Test
     void testNgdmImageWithConfigDisabled() throws RepositoryException, IOException {
+        System.setProperty(FeatureToggleConstants.FT_NGDM_IMAGE_PICKER, "true");
         MockNextGenDynamicMediaConfig config = new MockNextGenDynamicMediaConfig();
         config.setEnabled(false);
         config.setRepositoryId("testrepo");
@@ -246,12 +255,26 @@ public class StaticImageImplTest {
 
     @Test
     void testNgdmImageWithoutConfig() throws RepositoryException, IOException {
+        System.setProperty(FeatureToggleConstants.FT_NGDM_IMAGE_PICKER, "true");
         StaticImage image = Utils.getComponentUnderTest(PATH_IMAGE_NGDM, StaticImage.class, context);
         assertNull(image.getImageSrc());
     }
 
     @Test
+    void testNgdmImageWithFeatureToggleDisabled() throws RepositoryException, IOException {
+        MockNextGenDynamicMediaConfig config = new MockNextGenDynamicMediaConfig();
+        config.setEnabled(true);
+        config.setRepositoryId("testrepo");
+        context.registerService(com.adobe.cq.ui.wcm.commons.config.NextGenDynamicMediaConfig.class, config);
+
+        StaticImage image = Utils.getComponentUnderTest(PATH_IMAGE_NGDM, StaticImage.class, context);
+        assertNull(image.getImageSrc());
+        assertTrue(image.getProperties().containsKey(StaticImageImpl.DAM_REPO_PATH));
+    }
+
+    @Test
     void testJSONExportForNgdm() throws Exception {
+        System.setProperty(FeatureToggleConstants.FT_NGDM_IMAGE_PICKER, "true");
         MockNextGenDynamicMediaConfig config = new MockNextGenDynamicMediaConfig();
         config.setEnabled(true);
         config.setRepositoryId("testrepo");

--- a/bundles/af-core/src/test/java/com/adobe/cq/forms/core/components/internal/models/v1/form/StaticImageImplTest.java
+++ b/bundles/af-core/src/test/java/com/adobe/cq/forms/core/components/internal/models/v1/form/StaticImageImplTest.java
@@ -249,4 +249,15 @@ public class StaticImageImplTest {
         StaticImage image = Utils.getComponentUnderTest(PATH_IMAGE_NGDM, StaticImage.class, context);
         assertNull(image.getImageSrc());
     }
+
+    @Test
+    void testJSONExportForNgdm() throws Exception {
+        MockNextGenDynamicMediaConfig config = new MockNextGenDynamicMediaConfig();
+        config.setEnabled(true);
+        config.setRepositoryId("testrepo");
+        context.registerService(com.adobe.cq.ui.wcm.commons.config.NextGenDynamicMediaConfig.class, config);
+
+        StaticImage image = Utils.getComponentUnderTest(PATH_IMAGE_NGDM, StaticImage.class, context);
+        Utils.testJSONExport(image, Utils.getTestExporterJSONPath(BASE, PATH_IMAGE_NGDM));
+    }
 }

--- a/bundles/af-core/src/test/java/com/adobe/cq/forms/core/testing/MockNextGenDynamicMediaConfig.java
+++ b/bundles/af-core/src/test/java/com/adobe/cq/forms/core/testing/MockNextGenDynamicMediaConfig.java
@@ -1,0 +1,144 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2026 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.forms.core.testing;
+
+import com.adobe.cq.ui.wcm.commons.config.NextGenDynamicMediaConfig;
+
+public class MockNextGenDynamicMediaConfig implements NextGenDynamicMediaConfig {
+
+    static final String DEFAULT_IMAGE_DELIVERY_BASE_PATH = "/adobe/dynamicmedia/deliver/{asset-id}/{seo-name}.{format}";
+
+    private boolean enabled;
+    private String repositoryId;
+    private String apiKey;
+    private String env;
+    private String imsOrg;
+    private String imsEnv;
+    private String imsClient;
+    private String assetSelectorsJsUrl;
+    private String imageDeliveryBasePath = DEFAULT_IMAGE_DELIVERY_BASE_PATH;
+    private String videoDeliveryPath;
+    private String assetOriginalBinaryDeliveryPath;
+    private String assetMetadataPath;
+
+    @Override
+    public boolean enabled() {
+        return enabled;
+    }
+
+    @Override
+    public String getRepositoryId() {
+        return repositoryId;
+    }
+
+    @Override
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    @Override
+    public String getEnv() {
+        return env;
+    }
+
+    @Override
+    public String getImsOrg() {
+        return imsOrg;
+    }
+
+    @Override
+    public String getImsEnv() {
+        return imsEnv;
+    }
+
+    @Override
+    public String getImsClient() {
+        return imsClient;
+    }
+
+    @Override
+    public String getAssetSelectorsJsUrl() {
+        return assetSelectorsJsUrl;
+    }
+
+    @Override
+    public String getImageDeliveryBasePath() {
+        return imageDeliveryBasePath;
+    }
+
+    @Override
+    public String getVideoDeliveryPath() {
+        return videoDeliveryPath;
+    }
+
+    @Override
+    public String getAssetOriginalBinaryDeliveryPath() {
+        return assetOriginalBinaryDeliveryPath;
+    }
+
+    @Override
+    public String getAssetMetadataPath() {
+        return assetMetadataPath;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public void setRepositoryId(String repositoryId) {
+        this.repositoryId = repositoryId;
+    }
+
+    public void setApiKey(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    public void setEnv(String env) {
+        this.env = env;
+    }
+
+    public void setImsOrg(String imsOrg) {
+        this.imsOrg = imsOrg;
+    }
+
+    public void setImsEnv(String imsEnv) {
+        this.imsEnv = imsEnv;
+    }
+
+    public void setImsClient(String imsClient) {
+        this.imsClient = imsClient;
+    }
+
+    public void setAssetSelectorsJsUrl(String assetSelectorsJsUrl) {
+        this.assetSelectorsJsUrl = assetSelectorsJsUrl;
+    }
+
+    public void setImageDeliveryBasePath(String imageDeliveryBasePath) {
+        this.imageDeliveryBasePath = imageDeliveryBasePath;
+    }
+
+    public void setVideoDeliveryPath(String videoDeliveryPath) {
+        this.videoDeliveryPath = videoDeliveryPath;
+    }
+
+    public void setAssetOriginalBinaryDeliveryPath(String assetOriginalBinaryDeliveryPath) {
+        this.assetOriginalBinaryDeliveryPath = assetOriginalBinaryDeliveryPath;
+    }
+
+    public void setAssetMetadataPath(String assetMetadataPath) {
+        this.assetMetadataPath = assetMetadataPath;
+    }
+}

--- a/bundles/af-core/src/test/resources/form/image/exporter-image-ngdm.json
+++ b/bundles/af-core/src/test/resources/form/image/exporter-image-ngdm.json
@@ -1,0 +1,17 @@
+{
+  "id": "image-05f90862ec",
+  "fieldType": "image",
+  "name": "abcd",
+  "value": "https://testrepo/adobe/dynamicmedia/deliver/urn:aaid:aem:e82c3c87-1453-48f5-844b-1822fb610911/cutfruits.png?width=640&preferwebp=true",
+  "visible": false,
+  "altText": "abc",
+  "properties": {
+    "fd:path": "/content/image-ngdm"
+  },
+  "events": {
+    "custom:setProperty": [
+      "$event.payload"
+    ]
+  },
+  ":type": "core/fd/components/form/image/v1/image"
+}

--- a/bundles/af-core/src/test/resources/form/image/test-content.json
+++ b/bundles/af-core/src/test/resources/form/image/test-content.json
@@ -65,5 +65,17 @@
     "hideTitle" : false,
     "visible" : false,
     "altText": "abc"
+  },
+  "image-ngdm": {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType": "core/fd/components/form/image/v1/image",
+    "name": "abcd",
+    "jcr:title": "def",
+    "hideTitle": false,
+    "visible": false,
+    "altText": "abc",
+    "fileReference": "/urn:aaid:aem:e82c3c87-1453-48f5-844b-1822fb610911/cutfruits.png",
+    "excludeFromDor": false,
+    "fieldType": "image"
   }
 }

--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -504,6 +504,12 @@
             <artifactId>uber-jar</artifactId>
         </dependency>
 
+        <!-- Needed for NextGenDynamicMediaConfig, used by the NGDM image picker. -->
+        <dependency>
+            <groupId>com.adobe.aem</groupId>
+            <artifactId>aem-sdk-api</artifactId>
+        </dependency>
+
         <!-- End of AEM and forms sdk versions -->
 
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1131,6 +1131,15 @@
                 <scope>provided</scope>
             </dependency>
 
+
+            <!-- Needed for NextGenDynamicMediaConfig, used by the NGDM image picker. -->
+            <dependency>
+                <groupId>com.adobe.aem</groupId>
+                <artifactId>aem-sdk-api</artifactId>
+                <version>2023.9.13665.20230927T063259Z-230800</version>
+                <scope>provided</scope>
+            </dependency>
+
             <!-- Testing -->
             <dependency>
                 <groupId>junit</groupId>

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/image/v1/image/_cq_dialog/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/image/v1/image/_cq_dialog/.content.xml
@@ -55,6 +55,7 @@
                                                     sling:orderBefore="visible"
                                                     sling:resourceType="cq/gui/components/authoring/dialog/fileupload"
                                                     class="cq-droptarget"
+                                                    enableNextGenDynamicMedia="{Boolean}true"
                                                     fileNameParameter="./fileName"
                                                     fileReferenceParameter="./fileReference"
                                                     mimeTypes="[image/gif,image/jpeg,image/png,image/tiff,image/svg+xml]"

--- a/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/image/v1/image/_cq_dialog/.content.xml
+++ b/ui.af.apps/src/main/content/jcr_root/apps/core/fd/components/form/image/v1/image/_cq_dialog/.content.xml
@@ -59,7 +59,30 @@
                                                     fileNameParameter="./fileName"
                                                     fileReferenceParameter="./fileReference"
                                                     mimeTypes="[image/gif,image/jpeg,image/png,image/tiff,image/svg+xml]"
-                                                    name="./file"/>
+                                                    name="./file">
+                                                <granite:rendercondition
+                                                        jcr:primaryType="nt:unstructured"
+                                                        sling:resourceType="granite/ui/components/renderconditions/featuretoggle"
+                                                        toggleName="FT_FORMS-26424"/>
+                                            </file>
+                                            <fileLegacy
+                                                    jcr:primaryType="nt:unstructured"
+                                                    sling:orderBefore="visible"
+                                                    sling:resourceType="cq/gui/components/authoring/dialog/fileupload"
+                                                    class="cq-droptarget"
+                                                    fileNameParameter="./fileName"
+                                                    fileReferenceParameter="./fileReference"
+                                                    mimeTypes="[image/gif,image/jpeg,image/png,image/tiff,image/svg+xml]"
+                                                    name="./file">
+                                                <granite:rendercondition
+                                                        jcr:primaryType="nt:unstructured"
+                                                        sling:resourceType="granite/ui/components/coral/foundation/renderconditions/not">
+                                                    <featuretoggle
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/renderconditions/featuretoggle"
+                                                            toggleName="FT_FORMS-26424"/>
+                                                </granite:rendercondition>
+                                            </fileLegacy>
                                             <alt
                                                     jcr:primaryType="nt:unstructured"
                                                     sling:orderBefore="visible"


### PR DESCRIPTION
## Summary
- Ports NGDM (Next Gen Dynamic Media) asset support to the Adaptive Form Image (v1) component, gated behind `FT_FORMS-26424`
- When `fileReference` is an NGDM asset (`/urn:aaid:aem:...`) and `NextGenDynamicMediaConfig` is enabled, the delivery URL is built directly instead of resolving a DAM rendition
- Adds `enableNextGenDynamicMedia` on the Image field's authoring dialog — this activates AEM's own platform Asset Selector (Pick ▾ → Local/Remote), no custom widget needed
- Toggle-off behavior is unchanged: falls back to the existing file upload field
- Fix found only on this branch during backport:
  - Add `aem-sdk-api` dependency to `bundles/core` and `bundles/af-core` — needed for `NextGenDynamicMediaConfig`, not previously a dependency on this branch

## Testing
- Unit tests: `StaticImageImplTest`, `NgdmImageUtilsTest` — all passing, coverage checks met
- Live-verified on AEM 6.5.3 LTS SP3:
  - Toggle OFF: original Browse Assets/Upload UI, no regression
  - Toggle ON: Pick ▾ dropdown renders (Local + Remote), Remote opens NGDM Asset Selector, picked asset renders correctly in canvas
  - Bundle health confirmed (no unresolved/inactive bundles) after deploy

## Screenshots
Will attach separately (working Pick dropdown, dialog with resolved NGDM image) — not embeddable via CLI.