### PR TITLE
feat(webmcp): register the WebMCP tool catalog on form load

### DIFF
--- a/ui.frontend/__tests__/webmcp.test.js
+++ b/ui.frontend/__tests__/webmcp.test.js
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright 2022 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+// The adapter is exercised in af-webmcp's own suite; here we only assert the CC
+// runtime hands the af-core model to WebMCP once per form load.
+jest.mock('@aemforms/af-webmcp', () => ({registerFormWebMCP: jest.fn()}));
+jest.mock('../src/HTTPAPILayer.js', () => ({
+    __esModule: true,
+    default: {getFormDefinition: jest.fn(), getJson: jest.fn()}
+}));
+jest.mock('../src/RuleUtils.js', () => ({
+    __esModule: true,
+    default: {registerCustomFunctionsV2: jest.fn(), registerCustomFunctionsByUrl: jest.fn()}
+}));
+
+import Utils from '../src/utils';
+import FormContainer from '../src/view/FormContainer';
+import {registerFormWebMCP} from '@aemforms/af-webmcp';
+import HTTPAPILayer from '../src/HTTPAPILayer.js';
+import formJson from './resources/form.json';
+
+test('setupFormContainer registers the WebMCP catalog once with the form model', async () => {
+    HTTPAPILayer.getFormDefinition.mockResolvedValue(formJson);
+
+    const el = document.createElement('div');
+    el.classList.add('cmp-adaptiveform-container');
+    el.dataset.cmpPath = '/content/a/b/c';
+    document.body.appendChild(el);
+
+    let container;
+    const createFormContainer = (params) => {
+        container = new FormContainer(params);
+        return container;
+    };
+
+    await Utils.setupFormContainer(createFormContainer, '.cmp-adaptiveform-container', 'adaptiveFormContainer');
+
+    expect(registerFormWebMCP).toHaveBeenCalledTimes(1);
+    expect(registerFormWebMCP).toHaveBeenCalledWith(container.getModel());
+});

--- a/ui.frontend/jest.config.js
+++ b/ui.frontend/jest.config.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  ******************************************************************************/
 
-const esModules = ['@adobe/json-formula', '@aemforms/af-custom-functions'].join('|');
+const esModules = ['@adobe/json-formula', '@aemforms/af-custom-functions', '@aemforms/af-webmcp'].join('|');
 
 module.exports = {
     transformIgnorePatterns: [`node_modules/(?!${esModules})`],

--- a/ui.frontend/package.json
+++ b/ui.frontend/package.json
@@ -28,6 +28,7 @@
     "@aemforms/af-core": "^1.0.4",
     "@aemforms/af-core-xfa": "^0.1.6",
     "@aemforms/af-formatters": "^1.0.4",
-    "@aemforms/af-custom-functions": "1.0.17"
+    "@aemforms/af-custom-functions": "1.0.17",
+    "@aemforms/af-webmcp": "^1.0.4"
   }
 }

--- a/ui.frontend/src/utils.js
+++ b/ui.frontend/src/utils.js
@@ -18,6 +18,7 @@ import {Constants} from "./constants.js";
 import HTTPAPILayer from "./HTTPAPILayer.js";
 import {customFunctions} from "./customFunctions.js";
 import {FunctionRuntime} from '@aemforms/af-core';
+import {registerFormWebMCP} from '@aemforms/af-webmcp';
 import {loadXfa} from "./handleXfa";
 import RuleUtils from "./RuleUtils.js";
 
@@ -371,6 +372,9 @@ class Utils {
                     callback(formContainer.getModel());
                 }
                 Utils.initializeAllFields(formContainer);
+                // Expose the form's WebMCP tool catalog to in-browser AI agents. No-ops unless the
+                // form opted in via fd:webMcpEnabled and a browser modelContext is available.
+                registerFormWebMCP(formContainer.getModel());
                 const event = new CustomEvent(Constants.FORM_CONTAINER_INITIALISED, { "detail": formContainer });
                 document.dispatchEvent(event);
             }


### PR DESCRIPTION
## What

Exposes each rendered form's **WebMCP** tool catalog to in-browser AI agents (Gemini-in-Chrome, ChatGPT Site tools, etc.) so they can drive the form through a declared tool catalog instead of scraping the DOM.

A single call at the form-container bootstrap seam (`Utils.setupFormContainer`, right after fields are initialised) hands the af-core model to the adapter:

```js
registerFormWebMCP(formContainer.getModel());
```

## Opt-in and safe by default

- **Per-form opt-in** via the authored form property `fd:webMcpEnabled` (read by af-core's `form.webMcpEnabled`). Absent → nothing registers.
- No-ops when no browser `modelContext` is available (SSR/unsupported browser).
- Default behaviour is unchanged.

## Changes

- `ui.frontend/src/utils.js` — import `registerFormWebMCP` and call it once per form load.
- `ui.frontend/package.json` — add `@aemforms/af-webmcp`.
- `ui.frontend/jest.config.js` — allow `@aemforms/af-webmcp` through the ESM transform.
- `ui.frontend/__tests__/webmcp.test.js` — asserts the catalog is registered once with the form model.

## Dependency / release note

Requires the `@aemforms/af-core` + `@aemforms/af-webmcp` release that ships the WebMCP catalog (`buildFormTools` + the `form.webMcpEnabled` getter). Until it publishes, CI install of `af-webmcp` will fail — this is expected and clears with that release.

## Design doc

[Adaptive Forms Runtime via WebMCP (wiki)](https://wiki.corp.adobe.com/spaces/lc/pages/4040736062)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
